### PR TITLE
Add character deletion confirmation flow

### DIFF
--- a/app/src/main/kotlin/com/github/arhor/spellbindr/ui/SpellbindrApp.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/ui/SpellbindrApp.kt
@@ -90,6 +90,7 @@ fun SpellbindrApp(
                             onEditCharacter = { controller.navigate(AppDestination.CharacterEditor(characterId = it)) },
                             onOpenSpellDetail = { controller.navigate(AppDestination.SpellDetail(it)) },
                             onAddSpells = { controller.navigate(AppDestination.CharacterSpellPicker(characterId = it)) },
+                            onCharacterDeleted = { controller.navigateUp() },
                             savedStateHandle = entry.savedStateHandle,
                         )
                     }

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/characters/sheet/CharacterSheetScreen.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/characters/sheet/CharacterSheetScreen.kt
@@ -3,11 +3,14 @@ package com.github.arhor.spellbindr.ui.feature.characters.sheet
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -41,6 +44,7 @@ fun CharacterSheetRoute(
     onEditCharacter: (String) -> Unit,
     onOpenSpellDetail: (String) -> Unit,
     onAddSpells: (String) -> Unit,
+    onCharacterDeleted: () -> Unit,
     savedStateHandle: SavedStateHandle,
     modifier: Modifier = Modifier,
     viewModel: CharacterSheetViewModel = hiltViewModel(),
@@ -86,6 +90,7 @@ fun CharacterSheetRoute(
             onSpellSelected = onOpenSpellDetail,
             onAddSpellsClicked = { state.characterId?.let(onAddSpells) },
             onOpenFullEditor = { state.characterId?.let(onEditCharacter) },
+            onDeleteCharacter = { viewModel.deleteCharacter(onCharacterDeleted) },
         ),
         modifier = modifier,
     )
@@ -99,6 +104,7 @@ fun CharacterSheetScreen(
     modifier: Modifier = Modifier,
 ) {
     var overflowExpanded by remember { mutableStateOf(false) }
+    var showDeleteConfirmation by remember { mutableStateOf(false) }
     val headerState = state.header
 
     WithAppTopBar(
@@ -121,6 +127,14 @@ fun CharacterSheetScreen(
                         onClick = {
                             overflowExpanded = false
                             callbacks.onOpenFullEditor()
+                        },
+                        enabled = state.characterId != null,
+                    )
+                    DropdownMenuItem(
+                        text = { Text("Delete character", color = MaterialTheme.colorScheme.error) },
+                        onClick = {
+                            overflowExpanded = false
+                            showDeleteConfirmation = true
                         },
                         enabled = state.characterId != null,
                     )
@@ -159,6 +173,31 @@ fun CharacterSheetScreen(
                 }
             }
         }
+    }
+
+    if (showDeleteConfirmation) {
+        AlertDialog(
+            onDismissRequest = { showDeleteConfirmation = false },
+            title = { Text(text = "Delete character") },
+            text = {
+                Text(
+                    text = "This will permanently remove the character and all of its data. This action cannot be undone.",
+                )
+            },
+            confirmButton = {
+                TextButton(onClick = {
+                    showDeleteConfirmation = false
+                    callbacks.onDeleteCharacter()
+                }) {
+                    Text(text = "Delete", color = MaterialTheme.colorScheme.error)
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDeleteConfirmation = false }) {
+                    Text(text = "Cancel")
+                }
+            },
+        )
     }
 }
 

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/characters/sheet/CharacterSheetViewModel.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/characters/sheet/CharacterSheetViewModel.kt
@@ -120,6 +120,18 @@ class CharacterSheetViewModel @Inject constructor(
                 initialValue = CharacterSheetUiState(isLoading = true, characterId = characterId),
             )
 
+    fun deleteCharacter(onDeleted: () -> Unit) {
+        val id = characterId ?: return
+        viewModelScope.launch {
+            _errors.value = null
+            runCatching { characterRepository.deleteCharacter(id) }
+                .onSuccess { onDeleted() }
+                .onFailure { throwable ->
+                    _errors.value = throwable.message ?: "Unable to delete character"
+                }
+        }
+    }
+
     fun onTabSelected(tab: CharacterSheetTab) {
         _selectedTab.value = tab
     }

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/characters/sheet/model/CharacterSheetCallbacks.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/characters/sheet/model/CharacterSheetCallbacks.kt
@@ -24,4 +24,5 @@ data class CharacterSheetCallbacks(
     val onSpellSelected: (String) -> Unit = {},
     val onAddSpellsClicked: () -> Unit = {},
     val onOpenFullEditor: () -> Unit = {},
+    val onDeleteCharacter: () -> Unit = {},
 )


### PR DESCRIPTION
## Summary
- add overflow action to delete a character from the sheet view
- prompt users with a confirmation dialog before deletion and hook deletion into the view model
- navigate back after a successful deletion

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69231ddc7760833084ce39ec4cd598ce)