### PR TITLE
Add Android SDK setup automation for cloud agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,37 @@ To build and run the app from the source code, follow these steps:
 3.  Let Android Studio sync the project and download the required Gradle dependencies.
 4.  Build and run the app on an emulator or a physical device.
 
+### 🏗️ Automated SDK setup for cloud agents
+
+Ephemeral CI/agent environments may not ship with the Android SDK. Run the provided setup script during your setup phase to
+provision only the components required by this project and to warm the Gradle dependency cache for offline builds:
+
+```bash
+./scripts/setup-android-sdk.sh
+```
+
+What the script installs (using the versions configured in `app/build.gradle.kts`):
+
+- Android command-line tools (installed under `$HOME/android-sdk/cmdline-tools/latest` by default)
+- Platform tools
+- Platform `android-36` (matches `compileSdk = 36` / `targetSdk = 36`)
+- Build tools `36.0.0`
+
+The script also writes `local.properties` with `sdk.dir=$HOME/android-sdk` so Gradle can locate the SDK without additional
+environment setup and runs `./gradlew resolveAllDependencies` to download all declared dependencies while the network is
+available.
+
+If the compile SDK or build tools change in the future, update the `PLATFORM_VERSION`/`BUILD_TOOLS_VERSION` values inside
+`scripts/setup-android-sdk.sh` to match the values set in `app/build.gradle.kts`.
+
+Verification commands for agents after setup:
+
+```bash
+./gradlew help              # Confirms the SDK is visible to Gradle
+./gradlew assembleDebug     # Example build task that should now work offline
+./gradlew testDebugUnitTest # JVM unit tests
+```
+
 ## 📜 Data Source
 
 Spellbindr uses game content from the Dungeons & Dragons 5th Edition **System Reference Document 5.1** (SRD) provided by Wizards of the Coast. This content is available under the terms of the **Open Gaming License v1.0a**.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,3 +7,18 @@ plugins {
     alias(libs.plugins.kotlin.serialization) apply false
     alias(libs.plugins.kotlin.ksp) apply false
 }
+
+tasks.register("resolveAllDependencies") {
+    group = "build setup"
+    description = "Resolves all resolvable configurations in all projects to warm caches for offline builds."
+
+    doLast {
+        rootProject.allprojects.forEach { project ->
+            project.configurations
+                .filter { configuration -> configuration.isCanBeResolved }
+                .forEach { configuration ->
+                    configuration.resolve()
+                }
+        }
+    }
+}

--- a/scripts/setup-android-sdk.sh
+++ b/scripts/setup-android-sdk.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Setup script to provision a minimal Android SDK and pre-resolve Gradle dependencies
+# for offline/limited-network build phases. Designed for non-interactive CI/agent
+# environments. Run during the workspace setup phase before executing Gradle tasks.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ANDROID_SDK_ROOT="${ANDROID_SDK_ROOT:-"$HOME/android-sdk"}"
+ANDROID_HOME="$ANDROID_SDK_ROOT"
+CMDLINE_TOOLS_VERSION="10406996"
+CMDLINE_TOOLS_ZIP="commandlinetools-linux-${CMDLINE_TOOLS_VERSION}_latest.zip"
+CMDLINE_TOOLS_URL="https://dl.google.com/android/repository/${CMDLINE_TOOLS_ZIP}"
+SDK_MANAGER="$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager"
+PLATFORM_VERSION="36"
+BUILD_TOOLS_VERSION="36.0.0"
+
+log() {
+    echo "[setup-android-sdk] $*"
+}
+
+install_prereqs() {
+    local packages=(curl unzip)
+    local missing=()
+    for pkg in "${packages[@]}"; do
+        if ! command -v "$pkg" >/dev/null 2>&1; then
+            missing+=("$pkg")
+        fi
+    done
+
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        log "Installing prerequisites: ${missing[*]}"
+        export DEBIAN_FRONTEND=noninteractive
+        apt-get update -y >/dev/null
+        apt-get install -y "${missing[@]}" >/dev/null
+    fi
+}
+
+download_cmdline_tools() {
+    if [[ -x "$SDK_MANAGER" ]]; then
+        log "Command-line tools already present at $SDK_MANAGER"
+        return
+    fi
+
+    log "Downloading Android command-line tools (${CMDLINE_TOOLS_VERSION})"
+    local tmp_dir
+    tmp_dir="$(mktemp -d)"
+    trap 'rm -rf "${tmp_dir}"' EXIT
+
+    curl -sSL "$CMDLINE_TOOLS_URL" -o "$tmp_dir/$CMDLINE_TOOLS_ZIP"
+    mkdir -p "$ANDROID_SDK_ROOT/cmdline-tools"
+    unzip -q "$tmp_dir/$CMDLINE_TOOLS_ZIP" -d "$tmp_dir"
+
+    # Ensure the expected cmdline-tools/latest layout for sdkmanager
+    rm -rf "$ANDROID_SDK_ROOT/cmdline-tools/latest"
+    mv "$tmp_dir/cmdline-tools" "$ANDROID_SDK_ROOT/cmdline-tools/latest"
+
+    log "Installed command-line tools to $ANDROID_SDK_ROOT/cmdline-tools/latest"
+}
+
+install_sdk_components() {
+    log "Installing minimal SDK components (platform-tools, platform ${PLATFORM_VERSION}, build-tools ${BUILD_TOOLS_VERSION})"
+    yes | "$SDK_MANAGER" --sdk_root="$ANDROID_SDK_ROOT" --licenses >/dev/null
+
+    "$SDK_MANAGER" --sdk_root="$ANDROID_SDK_ROOT" --install \
+        "platform-tools" \
+        "platforms;android-${PLATFORM_VERSION}" \
+        "build-tools;${BUILD_TOOLS_VERSION}"
+}
+
+write_local_properties() {
+    local local_props="$REPO_ROOT/local.properties"
+    log "Writing sdk.dir to $local_props"
+    cat >"$local_props" <<'EOF_LOCAL'
+sdk.dir=$ANDROID_SDK_ROOT
+EOF_LOCAL
+}
+
+warmup_gradle_dependencies() {
+    log "Pre-resolving Gradle dependencies to warm the cache"
+    (cd "$REPO_ROOT" && ANDROID_SDK_ROOT="$ANDROID_SDK_ROOT" ANDROID_HOME="$ANDROID_HOME" ./gradlew --no-daemon resolveAllDependencies)
+}
+
+main() {
+    install_prereqs
+    mkdir -p "$ANDROID_SDK_ROOT"
+    download_cmdline_tools
+    install_sdk_components
+    write_local_properties
+    warmup_gradle_dependencies
+
+    log "Android SDK setup complete. ANDROID_SDK_ROOT=$ANDROID_SDK_ROOT"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- add a non-interactive setup script that installs a minimal Android SDK and warms the Gradle cache
- register a resolveAllDependencies helper task for pre-resolving build inputs
- document how agents should run the setup script and which SDK components it provisions

## Testing
- bash -n scripts/setup-android-sdk.sh

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6935bfad679c8330a6a76ac44752b31c)