### PR TITLE
Align Robolectric tests with JUnit 5

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -76,6 +76,7 @@ dependencies {
     testImplementation(libs.truth)
     testImplementation(libs.mockk)
     testImplementation(libs.robolectric)
+    testRuntimeOnly(libs.junit.jupiter.engine)
     testRuntimeOnly(libs.junit.platform.launcher)
 
     kspAndroidTest(libs.hilt.android.compiler)

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/ExampleUnitTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/ExampleUnitTest.kt
@@ -1,7 +1,8 @@
 package com.github.arhor.spellbindr
 
 import com.google.common.truth.Truth.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 
 /**
  * Example local unit test, which will execute on the development machine (host).
@@ -9,6 +10,11 @@ import org.junit.Test
  * See [testing documentation](http://d.android.com/tools/testing).
  */
 class ExampleUnitTest {
+
+    @JvmField
+    @RegisterExtension
+    val mainDispatcherRule = MainDispatcherRule()
+
     @Test
     fun addition_isCorrect() {
         assertThat(2 + 2).isEqualTo(4)

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/MainDispatcherRule.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/MainDispatcherRule.kt
@@ -6,19 +6,20 @@ import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
-import org.junit.rules.TestWatcher
-import org.junit.runner.Description
+import org.junit.jupiter.api.extension.AfterEachCallback
+import org.junit.jupiter.api.extension.BeforeEachCallback
+import org.junit.jupiter.api.extension.ExtensionContext
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class MainDispatcherRule(
     val dispatcher: TestDispatcher = StandardTestDispatcher(),
-) : TestWatcher() {
+) : BeforeEachCallback, AfterEachCallback {
 
-    override fun starting(description: Description) {
+    override fun beforeEach(context: ExtensionContext) {
         Dispatchers.setMain(dispatcher)
     }
 
-    override fun finished(description: Description) {
+    override fun afterEach(context: ExtensionContext) {
         Dispatchers.resetMain()
     }
 }


### PR DESCRIPTION
## Summary
- add JUnit Jupiter engine runtime dependency to back Robolectric's JUnit 5 execution
- migrate coroutine dispatcher test rule to a JUnit Jupiter extension and apply it in unit tests

## Testing
- ./gradlew testDebugUnitTest *(fails: Android SDK path not configured in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69395e502244833086e6e34817e434c7)