### PR TITLE
Enrich feats data with effects and prerequisites

### DIFF
--- a/app/src/main/assets/data/feats.json
+++ b/app/src/main/assets/data/feats.json
@@ -1,862 +1,862 @@
 [
-  {
-    "id": "actor",
-    "name": "Actor",
-    "desc": [
-      "Skilled at mimicry and dramatics, you gain the following benefits:",
-      "- Increase your Charisma score by 1, to a maximum of 20.",
-      "- You have advantage on Charisma (Deception) and Charisma (Performance) checks when trying to pass yourself off as a different person.",
-      "- You can mimic the speech of another person or the sounds made by other creatures. You must have heard the person speaking, or heard the creature make the sound, for at least 1 minute. A successful Wisdom (Insight) check contested by your Charisma (Deception) check allows a listener to determine the effect is faked."
-    ],
-    "prerequisites": [
-      {
-        "type": "ability-score",
-        "abilityScore": [
-          "cha"
+    {
+        "id": "actor",
+        "name": "Actor",
+        "desc": [
+            "Skilled at mimicry and dramatics, you gain the following benefits:",
+            "- Increase your Charisma score by 1, to a maximum of 20.",
+            "- You have advantage on Charisma (Deception) and Charisma (Performance) checks when trying to pass yourself off as a different person.",
+            "- You can mimic the speech of another person or the sounds made by other creatures. You must have heard the person speaking, or heard the creature make the sound, for at least 1 minute. A successful Wisdom (Insight) check contested by your Charisma (Deception) check allows a listener to determine the effect is faked."
         ],
-        "minimumValue": 13,
-        "atLeastOne": false
-      }
-    ],
-    "effects": [
-      {
-        "type": "modify-abilities",
-        "abilities": {
-          "cha": 1
-        }
-      }
-    ]
-  },
-  {
-    "id": "alert",
-    "name": "Alert",
-    "desc": [
-      "Always on the lookout for danger, you gain the following benefits:",
-      "- You gain a +5 bonus to initiative.",
-      "- You can\u2019t be surprised while you are conscious.",
-      "- Other creatures don\u2019t gain advantage on attack rolls against you as a result of being unseen by you."
-    ],
-    "prerequisites": []
-  },
-  {
-    "id": "athlete",
-    "name": "Athlete",
-    "desc": [
-      "You have undergone extensive physical training to gain the following benefits:",
-      "- Increase your Strength or Dexterity score by 1, to a maximum of 20.",
-      "- When you are prone, standing up uses only 5 feet of movement.",
-      "- Climbing doesn\u2019t halve your speed.",
-      "- You can make a running long jump or a running high jump after moving only 5 feet on foot, rather than 10 feet."
-    ],
-    "prerequisites": [
-      {
-        "type": "ability-score",
-        "abilityScore": [
-          "str",
-          "dex"
+        "prerequisites": [
+            {
+                "type": "ability-score",
+                "abilityScore": [
+                    "cha"
+                ],
+                "minimumValue": 13,
+                "atLeastOne": false
+            }
         ],
-        "minimumValue": 13,
-        "atLeastOne": true
-      }
-    ],
-    "abilityBonusChoice": {
-      "type": "ability-bonus",
-      "from": [
-        {
-          "str": 1
-        },
-        {
-          "dex": 1
-        }
-      ],
-      "choose": 1
-    }
-  },
-  {
-    "id": "charger",
-    "name": "Charger",
-    "desc": [
-      "When you use your action to Dash, you can use a bonus action to make one melee weapon attack or to shove a creature.",
-      "- If you move at least 10 feet in a straight line immediately before taking this bonus action, you either gain a +5 bonus to the attack\u2019s damage roll (if you chose to make a melee attack and hit) or push the target up to 10 feet away from you (if you chose to shove and you succeed)."
-    ],
-    "prerequisites": []
-  },
-  {
-    "id": "crossbow-expert",
-    "name": "Crossbow Expert",
-    "desc": [
-      "Thanks to extensive practice with the crossbow, you gain the following benefits:",
-      "- You ignore the loading quality of crossbows with which you are proficient.",
-      "- Being within 5 feet of a hostile creature doesn\u2019t impose disadvantage on your ranged attack rolls.",
-      "- When you use the Attack action and attack with a one-handed weapon, you can use a bonus action to attack with a loaded hand crossbow you are holding."
-    ],
-    "prerequisites": []
-  },
-  {
-    "id": "defensive-duelist",
-    "name": "Defensive Duelist",
-    "desc": [
-      "Prerequisite: Dexterity 13 or higher.",
-      "When you are wielding a finesse weapon with which you are proficient and another creature hits you with a melee attack, you can use your reaction to add your proficiency bonus to your AC for that attack, potentially causing the attack to miss you."
-    ],
-    "prerequisites": [
-      {
-        "type": "ability-score",
-        "abilityScore": [
-          "dex"
-        ],
-        "minimumValue": 13,
-        "atLeastOne": false
-      }
-    ]
-  },
-  {
-    "id": "dual-wielder",
-    "name": "Dual Wielder",
-    "desc": [
-      "You master fighting with two weapons, gaining the following benefits:",
-      "- You gain a +1 bonus to AC while you are wielding a separate melee weapon in each hand.",
-      "- You can use two-weapon fighting even when the one-handed melee weapons you are wielding aren\u2019t light.",
-      "- You can draw or stow two one-handed weapons when you would normally be able to draw or stow only one."
-    ],
-    "prerequisites": []
-  },
-  {
-    "id": "dungeon-delver",
-    "name": "Dungeon Delver",
-    "desc": [
-      "Alert to the hidden traps and secret doors found in many dungeons, you gain the following benefits:",
-      "- You have advantage on Wisdom (Perception) and Intelligence (Investigation) checks made to detect the presence of secret doors.",
-      "- You have advantage on saving throws made to avoid or resist traps.",
-      "- You have resistance to the damage dealt by traps.",
-      "- You can search for traps while traveling at a normal pace, instead of only at a slow pace."
-    ],
-    "prerequisites": []
-  },
-  {
-    "id": "durable",
-    "name": "Durable",
-    "desc": [
-      "Hardy and resilient, you gain the following benefits:",
-      "- Increase your Constitution score by 1, to a maximum of 20.",
-      "- When you roll a Hit Die to regain hit points, the minimum number of hit points you regain from the roll equals twice your Constitution modifier (minimum of 2)."
-    ],
-    "prerequisites": [
-      {
-        "type": "ability-score",
-        "abilityScore": [
-          "con"
-        ],
-        "minimumValue": 13,
-        "atLeastOne": false
-      }
-    ],
-    "effects": [
-      {
-        "type": "modify-abilities",
-        "abilities": {
-          "con": 1
-        }
-      }
-    ]
-  },
-  {
-    "id": "elemental-adept",
-    "name": "Elemental Adept",
-    "desc": [
-      "Prerequisite: The ability to cast at least one spell.",
-      "When you gain this feat, choose one of the following damage types: acid, cold, fire, lightning, or thunder.",
-      "- Spells you cast ignore resistance to damage of the chosen type.",
-      "- When you roll damage for a spell you cast that deals damage of the chosen type, you can treat any 1 on a damage die as a 2.",
-      "You can select this feat multiple times. Each time you do so, you must choose a different damage type."
-    ],
-    "prerequisites": []
-  },
-  {
-    "id": "grappler",
-    "name": "Grappler",
-    "prerequisites": [
-      {
-        "abilityScore": {
-          "id": "str"
-        },
-        "minimumScore": 13
-      }
-    ],
-    "desc": [
-      "Prerequisite: Strength 13 or higher.",
-      "You\u2019ve developed the skills necessary to hold your own in close-quarters grappling. You gain the following benefits:",
-      "- You have advantage on attack rolls against a creature you are grappling.",
-      "- You can use your action to try to pin a creature grappled by you. To do so, make another grapple check. If you succeed, you and the creature are both restrained until the grapple ends."
-    ]
-  },
-  {
-    "id": "great-weapon-master",
-    "name": "Great Weapon Master",
-    "desc": [
-      "You\u2019ve learned to put the weight of a weapon to your advantage, letting its momentum empower your strikes. You gain the following benefits:",
-      "- On your turn, when you score a critical hit with a melee weapon or reduce a creature to 0 hit points with one, you can make one melee weapon attack as a bonus action.",
-      "- Before you make a melee attack with a heavy weapon that you are proficient with, you can choose to take a -5 penalty to the attack roll. If the attack hits, you add +10 to the attack\u2019s damage."
-    ],
-    "prerequisites": []
-  },
-  {
-    "id": "healer",
-    "name": "Healer",
-    "desc": [
-      "You are an able physician, allowing you to mend wounds quickly and get your allies back in the fight. You gain the following benefits:",
-      "- When you use a healer\u2019s kit to stabilize a dying creature, that creature also regains 1 hit point.",
-      "- As an action, you can spend one use of a healer\u2019s kit to tend to a creature and restore 1d6 + 4 hit points to it, plus additional hit points equal to the creature\u2019s maximum number of Hit Dice. The creature can\u2019t regain hit points from this feat again until it finishes a short or long rest."
-    ],
-    "prerequisites": []
-  },
-  {
-    "id": "heavily-armored",
-    "name": "Heavily Armored",
-    "desc": [
-      "Prerequisite: Proficiency with medium armor.",
-      "You have trained to master the use of heavy armor, gaining the following benefits:",
-      "- Increase your Strength score by 1, to a maximum of 20.",
-      "- You gain proficiency with heavy armor."
-    ],
-    "prerequisites": [
-      {
-        "type": "proficiency",
-        "id": "medium-armor"
-      }
-    ],
-    "effects": [
-      {
-        "type": "modify-abilities",
-        "abilities": {
-          "str": 1
-        }
-      },
-      {
-        "type": "add-proficiencies",
-        "proficiencies": [
-          "heavy-armor"
+        "effects": [
+            {
+                "type": "modify-abilities",
+                "abilities": {
+                    "cha": 1
+                }
+            }
         ]
-      }
-    ]
-  },
-  {
-    "id": "heavy-armor-master",
-    "name": "Heavy Armor Master",
-    "desc": [
-      "Prerequisite: Proficiency with heavy armor.",
-      "You can use your armor to deflect strikes that would kill others. You gain the following benefits:",
-      "- Increase your Strength score by 1, to a maximum of 20.",
-      "- While you are wearing heavy armor, bludgeoning, piercing, and slashing damage that you take from nonmagical weapons is reduced by 3."
-    ],
-    "prerequisites": [
-      {
-        "type": "proficiency",
-        "id": "heavy-armor"
-      }
-    ],
-    "effects": [
-      {
-        "type": "modify-abilities",
-        "abilities": {
-          "str": 1
-        }
-      }
-    ]
-  },
-  {
-    "id": "inspiring-leader",
-    "name": "Inspiring Leader",
-    "desc": [
-      "Prerequisite: Charisma 13 or higher.",
-      "You can spend 10 minutes inspiring your companions, shoring up their resolve to fight. When you do so, choose up to six friendly creatures (which can include yourself) within 30 feet of you who can see or hear you and who can understand you. Each creature can gain temporary hit points equal to your level + your Charisma modifier. A creature can\u2019t gain temporary hit points from this feat again until it has finished a short or long rest."
-    ],
-    "prerequisites": [
-      {
-        "type": "ability-score",
-        "abilityScore": [
-          "cha"
-        ],
-        "minimumValue": 13,
-        "atLeastOne": false
-      }
-    ]
-  },
-  {
-    "id": "keen-mind",
-    "name": "Keen Mind",
-    "desc": [
-      "You have a mind that can track time, direction, and detail with uncanny precision. You gain the following benefits:",
-      "- Increase your Intelligence score by 1, to a maximum of 20.",
-      "- You always know which way is north.",
-      "- You always know the number of hours left before the next sunrise or sunset.",
-      "- You can accurately recall anything you have seen or heard within the past month."
-    ],
-    "prerequisites": [
-      {
-        "type": "ability-score",
-        "abilityScore": [
-          "int"
-        ],
-        "minimumValue": 13,
-        "atLeastOne": false
-      }
-    ],
-    "effects": [
-      {
-        "type": "modify-abilities",
-        "abilities": {
-          "int": 1
-        }
-      }
-    ]
-  },
-  {
-    "id": "lightly-armored",
-    "name": "Lightly Armored",
-    "desc": [
-      "You have trained to master the use of light armor, gaining the following benefits:",
-      "- Increase your Strength or Dexterity score by 1, to a maximum of 20.",
-      "- You gain proficiency with light armor."
-    ],
-    "prerequisites": [],
-    "effects": [
-      {
-        "type": "add-proficiencies",
-        "proficiencies": [
-          "light-armor"
-        ]
-      }
-    ],
-    "abilityBonusChoice": {
-      "type": "ability-bonus",
-      "from": [
-        {
-          "str": 1
-        },
-        {
-          "dex": 1
-        }
-      ],
-      "choose": 1
-    }
-  },
-  {
-    "id": "linguist",
-    "name": "Linguist",
-    "desc": [
-      "You have studied languages and codes, gaining the following benefits:",
-      "- Increase your Intelligence score by 1, to a maximum of 20.",
-      "- You learn three languages of your choice.",
-      "- You can ably create written ciphers. Others can\u2019t decipher a code you create unless you teach them, they succeed on an Intelligence check (DC equal to your Intelligence score + your proficiency bonus), or they use magic to decipher it."
-    ],
-    "prerequisites": [
-      {
-        "type": "ability-score",
-        "abilityScore": [
-          "int"
-        ],
-        "minimumValue": 13,
-        "atLeastOne": false
-      }
-    ],
-    "effects": [
-      {
-        "type": "modify-abilities",
-        "abilities": {
-          "int": 1
-        }
-      }
-    ],
-    "languageChoice": {
-      "type": "resource-list",
-      "from": "languages",
-      "choose": 3
-    }
-  },
-  {
-    "id": "lucky",
-    "name": "Lucky",
-    "desc": [
-      "You have inexplicable luck that seems to kick in at just the right moment.",
-      "- You have 3 luck points. Whenever you make an attack roll, an ability check, or a saving throw, you can spend one luck point to roll an additional d20. You can choose to spend one of your luck points after you roll the die, but before the outcome is determined. You choose which of the d20s is used for the attack roll, ability check, or saving throw.",
-      "- You can also spend one luck point when an attack roll is made against you. Roll a d20, and then choose whether the attack uses the attacker\u2019s roll or yours.",
-      "- If more than one creature spends a luck point to influence the outcome of a roll, the points cancel each other out; no additional dice are rolled.",
-      "You regain your expended luck points when you finish a long rest."
-    ],
-    "prerequisites": []
-  },
-  {
-    "id": "mage-slayer",
-    "name": "Mage Slayer",
-    "desc": [
-      "You have practiced techniques useful in melee combat against spellcasters, gaining the following benefits:",
-      "- When a creature within 5 feet of you casts a spell, you can use your reaction to make a melee weapon attack against that creature.",
-      "- When you damage a creature that is concentrating on a spell, that creature has disadvantage on the saving throw it makes to maintain its concentration.",
-      "- You have advantage on saving throws against spells cast by creatures within 5 feet of you."
-    ],
-    "prerequisites": []
-  },
-  {
-    "id": "magic-initiate",
-    "name": "Magic Initiate",
-    "desc": [
-      "Choose a class: bard, cleric, druid, sorcerer, warlock, or wizard. You learn two cantrips of your choice from that class\u2019s spell list.",
-      "- In addition, choose one 1st-level spell to learn from that same list. Using this feat, you can cast the spell at its lowest level. Once you cast it, you must finish a long rest before you can cast it in this way again.",
-      "- Your spellcasting ability for these spells depends on the class you chose: Charisma for bard, sorcerer, or warlock; Wisdom for cleric or druid; or Intelligence for wizard."
-    ],
-    "prerequisites": []
-  },
-  {
-    "id": "martial-adept",
-    "name": "Martial Adept",
-    "desc": [
-      "You have martial training that allows you to perform special combat maneuvers. You gain the following benefits:",
-      "- You learn two maneuvers of your choice from among those available to the Battle Master archetype in the fighter class. If a maneuver you use requires your target to make a saving throw to resist the maneuver\u2019s effects, the saving throw DC equals 8 + your proficiency bonus + your Strength or Dexterity modifier (your choice).",
-      "- If you already have a superiority dice, you gain one more; otherwise, you have one superiority die, which is a d6. This die is used to fuel your maneuvers. A superiority die is expended when you use it. You regain your expended superiority dice when you finish a short or long rest."
-    ],
-    "prerequisites": []
-  },
-  {
-    "id": "medium-armor-master",
-    "name": "Medium Armor Master",
-    "desc": [
-      "Prerequisite: Proficiency with medium armor.",
-      "You have practiced moving in medium armor to gain the following benefits:",
-      "- Wearing medium armor doesn\u2019t impose disadvantage on your Dexterity (Stealth) checks.",
-      "- When you wear medium armor, you can add 3, rather than 2, to your AC if you have a Dexterity of 16 or higher."
-    ],
-    "prerequisites": [
-      {
-        "type": "proficiency",
-        "id": "medium-armor"
-      }
-    ]
-  },
-  {
-    "id": "mobile",
-    "name": "Mobile",
-    "desc": [
-      "You are exceptionally speedy and agile. You gain the following benefits:",
-      "- Your speed increases by 10 feet.",
-      "- When you use the Dash action, difficult terrain doesn\u2019t cost you extra movement on that turn.",
-      "- When you make a melee attack against a creature, you don\u2019t provoke opportunity attacks from that creature for the rest of the turn, whether you hit or not."
-    ],
-    "prerequisites": []
-  },
-  {
-    "id": "moderately-armored",
-    "name": "Moderately Armored",
-    "desc": [
-      "Prerequisite: Proficiency with light armor.",
-      "You have trained to master the use of medium armor and shields, gaining the following benefits:",
-      "- Increase your Strength or Dexterity score by 1, to a maximum of 20.",
-      "- You gain proficiency with medium armor and shields."
-    ],
-    "prerequisites": [
-      {
-        "type": "proficiency",
-        "id": "light-armor"
-      }
-    ],
-    "effects": [
-      {
-        "type": "add-proficiencies",
-        "proficiencies": [
-          "medium-armor",
-          "shields"
-        ]
-      }
-    ],
-    "abilityBonusChoice": {
-      "type": "ability-bonus",
-      "from": [
-        {
-          "str": 1
-        },
-        {
-          "dex": 1
-        }
-      ],
-      "choose": 1
-    }
-  },
-  {
-    "id": "mounted-combatant",
-    "name": "Mounted Combatant",
-    "desc": [
-      "You are a dangerous foe to face while mounted. While you are mounted and aren\u2019t incapacitated, you gain the following benefits:",
-      "- You have advantage on melee attack rolls against any unmounted creature that is smaller than your mount.",
-      "- You can force an attack targeted at your mount to target you instead.",
-      "- If your mount is subjected to an effect that allows it to make a Dexterity saving throw to take only half damage, it instead takes no damage if it succeeds on the saving throw, and only half damage if it fails."
-    ],
-    "prerequisites": []
-  },
-  {
-    "id": "observant",
-    "name": "Observant",
-    "desc": [
-      "Quick to notice details of your environment, you gain the following benefits:",
-      "- Increase your Intelligence or Wisdom score by 1, to a maximum of 20.",
-      "- If you can see a creature\u2019s mouth while it is speaking a language you understand, you can interpret what it\u2019s saying by reading its lips.",
-      "- You have a +5 bonus to your passive Wisdom (Perception) and passive Intelligence (Investigation) scores."
-    ],
-    "prerequisites": [
-      {
-        "type": "ability-score",
-        "abilityScore": [
-          "int",
-          "wis"
-        ],
-        "minimumValue": 13,
-        "atLeastOne": true
-      }
-    ],
-    "abilityBonusChoice": {
-      "type": "ability-bonus",
-      "from": [
-        {
-          "int": 1
-        },
-        {
-          "wis": 1
-        }
-      ],
-      "choose": 1
-    }
-  },
-  {
-    "id": "polearm-master",
-    "name": "Polearm Master",
-    "desc": [
-      "You can keep your enemies at bay with reach weapons. You gain the following benefits:",
-      "- When you take the Attack action and attack with only a glaive, halberd, quarterstaff, or spear, you can use a bonus action to make a melee attack with the opposite end of the weapon. This attack uses the same ability modifier as the primary attack. The weapon\u2019s damage die for this attack is a d4, and the attack deals bludgeoning damage.",
-      "- While you are wielding a glaive, halberd, pike, quarterstaff, or spear, other creatures provoke an opportunity attack from you when they enter your reach."
-    ],
-    "prerequisites": []
-  },
-  {
-    "id": "resilient",
-    "name": "Resilient",
-    "desc": [
-      "Choose one ability score. You gain the following benefits:",
-      "- Increase the chosen ability score by 1, to a maximum of 20.",
-      "- You gain proficiency in saving throws using the chosen ability."
-    ],
-    "prerequisites": [],
-    "abilityBonusChoice": {
-      "type": "ability-bonus",
-      "from": [
-        {
-          "str": 1
-        },
-        {
-          "dex": 1
-        },
-        {
-          "con": 1
-        },
-        {
-          "int": 1
-        },
-        {
-          "wis": 1
-        },
-        {
-          "cha": 1
-        }
-      ],
-      "choose": 1
     },
-    "proficiencyChoice": {
-      "type": "options-array",
-      "from": [
-        "saving-throw-str",
-        "saving-throw-dex",
-        "saving-throw-con",
-        "saving-throw-int",
-        "saving-throw-wis",
-        "saving-throw-cha"
-      ],
-      "choose": 1
-    }
-  },
-  {
-    "id": "ritual-caster",
-    "name": "Ritual Caster",
-    "desc": [
-      "Prerequisite: Intelligence or Wisdom 13 or higher.",
-      "You have learned a number of spells that you can cast as rituals. These spells are written in a ritual book, which you must have in hand while casting one of them.",
-      "- Choose one of the following classes: bard, cleric, druid, sorcerer, warlock, or wizard. You acquire a ritual book holding two 1st-level spells of your choice. You must choose your spells from that class\u2019s spell list, and the spells you choose must have the ritual tag.",
-      "- If you come across a spell in written form, you might be able to add it to your ritual book. The spell must be on the spell list for the class you chose, the spell\u2019s level can be no higher than half your level (rounded up), and it must have the ritual tag. The process of copying the spell takes 2 hours per level of the spell, and costs 50 gp per level."
-    ],
-    "prerequisites": [
-      {
-        "type": "ability-score",
-        "abilityScore": [
-          "int",
-          "wis"
+    {
+        "id": "alert",
+        "name": "Alert",
+        "desc": [
+            "Always on the lookout for danger, you gain the following benefits:",
+            "- You gain a +5 bonus to initiative.",
+            "- You can\u2019t be surprised while you are conscious.",
+            "- Other creatures don\u2019t gain advantage on attack rolls against you as a result of being unseen by you."
         ],
-        "minimumValue": 13,
-        "atLeastOne": true
-      }
-    ]
-  },
-  {
-    "id": "savage-attacker",
-    "name": "Savage Attacker",
-    "desc": [
-      "Once per turn when you roll damage for a melee weapon attack, you can reroll the weapon\u2019s damage dice and use either total."
-    ],
-    "prerequisites": []
-  },
-  {
-    "id": "sentinel",
-    "name": "Sentinel",
-    "desc": [
-      "You have mastered techniques to take advantage of every drop in any enemy\u2019s guard, gaining the following benefits:",
-      "- When you hit a creature with an opportunity attack, the creature\u2019s speed becomes 0 for the rest of the turn.",
-      "- Creatures provoke opportunity attacks from you even if they take the Disengage action before leaving your reach.",
-      "- When a creature within 5 feet of you makes an attack against a target other than you (and that target doesn\u2019t have this feat), you can use your reaction to make a melee weapon attack against the attacking creature."
-    ],
-    "prerequisites": []
-  },
-  {
-    "id": "sharpshooter",
-    "name": "Sharpshooter",
-    "desc": [
-      "You have mastered ranged weapons and can make shots that others find impossible. You gain the following benefits:",
-      "- Attacking at long range doesn\u2019t impose disadvantage on your ranged weapon attack rolls.",
-      "- Your ranged weapon attacks ignore half cover and three-quarters cover.",
-      "- Before you make an attack with a ranged weapon that you are proficient with, you can choose to take a -5 penalty to the attack roll. If the attack hits, you add +10 to the attack\u2019s damage."
-    ],
-    "prerequisites": []
-  },
-  {
-    "id": "shield-master",
-    "name": "Shield Master",
-    "desc": [
-      "You use shields not just for protection but also for offense. You gain the following benefits while you are wielding a shield:",
-      "- If you take the Attack action on your turn, you can use a bonus action to try to shove a creature within 5 feet of you with your shield.",
-      "- If you aren\u2019t incapacitated, you can add your shield\u2019s AC bonus to any Dexterity saving throw you make against a spell or other harmful effect that targets only you.",
-      "- If you are subjected to an effect that allows you to make a Dexterity saving throw to take only half damage, you can use your reaction to take no damage if you succeed on the saving throw, interposing your shield between yourself and the source of the effect."
-    ],
-    "prerequisites": []
-  },
-  {
-    "id": "skilled",
-    "name": "Skilled",
-    "desc": [
-      "You gain proficiency in any combination of three skills or tools of your choice."
-    ],
-    "prerequisites": [],
-    "proficiencyChoice": {
-      "type": "options-array",
-      "from": [
-        "alchemists-supplies",
-        "brewers-supplies",
-        "calligraphers-supplies",
-        "carpenters-tools",
-        "cartographers-tools",
-        "cobblers-tools",
-        "cooks-utensils",
-        "glassblowers-tools",
-        "jewelers-tools",
-        "leatherworkers-tools",
-        "masons-tools",
-        "painters-supplies",
-        "potters-tools",
-        "smiths-tools",
-        "tinkers-tools",
-        "weavers-tools",
-        "woodcarvers-tools",
-        "disguise-kit",
-        "forgery-kit",
-        "dice-set",
-        "playing-card-set",
-        "bagpipes",
-        "drum",
-        "dulcimer",
-        "flute",
-        "lute",
-        "lyre",
-        "horn",
-        "pan-flute",
-        "shawm",
-        "viol",
-        "herbalism-kit",
-        "navigators-tools",
-        "poisoners-kit",
-        "thieves-tools",
-        "land-vehicles",
-        "water-vehicles",
-        "skill-acrobatics",
-        "skill-animal-handling",
-        "skill-arcana",
-        "skill-athletics",
-        "skill-deception",
-        "skill-history",
-        "skill-insight",
-        "skill-intimidation",
-        "skill-investigation",
-        "skill-medicine",
-        "skill-nature",
-        "skill-perception",
-        "skill-performance",
-        "skill-persuasion",
-        "skill-religion",
-        "skill-sleight-of-hand",
-        "skill-stealth",
-        "skill-survival"
-      ],
-      "choose": 3
-    }
-  },
-  {
-    "id": "skulker",
-    "name": "Skulker",
-    "desc": [
-      "Prerequisite: Dexterity 13 or higher.",
-      "You are expert at slinking through shadows. You gain the following benefits:",
-      "- You can try to hide when you are lightly obscured from the creature from which you are hiding.",
-      "- When you are hidden from a creature and miss it with a ranged weapon attack, making the attack doesn\u2019t reveal your position.",
-      "- Dim light doesn\u2019t impose disadvantage on your Wisdom (Perception) checks relying on sight."
-    ],
-    "prerequisites": [
-      {
-        "type": "proficiency",
-        "id": "skill-stealth"
-      }
-    ]
-  },
-  {
-    "id": "spell-sniper",
-    "name": "Spell Sniper",
-    "desc": [
-      "Prerequisite: The ability to cast at least one spell.",
-      "You have learned techniques to enhance your attacks with certain kinds of spells, gaining the following benefits:",
-      "- When you cast a spell that requires you to make an attack roll, the spell\u2019s range is doubled.",
-      "- Your ranged spell attacks ignore half cover and three-quarters cover.",
-      "- You learn one cantrip that requires an attack roll. Choose the cantrip from the bard, cleric, druid, sorcerer, warlock, or wizard spell list. Your spellcasting ability for this cantrip depends on the spell list you chose."
-    ],
-    "prerequisites": []
-  },
-  {
-    "id": "tavern-brawler",
-    "name": "Tavern Brawler",
-    "desc": [
-      "Accustomed to rough-and-tumble fighting using whatever weapons happen to be at hand, you gain the following benefits:",
-      "- Increase your Strength or Constitution score by 1, to a maximum of 20.",
-      "- You are proficient with improvised weapons.",
-      "- Your unarmed strike uses a d4 for damage.",
-      "- When you hit a creature with an unarmed strike or an improvised weapon on your turn, you can use a bonus action to attempt to grapple the target."
-    ],
-    "prerequisites": [],
-    "abilityBonusChoice": {
-      "type": "ability-bonus",
-      "from": [
-        {
-          "str": 1
-        },
-        {
-          "con": 1
-        }
-      ],
-      "choose": 1
-    }
-  },
-  {
-    "id": "tough",
-    "name": "Tough",
-    "desc": [
-      "Your hit point maximum increases by an amount equal to twice your level when you gain this feat. Whenever you gain a level thereafter, your hit point maximum increases by an additional 2 hit points."
-    ],
-    "prerequisites": [],
-    "effects": [
-      {
-        "type": "add-hp",
-        "value": 2,
-        "perLevel": true
-      }
-    ]
-  },
-  {
-    "id": "war-caster",
-    "name": "War Caster",
-    "desc": [
-      "Prerequisite: The ability to cast at least one spell.",
-      "You have practiced casting spells in the midst of combat, learning techniques that grant you the following benefits:",
-      "- You have advantage on Constitution saving throws that you make to maintain your concentration on a spell when you take damage.",
-      "- You can perform the somatic components of spells even when you have weapons or a shield in one or both hands.",
-      "- When a hostile creature\u2019s movement provokes an opportunity attack from you, you can use your reaction to cast a spell at the creature, rather than making an opportunity attack. The spell must have a casting time of 1 action and must target only that creature."
-    ],
-    "prerequisites": []
-  },
-  {
-    "id": "weapon-master",
-    "name": "Weapon Master",
-    "desc": [
-      "You have practiced extensively with a variety of weapons, gaining the following benefits:",
-      "- Increase your Strength or Dexterity score by 1, to a maximum of 20.",
-      "- You gain proficiency with four weapons of your choice. Each one must be a simple or a martial weapon."
-    ],
-    "prerequisites": [],
-    "abilityBonusChoice": {
-      "type": "ability-bonus",
-      "from": [
-        {
-          "str": 1
-        },
-        {
-          "dex": 1
-        }
-      ],
-      "choose": 1
+        "prerequisites": []
     },
-    "proficiencyChoice": {
-      "type": "options-array",
-      "from": [
-        "simple-weapons",
-        "martial-weapons",
-        "clubs",
-        "daggers",
-        "greatclubs",
-        "handaxes",
-        "javelins",
-        "light-hammers",
-        "maces",
-        "quarterstaffs",
-        "sickles",
-        "spears",
-        "crossbows-light",
-        "darts",
-        "shortbows",
-        "slings",
-        "battleaxes",
-        "flails",
-        "glaives",
-        "greataxes",
-        "greatswords",
-        "halberds",
-        "lances",
-        "longswords",
-        "mauls",
-        "morningstars",
-        "pikes",
-        "rapiers",
-        "scimitars",
-        "shortswords",
-        "tridents",
-        "war-picks",
-        "warhammers",
-        "whips",
-        "blowguns",
-        "hand-crossbows",
-        "crossbows-heavy",
-        "longbows",
-        "nets"
-      ],
-      "choose": 4
+    {
+        "id": "athlete",
+        "name": "Athlete",
+        "desc": [
+            "You have undergone extensive physical training to gain the following benefits:",
+            "- Increase your Strength or Dexterity score by 1, to a maximum of 20.",
+            "- When you are prone, standing up uses only 5 feet of movement.",
+            "- Climbing doesn\u2019t halve your speed.",
+            "- You can make a running long jump or a running high jump after moving only 5 feet on foot, rather than 10 feet."
+        ],
+        "prerequisites": [
+            {
+                "type": "ability-score",
+                "abilityScore": [
+                    "str",
+                    "dex"
+                ],
+                "minimumValue": 13,
+                "atLeastOne": true
+            }
+        ],
+        "abilityBonusChoice": {
+            "type": "ability-bonus",
+            "from": [
+                {
+                    "str": 1
+                },
+                {
+                    "dex": 1
+                }
+            ],
+            "choose": 1
+        }
+    },
+    {
+        "id": "charger",
+        "name": "Charger",
+        "desc": [
+            "When you use your action to Dash, you can use a bonus action to make one melee weapon attack or to shove a creature.",
+            "- If you move at least 10 feet in a straight line immediately before taking this bonus action, you either gain a +5 bonus to the attack\u2019s damage roll (if you chose to make a melee attack and hit) or push the target up to 10 feet away from you (if you chose to shove and you succeed)."
+        ],
+        "prerequisites": []
+    },
+    {
+        "id": "crossbow-expert",
+        "name": "Crossbow Expert",
+        "desc": [
+            "Thanks to extensive practice with the crossbow, you gain the following benefits:",
+            "- You ignore the loading quality of crossbows with which you are proficient.",
+            "- Being within 5 feet of a hostile creature doesn\u2019t impose disadvantage on your ranged attack rolls.",
+            "- When you use the Attack action and attack with a one-handed weapon, you can use a bonus action to attack with a loaded hand crossbow you are holding."
+        ],
+        "prerequisites": []
+    },
+    {
+        "id": "defensive-duelist",
+        "name": "Defensive Duelist",
+        "desc": [
+            "Prerequisite: Dexterity 13 or higher.",
+            "When you are wielding a finesse weapon with which you are proficient and another creature hits you with a melee attack, you can use your reaction to add your proficiency bonus to your AC for that attack, potentially causing the attack to miss you."
+        ],
+        "prerequisites": [
+            {
+                "type": "ability-score",
+                "abilityScore": [
+                    "dex"
+                ],
+                "minimumValue": 13,
+                "atLeastOne": false
+            }
+        ]
+    },
+    {
+        "id": "dual-wielder",
+        "name": "Dual Wielder",
+        "desc": [
+            "You master fighting with two weapons, gaining the following benefits:",
+            "- You gain a +1 bonus to AC while you are wielding a separate melee weapon in each hand.",
+            "- You can use two-weapon fighting even when the one-handed melee weapons you are wielding aren\u2019t light.",
+            "- You can draw or stow two one-handed weapons when you would normally be able to draw or stow only one."
+        ],
+        "prerequisites": []
+    },
+    {
+        "id": "dungeon-delver",
+        "name": "Dungeon Delver",
+        "desc": [
+            "Alert to the hidden traps and secret doors found in many dungeons, you gain the following benefits:",
+            "- You have advantage on Wisdom (Perception) and Intelligence (Investigation) checks made to detect the presence of secret doors.",
+            "- You have advantage on saving throws made to avoid or resist traps.",
+            "- You have resistance to the damage dealt by traps.",
+            "- You can search for traps while traveling at a normal pace, instead of only at a slow pace."
+        ],
+        "prerequisites": []
+    },
+    {
+        "id": "durable",
+        "name": "Durable",
+        "desc": [
+            "Hardy and resilient, you gain the following benefits:",
+            "- Increase your Constitution score by 1, to a maximum of 20.",
+            "- When you roll a Hit Die to regain hit points, the minimum number of hit points you regain from the roll equals twice your Constitution modifier (minimum of 2)."
+        ],
+        "prerequisites": [
+            {
+                "type": "ability-score",
+                "abilityScore": [
+                    "con"
+                ],
+                "minimumValue": 13,
+                "atLeastOne": false
+            }
+        ],
+        "effects": [
+            {
+                "type": "modify-abilities",
+                "abilities": {
+                    "con": 1
+                }
+            }
+        ]
+    },
+    {
+        "id": "elemental-adept",
+        "name": "Elemental Adept",
+        "desc": [
+            "Prerequisite: The ability to cast at least one spell.",
+            "When you gain this feat, choose one of the following damage types: acid, cold, fire, lightning, or thunder.",
+            "- Spells you cast ignore resistance to damage of the chosen type.",
+            "- When you roll damage for a spell you cast that deals damage of the chosen type, you can treat any 1 on a damage die as a 2.",
+            "You can select this feat multiple times. Each time you do so, you must choose a different damage type."
+        ],
+        "prerequisites": []
+    },
+    {
+        "id": "grappler",
+        "name": "Grappler",
+        "prerequisites": [
+            {
+                "abilityScore": {
+                    "id": "str"
+                },
+                "minimumScore": 13
+            }
+        ],
+        "desc": [
+            "Prerequisite: Strength 13 or higher.",
+            "You\u2019ve developed the skills necessary to hold your own in close-quarters grappling. You gain the following benefits:",
+            "- You have advantage on attack rolls against a creature you are grappling.",
+            "- You can use your action to try to pin a creature grappled by you. To do so, make another grapple check. If you succeed, you and the creature are both restrained until the grapple ends."
+        ]
+    },
+    {
+        "id": "great-weapon-master",
+        "name": "Great Weapon Master",
+        "desc": [
+            "You\u2019ve learned to put the weight of a weapon to your advantage, letting its momentum empower your strikes. You gain the following benefits:",
+            "- On your turn, when you score a critical hit with a melee weapon or reduce a creature to 0 hit points with one, you can make one melee weapon attack as a bonus action.",
+            "- Before you make a melee attack with a heavy weapon that you are proficient with, you can choose to take a -5 penalty to the attack roll. If the attack hits, you add +10 to the attack\u2019s damage."
+        ],
+        "prerequisites": []
+    },
+    {
+        "id": "healer",
+        "name": "Healer",
+        "desc": [
+            "You are an able physician, allowing you to mend wounds quickly and get your allies back in the fight. You gain the following benefits:",
+            "- When you use a healer\u2019s kit to stabilize a dying creature, that creature also regains 1 hit point.",
+            "- As an action, you can spend one use of a healer\u2019s kit to tend to a creature and restore 1d6 + 4 hit points to it, plus additional hit points equal to the creature\u2019s maximum number of Hit Dice. The creature can\u2019t regain hit points from this feat again until it finishes a short or long rest."
+        ],
+        "prerequisites": []
+    },
+    {
+        "id": "heavily-armored",
+        "name": "Heavily Armored",
+        "desc": [
+            "Prerequisite: Proficiency with medium armor.",
+            "You have trained to master the use of heavy armor, gaining the following benefits:",
+            "- Increase your Strength score by 1, to a maximum of 20.",
+            "- You gain proficiency with heavy armor."
+        ],
+        "prerequisites": [
+            {
+                "type": "proficiency",
+                "id": "medium-armor"
+            }
+        ],
+        "effects": [
+            {
+                "type": "modify-abilities",
+                "abilities": {
+                    "str": 1
+                }
+            },
+            {
+                "type": "add-proficiencies",
+                "proficiencies": [
+                    "heavy-armor"
+                ]
+            }
+        ]
+    },
+    {
+        "id": "heavy-armor-master",
+        "name": "Heavy Armor Master",
+        "desc": [
+            "Prerequisite: Proficiency with heavy armor.",
+            "You can use your armor to deflect strikes that would kill others. You gain the following benefits:",
+            "- Increase your Strength score by 1, to a maximum of 20.",
+            "- While you are wearing heavy armor, bludgeoning, piercing, and slashing damage that you take from nonmagical weapons is reduced by 3."
+        ],
+        "prerequisites": [
+            {
+                "type": "proficiency",
+                "id": "heavy-armor"
+            }
+        ],
+        "effects": [
+            {
+                "type": "modify-abilities",
+                "abilities": {
+                    "str": 1
+                }
+            }
+        ]
+    },
+    {
+        "id": "inspiring-leader",
+        "name": "Inspiring Leader",
+        "desc": [
+            "Prerequisite: Charisma 13 or higher.",
+            "You can spend 10 minutes inspiring your companions, shoring up their resolve to fight. When you do so, choose up to six friendly creatures (which can include yourself) within 30 feet of you who can see or hear you and who can understand you. Each creature can gain temporary hit points equal to your level + your Charisma modifier. A creature can\u2019t gain temporary hit points from this feat again until it has finished a short or long rest."
+        ],
+        "prerequisites": [
+            {
+                "type": "ability-score",
+                "abilityScore": [
+                    "cha"
+                ],
+                "minimumValue": 13,
+                "atLeastOne": false
+            }
+        ]
+    },
+    {
+        "id": "keen-mind",
+        "name": "Keen Mind",
+        "desc": [
+            "You have a mind that can track time, direction, and detail with uncanny precision. You gain the following benefits:",
+            "- Increase your Intelligence score by 1, to a maximum of 20.",
+            "- You always know which way is north.",
+            "- You always know the number of hours left before the next sunrise or sunset.",
+            "- You can accurately recall anything you have seen or heard within the past month."
+        ],
+        "prerequisites": [
+            {
+                "type": "ability-score",
+                "abilityScore": [
+                    "int"
+                ],
+                "minimumValue": 13,
+                "atLeastOne": false
+            }
+        ],
+        "effects": [
+            {
+                "type": "modify-abilities",
+                "abilities": {
+                    "int": 1
+                }
+            }
+        ]
+    },
+    {
+        "id": "lightly-armored",
+        "name": "Lightly Armored",
+        "desc": [
+            "You have trained to master the use of light armor, gaining the following benefits:",
+            "- Increase your Strength or Dexterity score by 1, to a maximum of 20.",
+            "- You gain proficiency with light armor."
+        ],
+        "prerequisites": [],
+        "effects": [
+            {
+                "type": "add-proficiencies",
+                "proficiencies": [
+                    "light-armor"
+                ]
+            }
+        ],
+        "abilityBonusChoice": {
+            "type": "ability-bonus",
+            "from": [
+                {
+                    "str": 1
+                },
+                {
+                    "dex": 1
+                }
+            ],
+            "choose": 1
+        }
+    },
+    {
+        "id": "linguist",
+        "name": "Linguist",
+        "desc": [
+            "You have studied languages and codes, gaining the following benefits:",
+            "- Increase your Intelligence score by 1, to a maximum of 20.",
+            "- You learn three languages of your choice.",
+            "- You can ably create written ciphers. Others can\u2019t decipher a code you create unless you teach them, they succeed on an Intelligence check (DC equal to your Intelligence score + your proficiency bonus), or they use magic to decipher it."
+        ],
+        "prerequisites": [
+            {
+                "type": "ability-score",
+                "abilityScore": [
+                    "int"
+                ],
+                "minimumValue": 13,
+                "atLeastOne": false
+            }
+        ],
+        "effects": [
+            {
+                "type": "modify-abilities",
+                "abilities": {
+                    "int": 1
+                }
+            }
+        ],
+        "languageChoice": {
+            "type": "resource-list",
+            "from": "languages",
+            "choose": 3
+        }
+    },
+    {
+        "id": "lucky",
+        "name": "Lucky",
+        "desc": [
+            "You have inexplicable luck that seems to kick in at just the right moment.",
+            "- You have 3 luck points. Whenever you make an attack roll, an ability check, or a saving throw, you can spend one luck point to roll an additional d20. You can choose to spend one of your luck points after you roll the die, but before the outcome is determined. You choose which of the d20s is used for the attack roll, ability check, or saving throw.",
+            "- You can also spend one luck point when an attack roll is made against you. Roll a d20, and then choose whether the attack uses the attacker\u2019s roll or yours.",
+            "- If more than one creature spends a luck point to influence the outcome of a roll, the points cancel each other out; no additional dice are rolled.",
+            "You regain your expended luck points when you finish a long rest."
+        ],
+        "prerequisites": []
+    },
+    {
+        "id": "mage-slayer",
+        "name": "Mage Slayer",
+        "desc": [
+            "You have practiced techniques useful in melee combat against spellcasters, gaining the following benefits:",
+            "- When a creature within 5 feet of you casts a spell, you can use your reaction to make a melee weapon attack against that creature.",
+            "- When you damage a creature that is concentrating on a spell, that creature has disadvantage on the saving throw it makes to maintain its concentration.",
+            "- You have advantage on saving throws against spells cast by creatures within 5 feet of you."
+        ],
+        "prerequisites": []
+    },
+    {
+        "id": "magic-initiate",
+        "name": "Magic Initiate",
+        "desc": [
+            "Choose a class: bard, cleric, druid, sorcerer, warlock, or wizard. You learn two cantrips of your choice from that class\u2019s spell list.",
+            "- In addition, choose one 1st-level spell to learn from that same list. Using this feat, you can cast the spell at its lowest level. Once you cast it, you must finish a long rest before you can cast it in this way again.",
+            "- Your spellcasting ability for these spells depends on the class you chose: Charisma for bard, sorcerer, or warlock; Wisdom for cleric or druid; or Intelligence for wizard."
+        ],
+        "prerequisites": []
+    },
+    {
+        "id": "martial-adept",
+        "name": "Martial Adept",
+        "desc": [
+            "You have martial training that allows you to perform special combat maneuvers. You gain the following benefits:",
+            "- You learn two maneuvers of your choice from among those available to the Battle Master archetype in the fighter class. If a maneuver you use requires your target to make a saving throw to resist the maneuver\u2019s effects, the saving throw DC equals 8 + your proficiency bonus + your Strength or Dexterity modifier (your choice).",
+            "- If you already have a superiority dice, you gain one more; otherwise, you have one superiority die, which is a d6. This die is used to fuel your maneuvers. A superiority die is expended when you use it. You regain your expended superiority dice when you finish a short or long rest."
+        ],
+        "prerequisites": []
+    },
+    {
+        "id": "medium-armor-master",
+        "name": "Medium Armor Master",
+        "desc": [
+            "Prerequisite: Proficiency with medium armor.",
+            "You have practiced moving in medium armor to gain the following benefits:",
+            "- Wearing medium armor doesn\u2019t impose disadvantage on your Dexterity (Stealth) checks.",
+            "- When you wear medium armor, you can add 3, rather than 2, to your AC if you have a Dexterity of 16 or higher."
+        ],
+        "prerequisites": [
+            {
+                "type": "proficiency",
+                "id": "medium-armor"
+            }
+        ]
+    },
+    {
+        "id": "mobile",
+        "name": "Mobile",
+        "desc": [
+            "You are exceptionally speedy and agile. You gain the following benefits:",
+            "- Your speed increases by 10 feet.",
+            "- When you use the Dash action, difficult terrain doesn\u2019t cost you extra movement on that turn.",
+            "- When you make a melee attack against a creature, you don\u2019t provoke opportunity attacks from that creature for the rest of the turn, whether you hit or not."
+        ],
+        "prerequisites": []
+    },
+    {
+        "id": "moderately-armored",
+        "name": "Moderately Armored",
+        "desc": [
+            "Prerequisite: Proficiency with light armor.",
+            "You have trained to master the use of medium armor and shields, gaining the following benefits:",
+            "- Increase your Strength or Dexterity score by 1, to a maximum of 20.",
+            "- You gain proficiency with medium armor and shields."
+        ],
+        "prerequisites": [
+            {
+                "type": "proficiency",
+                "id": "light-armor"
+            }
+        ],
+        "effects": [
+            {
+                "type": "add-proficiencies",
+                "proficiencies": [
+                    "medium-armor",
+                    "shields"
+                ]
+            }
+        ],
+        "abilityBonusChoice": {
+            "type": "ability-bonus",
+            "from": [
+                {
+                    "str": 1
+                },
+                {
+                    "dex": 1
+                }
+            ],
+            "choose": 1
+        }
+    },
+    {
+        "id": "mounted-combatant",
+        "name": "Mounted Combatant",
+        "desc": [
+            "You are a dangerous foe to face while mounted. While you are mounted and aren\u2019t incapacitated, you gain the following benefits:",
+            "- You have advantage on melee attack rolls against any unmounted creature that is smaller than your mount.",
+            "- You can force an attack targeted at your mount to target you instead.",
+            "- If your mount is subjected to an effect that allows it to make a Dexterity saving throw to take only half damage, it instead takes no damage if it succeeds on the saving throw, and only half damage if it fails."
+        ],
+        "prerequisites": []
+    },
+    {
+        "id": "observant",
+        "name": "Observant",
+        "desc": [
+            "Quick to notice details of your environment, you gain the following benefits:",
+            "- Increase your Intelligence or Wisdom score by 1, to a maximum of 20.",
+            "- If you can see a creature\u2019s mouth while it is speaking a language you understand, you can interpret what it\u2019s saying by reading its lips.",
+            "- You have a +5 bonus to your passive Wisdom (Perception) and passive Intelligence (Investigation) scores."
+        ],
+        "prerequisites": [
+            {
+                "type": "ability-score",
+                "abilityScore": [
+                    "int",
+                    "wis"
+                ],
+                "minimumValue": 13,
+                "atLeastOne": true
+            }
+        ],
+        "abilityBonusChoice": {
+            "type": "ability-bonus",
+            "from": [
+                {
+                    "int": 1
+                },
+                {
+                    "wis": 1
+                }
+            ],
+            "choose": 1
+        }
+    },
+    {
+        "id": "polearm-master",
+        "name": "Polearm Master",
+        "desc": [
+            "You can keep your enemies at bay with reach weapons. You gain the following benefits:",
+            "- When you take the Attack action and attack with only a glaive, halberd, quarterstaff, or spear, you can use a bonus action to make a melee attack with the opposite end of the weapon. This attack uses the same ability modifier as the primary attack. The weapon\u2019s damage die for this attack is a d4, and the attack deals bludgeoning damage.",
+            "- While you are wielding a glaive, halberd, pike, quarterstaff, or spear, other creatures provoke an opportunity attack from you when they enter your reach."
+        ],
+        "prerequisites": []
+    },
+    {
+        "id": "resilient",
+        "name": "Resilient",
+        "desc": [
+            "Choose one ability score. You gain the following benefits:",
+            "- Increase the chosen ability score by 1, to a maximum of 20.",
+            "- You gain proficiency in saving throws using the chosen ability."
+        ],
+        "prerequisites": [],
+        "abilityBonusChoice": {
+            "type": "ability-bonus",
+            "from": [
+                {
+                    "str": 1
+                },
+                {
+                    "dex": 1
+                },
+                {
+                    "con": 1
+                },
+                {
+                    "int": 1
+                },
+                {
+                    "wis": 1
+                },
+                {
+                    "cha": 1
+                }
+            ],
+            "choose": 1
+        },
+        "proficiencyChoice": {
+            "type": "options-array",
+            "from": [
+                "saving-throw-str",
+                "saving-throw-dex",
+                "saving-throw-con",
+                "saving-throw-int",
+                "saving-throw-wis",
+                "saving-throw-cha"
+            ],
+            "choose": 1
+        }
+    },
+    {
+        "id": "ritual-caster",
+        "name": "Ritual Caster",
+        "desc": [
+            "Prerequisite: Intelligence or Wisdom 13 or higher.",
+            "You have learned a number of spells that you can cast as rituals. These spells are written in a ritual book, which you must have in hand while casting one of them.",
+            "- Choose one of the following classes: bard, cleric, druid, sorcerer, warlock, or wizard. You acquire a ritual book holding two 1st-level spells of your choice. You must choose your spells from that class\u2019s spell list, and the spells you choose must have the ritual tag.",
+            "- If you come across a spell in written form, you might be able to add it to your ritual book. The spell must be on the spell list for the class you chose, the spell\u2019s level can be no higher than half your level (rounded up), and it must have the ritual tag. The process of copying the spell takes 2 hours per level of the spell, and costs 50 gp per level."
+        ],
+        "prerequisites": [
+            {
+                "type": "ability-score",
+                "abilityScore": [
+                    "int",
+                    "wis"
+                ],
+                "minimumValue": 13,
+                "atLeastOne": true
+            }
+        ]
+    },
+    {
+        "id": "savage-attacker",
+        "name": "Savage Attacker",
+        "desc": [
+            "Once per turn when you roll damage for a melee weapon attack, you can reroll the weapon\u2019s damage dice and use either total."
+        ],
+        "prerequisites": []
+    },
+    {
+        "id": "sentinel",
+        "name": "Sentinel",
+        "desc": [
+            "You have mastered techniques to take advantage of every drop in any enemy\u2019s guard, gaining the following benefits:",
+            "- When you hit a creature with an opportunity attack, the creature\u2019s speed becomes 0 for the rest of the turn.",
+            "- Creatures provoke opportunity attacks from you even if they take the Disengage action before leaving your reach.",
+            "- When a creature within 5 feet of you makes an attack against a target other than you (and that target doesn\u2019t have this feat), you can use your reaction to make a melee weapon attack against the attacking creature."
+        ],
+        "prerequisites": []
+    },
+    {
+        "id": "sharpshooter",
+        "name": "Sharpshooter",
+        "desc": [
+            "You have mastered ranged weapons and can make shots that others find impossible. You gain the following benefits:",
+            "- Attacking at long range doesn\u2019t impose disadvantage on your ranged weapon attack rolls.",
+            "- Your ranged weapon attacks ignore half cover and three-quarters cover.",
+            "- Before you make an attack with a ranged weapon that you are proficient with, you can choose to take a -5 penalty to the attack roll. If the attack hits, you add +10 to the attack\u2019s damage."
+        ],
+        "prerequisites": []
+    },
+    {
+        "id": "shield-master",
+        "name": "Shield Master",
+        "desc": [
+            "You use shields not just for protection but also for offense. You gain the following benefits while you are wielding a shield:",
+            "- If you take the Attack action on your turn, you can use a bonus action to try to shove a creature within 5 feet of you with your shield.",
+            "- If you aren\u2019t incapacitated, you can add your shield\u2019s AC bonus to any Dexterity saving throw you make against a spell or other harmful effect that targets only you.",
+            "- If you are subjected to an effect that allows you to make a Dexterity saving throw to take only half damage, you can use your reaction to take no damage if you succeed on the saving throw, interposing your shield between yourself and the source of the effect."
+        ],
+        "prerequisites": []
+    },
+    {
+        "id": "skilled",
+        "name": "Skilled",
+        "desc": [
+            "You gain proficiency in any combination of three skills or tools of your choice."
+        ],
+        "prerequisites": [],
+        "proficiencyChoice": {
+            "type": "options-array",
+            "from": [
+                "alchemists-supplies",
+                "brewers-supplies",
+                "calligraphers-supplies",
+                "carpenters-tools",
+                "cartographers-tools",
+                "cobblers-tools",
+                "cooks-utensils",
+                "glassblowers-tools",
+                "jewelers-tools",
+                "leatherworkers-tools",
+                "masons-tools",
+                "painters-supplies",
+                "potters-tools",
+                "smiths-tools",
+                "tinkers-tools",
+                "weavers-tools",
+                "woodcarvers-tools",
+                "disguise-kit",
+                "forgery-kit",
+                "dice-set",
+                "playing-card-set",
+                "bagpipes",
+                "drum",
+                "dulcimer",
+                "flute",
+                "lute",
+                "lyre",
+                "horn",
+                "pan-flute",
+                "shawm",
+                "viol",
+                "herbalism-kit",
+                "navigators-tools",
+                "poisoners-kit",
+                "thieves-tools",
+                "land-vehicles",
+                "water-vehicles",
+                "skill-acrobatics",
+                "skill-animal-handling",
+                "skill-arcana",
+                "skill-athletics",
+                "skill-deception",
+                "skill-history",
+                "skill-insight",
+                "skill-intimidation",
+                "skill-investigation",
+                "skill-medicine",
+                "skill-nature",
+                "skill-perception",
+                "skill-performance",
+                "skill-persuasion",
+                "skill-religion",
+                "skill-sleight-of-hand",
+                "skill-stealth",
+                "skill-survival"
+            ],
+            "choose": 3
+        }
+    },
+    {
+        "id": "skulker",
+        "name": "Skulker",
+        "desc": [
+            "Prerequisite: Dexterity 13 or higher.",
+            "You are expert at slinking through shadows. You gain the following benefits:",
+            "- You can try to hide when you are lightly obscured from the creature from which you are hiding.",
+            "- When you are hidden from a creature and miss it with a ranged weapon attack, making the attack doesn\u2019t reveal your position.",
+            "- Dim light doesn\u2019t impose disadvantage on your Wisdom (Perception) checks relying on sight."
+        ],
+        "prerequisites": [
+            {
+                "type": "proficiency",
+                "id": "skill-stealth"
+            }
+        ]
+    },
+    {
+        "id": "spell-sniper",
+        "name": "Spell Sniper",
+        "desc": [
+            "Prerequisite: The ability to cast at least one spell.",
+            "You have learned techniques to enhance your attacks with certain kinds of spells, gaining the following benefits:",
+            "- When you cast a spell that requires you to make an attack roll, the spell\u2019s range is doubled.",
+            "- Your ranged spell attacks ignore half cover and three-quarters cover.",
+            "- You learn one cantrip that requires an attack roll. Choose the cantrip from the bard, cleric, druid, sorcerer, warlock, or wizard spell list. Your spellcasting ability for this cantrip depends on the spell list you chose."
+        ],
+        "prerequisites": []
+    },
+    {
+        "id": "tavern-brawler",
+        "name": "Tavern Brawler",
+        "desc": [
+            "Accustomed to rough-and-tumble fighting using whatever weapons happen to be at hand, you gain the following benefits:",
+            "- Increase your Strength or Constitution score by 1, to a maximum of 20.",
+            "- You are proficient with improvised weapons.",
+            "- Your unarmed strike uses a d4 for damage.",
+            "- When you hit a creature with an unarmed strike or an improvised weapon on your turn, you can use a bonus action to attempt to grapple the target."
+        ],
+        "prerequisites": [],
+        "abilityBonusChoice": {
+            "type": "ability-bonus",
+            "from": [
+                {
+                    "str": 1
+                },
+                {
+                    "con": 1
+                }
+            ],
+            "choose": 1
+        }
+    },
+    {
+        "id": "tough",
+        "name": "Tough",
+        "desc": [
+            "Your hit point maximum increases by an amount equal to twice your level when you gain this feat. Whenever you gain a level thereafter, your hit point maximum increases by an additional 2 hit points."
+        ],
+        "prerequisites": [],
+        "effects": [
+            {
+                "type": "add-hp",
+                "value": 2,
+                "perLevel": true
+            }
+        ]
+    },
+    {
+        "id": "war-caster",
+        "name": "War Caster",
+        "desc": [
+            "Prerequisite: The ability to cast at least one spell.",
+            "You have practiced casting spells in the midst of combat, learning techniques that grant you the following benefits:",
+            "- You have advantage on Constitution saving throws that you make to maintain your concentration on a spell when you take damage.",
+            "- You can perform the somatic components of spells even when you have weapons or a shield in one or both hands.",
+            "- When a hostile creature\u2019s movement provokes an opportunity attack from you, you can use your reaction to cast a spell at the creature, rather than making an opportunity attack. The spell must have a casting time of 1 action and must target only that creature."
+        ],
+        "prerequisites": []
+    },
+    {
+        "id": "weapon-master",
+        "name": "Weapon Master",
+        "desc": [
+            "You have practiced extensively with a variety of weapons, gaining the following benefits:",
+            "- Increase your Strength or Dexterity score by 1, to a maximum of 20.",
+            "- You gain proficiency with four weapons of your choice. Each one must be a simple or a martial weapon."
+        ],
+        "prerequisites": [],
+        "abilityBonusChoice": {
+            "type": "ability-bonus",
+            "from": [
+                {
+                    "str": 1
+                },
+                {
+                    "dex": 1
+                }
+            ],
+            "choose": 1
+        },
+        "proficiencyChoice": {
+            "type": "options-array",
+            "from": [
+                "simple-weapons",
+                "martial-weapons",
+                "clubs",
+                "daggers",
+                "greatclubs",
+                "handaxes",
+                "javelins",
+                "light-hammers",
+                "maces",
+                "quarterstaffs",
+                "sickles",
+                "spears",
+                "crossbows-light",
+                "darts",
+                "shortbows",
+                "slings",
+                "battleaxes",
+                "flails",
+                "glaives",
+                "greataxes",
+                "greatswords",
+                "halberds",
+                "lances",
+                "longswords",
+                "mauls",
+                "morningstars",
+                "pikes",
+                "rapiers",
+                "scimitars",
+                "shortswords",
+                "tridents",
+                "war-picks",
+                "warhammers",
+                "whips",
+                "blowguns",
+                "hand-crossbows",
+                "crossbows-heavy",
+                "longbows",
+                "nets"
+            ],
+            "choose": 4
+        }
     }
-  }
 ]

--- a/app/src/main/assets/data/feats.json
+++ b/app/src/main/assets/data/feats.json
@@ -1,503 +1,862 @@
 [
-    {
-        "id": "actor",
-        "name": "Actor",
-        "desc": [
-            "Skilled at mimicry and dramatics, you gain the following benefits:",
-            "- Increase your Charisma score by 1, to a maximum of 20.",
-            "- You have advantage on Charisma (Deception) and Charisma (Performance) checks when trying to pass yourself off as a different person.",
-            "- You can mimic the speech of another person or the sounds made by other creatures. You must have heard the person speaking, or heard the creature make the sound, for at least 1 minute. A successful Wisdom (Insight) check contested by your Charisma (Deception) check allows a listener to determine the effect is faked."
+  {
+    "id": "actor",
+    "name": "Actor",
+    "desc": [
+      "Skilled at mimicry and dramatics, you gain the following benefits:",
+      "- Increase your Charisma score by 1, to a maximum of 20.",
+      "- You have advantage on Charisma (Deception) and Charisma (Performance) checks when trying to pass yourself off as a different person.",
+      "- You can mimic the speech of another person or the sounds made by other creatures. You must have heard the person speaking, or heard the creature make the sound, for at least 1 minute. A successful Wisdom (Insight) check contested by your Charisma (Deception) check allows a listener to determine the effect is faked."
+    ],
+    "prerequisites": [
+      {
+        "type": "ability-score",
+        "abilityScore": [
+          "cha"
         ],
-        "prerequisites": []
-    },
-    {
-        "id": "alert",
-        "name": "Alert",
-        "desc": [
-            "Always on the lookout for danger, you gain the following benefits:",
-            "- You gain a +5 bonus to initiative.",
-            "- You can\u2019t be surprised while you are conscious.",
-            "- Other creatures don\u2019t gain advantage on attack rolls against you as a result of being unseen by you."
+        "minimumValue": 13,
+        "atLeastOne": false
+      }
+    ],
+    "effects": [
+      {
+        "type": "modify-abilities",
+        "abilities": {
+          "cha": 1
+        }
+      }
+    ]
+  },
+  {
+    "id": "alert",
+    "name": "Alert",
+    "desc": [
+      "Always on the lookout for danger, you gain the following benefits:",
+      "- You gain a +5 bonus to initiative.",
+      "- You can\u2019t be surprised while you are conscious.",
+      "- Other creatures don\u2019t gain advantage on attack rolls against you as a result of being unseen by you."
+    ],
+    "prerequisites": []
+  },
+  {
+    "id": "athlete",
+    "name": "Athlete",
+    "desc": [
+      "You have undergone extensive physical training to gain the following benefits:",
+      "- Increase your Strength or Dexterity score by 1, to a maximum of 20.",
+      "- When you are prone, standing up uses only 5 feet of movement.",
+      "- Climbing doesn\u2019t halve your speed.",
+      "- You can make a running long jump or a running high jump after moving only 5 feet on foot, rather than 10 feet."
+    ],
+    "prerequisites": [
+      {
+        "type": "ability-score",
+        "abilityScore": [
+          "str",
+          "dex"
         ],
-        "prerequisites": []
-    },
-    {
-        "id": "athlete",
-        "name": "Athlete",
-        "desc": [
-            "You have undergone extensive physical training to gain the following benefits:",
-            "- Increase your Strength or Dexterity score by 1, to a maximum of 20.",
-            "- When you are prone, standing up uses only 5 feet of movement.",
-            "- Climbing doesn\u2019t halve your speed.",
-            "- You can make a running long jump or a running high jump after moving only 5 feet on foot, rather than 10 feet."
-        ],
-        "prerequisites": []
-    },
-    {
-        "id": "charger",
-        "name": "Charger",
-        "desc": [
-            "When you use your action to Dash, you can use a bonus action to make one melee weapon attack or to shove a creature.",
-            "- If you move at least 10 feet in a straight line immediately before taking this bonus action, you either gain a +5 bonus to the attack\u2019s damage roll (if you chose to make a melee attack and hit) or push the target up to 10 feet away from you (if you chose to shove and you succeed)."
-        ],
-        "prerequisites": []
-    },
-    {
-        "id": "crossbow-expert",
-        "name": "Crossbow Expert",
-        "desc": [
-            "Thanks to extensive practice with the crossbow, you gain the following benefits:",
-            "- You ignore the loading quality of crossbows with which you are proficient.",
-            "- Being within 5 feet of a hostile creature doesn\u2019t impose disadvantage on your ranged attack rolls.",
-            "- When you use the Attack action and attack with a one-handed weapon, you can use a bonus action to attack with a loaded hand crossbow you are holding."
-        ],
-        "prerequisites": []
-    },
-    {
-        "id": "defensive-duelist",
-        "name": "Defensive Duelist",
-        "desc": [
-            "Prerequisite: Dexterity 13 or higher.",
-            "When you are wielding a finesse weapon with which you are proficient and another creature hits you with a melee attack, you can use your reaction to add your proficiency bonus to your AC for that attack, potentially causing the attack to miss you."
-        ],
-        "prerequisites": [
-            {
-                "abilityScore": {
-                    "id": "dex"
-                },
-                "minimumScore": 13
-            }
-        ]
-    },
-    {
-        "id": "dual-wielder",
-        "name": "Dual Wielder",
-        "desc": [
-            "You master fighting with two weapons, gaining the following benefits:",
-            "- You gain a +1 bonus to AC while you are wielding a separate melee weapon in each hand.",
-            "- You can use two-weapon fighting even when the one-handed melee weapons you are wielding aren\u2019t light.",
-            "- You can draw or stow two one-handed weapons when you would normally be able to draw or stow only one."
-        ],
-        "prerequisites": []
-    },
-    {
-        "id": "dungeon-delver",
-        "name": "Dungeon Delver",
-        "desc": [
-            "Alert to the hidden traps and secret doors found in many dungeons, you gain the following benefits:",
-            "- You have advantage on Wisdom (Perception) and Intelligence (Investigation) checks made to detect the presence of secret doors.",
-            "- You have advantage on saving throws made to avoid or resist traps.",
-            "- You have resistance to the damage dealt by traps.",
-            "- You can search for traps while traveling at a normal pace, instead of only at a slow pace."
-        ],
-        "prerequisites": []
-    },
-    {
-        "id": "durable",
-        "name": "Durable",
-        "desc": [
-            "Hardy and resilient, you gain the following benefits:",
-            "- Increase your Constitution score by 1, to a maximum of 20.",
-            "- When you roll a Hit Die to regain hit points, the minimum number of hit points you regain from the roll equals twice your Constitution modifier (minimum of 2)."
-        ],
-        "prerequisites": []
-    },
-    {
-        "id": "elemental-adept",
-        "name": "Elemental Adept",
-        "desc": [
-            "Prerequisite: The ability to cast at least one spell.",
-            "When you gain this feat, choose one of the following damage types: acid, cold, fire, lightning, or thunder.",
-            "- Spells you cast ignore resistance to damage of the chosen type.",
-            "- When you roll damage for a spell you cast that deals damage of the chosen type, you can treat any 1 on a damage die as a 2.",
-            "You can select this feat multiple times. Each time you do so, you must choose a different damage type."
-        ],
-        "prerequisites": []
-    },
-    {
-        "id": "grappler",
-        "name": "Grappler",
-        "prerequisites": [
-            {
-                "abilityScore": {
-                    "id": "str"
-                },
-                "minimumScore": 13
-            }
-        ],
-        "desc": [
-            "Prerequisite: Strength 13 or higher.",
-            "You\u2019ve developed the skills necessary to hold your own in close-quarters grappling. You gain the following benefits:",
-            "- You have advantage on attack rolls against a creature you are grappling.",
-            "- You can use your action to try to pin a creature grappled by you. To do so, make another grapple check. If you succeed, you and the creature are both restrained until the grapple ends."
-        ]
-    },
-    {
-        "id": "great-weapon-master",
-        "name": "Great Weapon Master",
-        "desc": [
-            "You\u2019ve learned to put the weight of a weapon to your advantage, letting its momentum empower your strikes. You gain the following benefits:",
-            "- On your turn, when you score a critical hit with a melee weapon or reduce a creature to 0 hit points with one, you can make one melee weapon attack as a bonus action.",
-            "- Before you make a melee attack with a heavy weapon that you are proficient with, you can choose to take a -5 penalty to the attack roll. If the attack hits, you add +10 to the attack\u2019s damage."
-        ],
-        "prerequisites": []
-    },
-    {
-        "id": "healer",
-        "name": "Healer",
-        "desc": [
-            "You are an able physician, allowing you to mend wounds quickly and get your allies back in the fight. You gain the following benefits:",
-            "- When you use a healer\u2019s kit to stabilize a dying creature, that creature also regains 1 hit point.",
-            "- As an action, you can spend one use of a healer\u2019s kit to tend to a creature and restore 1d6 + 4 hit points to it, plus additional hit points equal to the creature\u2019s maximum number of Hit Dice. The creature can\u2019t regain hit points from this feat again until it finishes a short or long rest."
-        ],
-        "prerequisites": []
-    },
-    {
-        "id": "heavily-armored",
-        "name": "Heavily Armored",
-        "desc": [
-            "Prerequisite: Proficiency with medium armor.",
-            "You have trained to master the use of heavy armor, gaining the following benefits:",
-            "- Increase your Strength score by 1, to a maximum of 20.",
-            "- You gain proficiency with heavy armor."
-        ],
-        "prerequisites": []
-    },
-    {
-        "id": "heavy-armor-master",
-        "name": "Heavy Armor Master",
-        "desc": [
-            "Prerequisite: Proficiency with heavy armor.",
-            "You can use your armor to deflect strikes that would kill others. You gain the following benefits:",
-            "- Increase your Strength score by 1, to a maximum of 20.",
-            "- While you are wearing heavy armor, bludgeoning, piercing, and slashing damage that you take from nonmagical weapons is reduced by 3."
-        ],
-        "prerequisites": []
-    },
-    {
-        "id": "inspiring-leader",
-        "name": "Inspiring Leader",
-        "desc": [
-            "Prerequisite: Charisma 13 or higher.",
-            "You can spend 10 minutes inspiring your companions, shoring up their resolve to fight. When you do so, choose up to six friendly creatures (which can include yourself) within 30 feet of you who can see or hear you and who can understand you. Each creature can gain temporary hit points equal to your level + your Charisma modifier. A creature can\u2019t gain temporary hit points from this feat again until it has finished a short or long rest."
-        ],
-        "prerequisites": [
-            {
-                "abilityScore": {
-                    "id": "cha"
-                },
-                "minimumScore": 13
-            }
-        ]
-    },
-    {
-        "id": "keen-mind",
-        "name": "Keen Mind",
-        "desc": [
-            "You have a mind that can track time, direction, and detail with uncanny precision. You gain the following benefits:",
-            "- Increase your Intelligence score by 1, to a maximum of 20.",
-            "- You always know which way is north.",
-            "- You always know the number of hours left before the next sunrise or sunset.",
-            "- You can accurately recall anything you have seen or heard within the past month."
-        ],
-        "prerequisites": []
-    },
-    {
-        "id": "lightly-armored",
-        "name": "Lightly Armored",
-        "desc": [
-            "You have trained to master the use of light armor, gaining the following benefits:",
-            "- Increase your Strength or Dexterity score by 1, to a maximum of 20.",
-            "- You gain proficiency with light armor."
-        ],
-        "prerequisites": []
-    },
-    {
-        "id": "linguist",
-        "name": "Linguist",
-        "desc": [
-            "You have studied languages and codes, gaining the following benefits:",
-            "- Increase your Intelligence score by 1, to a maximum of 20.",
-            "- You learn three languages of your choice.",
-            "- You can ably create written ciphers. Others can\u2019t decipher a code you create unless you teach them, they succeed on an Intelligence check (DC equal to your Intelligence score + your proficiency bonus), or they use magic to decipher it."
-        ],
-        "prerequisites": []
-    },
-    {
-        "id": "lucky",
-        "name": "Lucky",
-        "desc": [
-            "You have inexplicable luck that seems to kick in at just the right moment.",
-            "- You have 3 luck points. Whenever you make an attack roll, an ability check, or a saving throw, you can spend one luck point to roll an additional d20. You can choose to spend one of your luck points after you roll the die, but before the outcome is determined. You choose which of the d20s is used for the attack roll, ability check, or saving throw.",
-            "- You can also spend one luck point when an attack roll is made against you. Roll a d20, and then choose whether the attack uses the attacker\u2019s roll or yours.",
-            "- If more than one creature spends a luck point to influence the outcome of a roll, the points cancel each other out; no additional dice are rolled.",
-            "You regain your expended luck points when you finish a long rest."
-        ],
-        "prerequisites": []
-    },
-    {
-        "id": "mage-slayer",
-        "name": "Mage Slayer",
-        "desc": [
-            "You have practiced techniques useful in melee combat against spellcasters, gaining the following benefits:",
-            "- When a creature within 5 feet of you casts a spell, you can use your reaction to make a melee weapon attack against that creature.",
-            "- When you damage a creature that is concentrating on a spell, that creature has disadvantage on the saving throw it makes to maintain its concentration.",
-            "- You have advantage on saving throws against spells cast by creatures within 5 feet of you."
-        ],
-        "prerequisites": []
-    },
-    {
-        "id": "magic-initiate",
-        "name": "Magic Initiate",
-        "desc": [
-            "Choose a class: bard, cleric, druid, sorcerer, warlock, or wizard. You learn two cantrips of your choice from that class\u2019s spell list.",
-            "- In addition, choose one 1st-level spell to learn from that same list. Using this feat, you can cast the spell at its lowest level. Once you cast it, you must finish a long rest before you can cast it in this way again.",
-            "- Your spellcasting ability for these spells depends on the class you chose: Charisma for bard, sorcerer, or warlock; Wisdom for cleric or druid; or Intelligence for wizard."
-        ],
-        "prerequisites": []
-    },
-    {
-        "id": "martial-adept",
-        "name": "Martial Adept",
-        "desc": [
-            "You have martial training that allows you to perform special combat maneuvers. You gain the following benefits:",
-            "- You learn two maneuvers of your choice from among those available to the Battle Master archetype in the fighter class. If a maneuver you use requires your target to make a saving throw to resist the maneuver\u2019s effects, the saving throw DC equals 8 + your proficiency bonus + your Strength or Dexterity modifier (your choice).",
-            "- If you already have a superiority dice, you gain one more; otherwise, you have one superiority die, which is a d6. This die is used to fuel your maneuvers. A superiority die is expended when you use it. You regain your expended superiority dice when you finish a short or long rest."
-        ],
-        "prerequisites": []
-    },
-    {
-        "id": "medium-armor-master",
-        "name": "Medium Armor Master",
-        "desc": [
-            "Prerequisite: Proficiency with medium armor.",
-            "You have practiced moving in medium armor to gain the following benefits:",
-            "- Wearing medium armor doesn\u2019t impose disadvantage on your Dexterity (Stealth) checks.",
-            "- When you wear medium armor, you can add 3, rather than 2, to your AC if you have a Dexterity of 16 or higher."
-        ],
-        "prerequisites": []
-    },
-    {
-        "id": "mobile",
-        "name": "Mobile",
-        "desc": [
-            "You are exceptionally speedy and agile. You gain the following benefits:",
-            "- Your speed increases by 10 feet.",
-            "- When you use the Dash action, difficult terrain doesn\u2019t cost you extra movement on that turn.",
-            "- When you make a melee attack against a creature, you don\u2019t provoke opportunity attacks from that creature for the rest of the turn, whether you hit or not."
-        ],
-        "prerequisites": []
-    },
-    {
-        "id": "moderately-armored",
-        "name": "Moderately Armored",
-        "desc": [
-            "Prerequisite: Proficiency with light armor.",
-            "You have trained to master the use of medium armor and shields, gaining the following benefits:",
-            "- Increase your Strength or Dexterity score by 1, to a maximum of 20.",
-            "- You gain proficiency with medium armor and shields."
-        ],
-        "prerequisites": []
-    },
-    {
-        "id": "mounted-combatant",
-        "name": "Mounted Combatant",
-        "desc": [
-            "You are a dangerous foe to face while mounted. While you are mounted and aren\u2019t incapacitated, you gain the following benefits:",
-            "- You have advantage on melee attack rolls against any unmounted creature that is smaller than your mount.",
-            "- You can force an attack targeted at your mount to target you instead.",
-            "- If your mount is subjected to an effect that allows it to make a Dexterity saving throw to take only half damage, it instead takes no damage if it succeeds on the saving throw, and only half damage if it fails."
-        ],
-        "prerequisites": []
-    },
-    {
-        "id": "observant",
-        "name": "Observant",
-        "desc": [
-            "Quick to notice details of your environment, you gain the following benefits:",
-            "- Increase your Intelligence or Wisdom score by 1, to a maximum of 20.",
-            "- If you can see a creature\u2019s mouth while it is speaking a language you understand, you can interpret what it\u2019s saying by reading its lips.",
-            "- You have a +5 bonus to your passive Wisdom (Perception) and passive Intelligence (Investigation) scores."
-        ],
-        "prerequisites": [
-            {
-                "abilityScore": {
-                    "id": "int"
-                },
-                "minimumScore": 13
-            },
-            {
-                "abilityScore": {
-                    "id": "wis"
-                },
-                "minimumScore": 13
-            }
-        ]
-    },
-    {
-        "id": "polearm-master",
-        "name": "Polearm Master",
-        "desc": [
-            "You can keep your enemies at bay with reach weapons. You gain the following benefits:",
-            "- When you take the Attack action and attack with only a glaive, halberd, quarterstaff, or spear, you can use a bonus action to make a melee attack with the opposite end of the weapon. This attack uses the same ability modifier as the primary attack. The weapon\u2019s damage die for this attack is a d4, and the attack deals bludgeoning damage.",
-            "- While you are wielding a glaive, halberd, pike, quarterstaff, or spear, other creatures provoke an opportunity attack from you when they enter your reach."
-        ],
-        "prerequisites": []
-    },
-    {
-        "id": "resilient",
-        "name": "Resilient",
-        "desc": [
-            "Choose one ability score. You gain the following benefits:",
-            "- Increase the chosen ability score by 1, to a maximum of 20.",
-            "- You gain proficiency in saving throws using the chosen ability."
-        ],
-        "prerequisites": []
-    },
-    {
-        "id": "ritual-caster",
-        "name": "Ritual Caster",
-        "desc": [
-            "Prerequisite: Intelligence or Wisdom 13 or higher.",
-            "You have learned a number of spells that you can cast as rituals. These spells are written in a ritual book, which you must have in hand while casting one of them.",
-            "- Choose one of the following classes: bard, cleric, druid, sorcerer, warlock, or wizard. You acquire a ritual book holding two 1st-level spells of your choice. You must choose your spells from that class\u2019s spell list, and the spells you choose must have the ritual tag.",
-            "- If you come across a spell in written form, you might be able to add it to your ritual book. The spell must be on the spell list for the class you chose, the spell\u2019s level can be no higher than half your level (rounded up), and it must have the ritual tag. The process of copying the spell takes 2 hours per level of the spell, and costs 50 gp per level."
-        ],
-        "prerequisites": [
-            {
-                "abilityScore": {
-                    "id": "int"
-                },
-                "minimumScore": 13
-            },
-            {
-                "abilityScore": {
-                    "id": "wis"
-                },
-                "minimumScore": 13
-            }
-        ]
-    },
-    {
-        "id": "savage-attacker",
-        "name": "Savage Attacker",
-        "desc": [
-            "Once per turn when you roll damage for a melee weapon attack, you can reroll the weapon\u2019s damage dice and use either total."
-        ],
-        "prerequisites": []
-    },
-    {
-        "id": "sentinel",
-        "name": "Sentinel",
-        "desc": [
-            "You have mastered techniques to take advantage of every drop in any enemy\u2019s guard, gaining the following benefits:",
-            "- When you hit a creature with an opportunity attack, the creature\u2019s speed becomes 0 for the rest of the turn.",
-            "- Creatures provoke opportunity attacks from you even if they take the Disengage action before leaving your reach.",
-            "- When a creature within 5 feet of you makes an attack against a target other than you (and that target doesn\u2019t have this feat), you can use your reaction to make a melee weapon attack against the attacking creature."
-        ],
-        "prerequisites": []
-    },
-    {
-        "id": "sharpshooter",
-        "name": "Sharpshooter",
-        "desc": [
-            "You have mastered ranged weapons and can make shots that others find impossible. You gain the following benefits:",
-            "- Attacking at long range doesn\u2019t impose disadvantage on your ranged weapon attack rolls.",
-            "- Your ranged weapon attacks ignore half cover and three-quarters cover.",
-            "- Before you make an attack with a ranged weapon that you are proficient with, you can choose to take a -5 penalty to the attack roll. If the attack hits, you add +10 to the attack\u2019s damage."
-        ],
-        "prerequisites": []
-    },
-    {
-        "id": "shield-master",
-        "name": "Shield Master",
-        "desc": [
-            "You use shields not just for protection but also for offense. You gain the following benefits while you are wielding a shield:",
-            "- If you take the Attack action on your turn, you can use a bonus action to try to shove a creature within 5 feet of you with your shield.",
-            "- If you aren\u2019t incapacitated, you can add your shield\u2019s AC bonus to any Dexterity saving throw you make against a spell or other harmful effect that targets only you.",
-            "- If you are subjected to an effect that allows you to make a Dexterity saving throw to take only half damage, you can use your reaction to take no damage if you succeed on the saving throw, interposing your shield between yourself and the source of the effect."
-        ],
-        "prerequisites": []
-    },
-    {
-        "id": "skilled",
-        "name": "Skilled",
-        "desc": [
-            "You gain proficiency in any combination of three skills or tools of your choice."
-        ],
-        "prerequisites": []
-    },
-    {
-        "id": "skulker",
-        "name": "Skulker",
-        "desc": [
-            "Prerequisite: Dexterity 13 or higher.",
-            "You are expert at slinking through shadows. You gain the following benefits:",
-            "- You can try to hide when you are lightly obscured from the creature from which you are hiding.",
-            "- When you are hidden from a creature and miss it with a ranged weapon attack, making the attack doesn\u2019t reveal your position.",
-            "- Dim light doesn\u2019t impose disadvantage on your Wisdom (Perception) checks relying on sight."
-        ],
-        "prerequisites": [
-            {
-                "abilityScore": {
-                    "id": "dex"
-                },
-                "minimumScore": 13
-            }
-        ]
-    },
-    {
-        "id": "spell-sniper",
-        "name": "Spell Sniper",
-        "desc": [
-            "Prerequisite: The ability to cast at least one spell.",
-            "You have learned techniques to enhance your attacks with certain kinds of spells, gaining the following benefits:",
-            "- When you cast a spell that requires you to make an attack roll, the spell\u2019s range is doubled.",
-            "- Your ranged spell attacks ignore half cover and three-quarters cover.",
-            "- You learn one cantrip that requires an attack roll. Choose the cantrip from the bard, cleric, druid, sorcerer, warlock, or wizard spell list. Your spellcasting ability for this cantrip depends on the spell list you chose."
-        ],
-        "prerequisites": []
-    },
-    {
-        "id": "tavern-brawler",
-        "name": "Tavern Brawler",
-        "desc": [
-            "Accustomed to rough-and-tumble fighting using whatever weapons happen to be at hand, you gain the following benefits:",
-            "- Increase your Strength or Constitution score by 1, to a maximum of 20.",
-            "- You are proficient with improvised weapons.",
-            "- Your unarmed strike uses a d4 for damage.",
-            "- When you hit a creature with an unarmed strike or an improvised weapon on your turn, you can use a bonus action to attempt to grapple the target."
-        ],
-        "prerequisites": []
-    },
-    {
-        "id": "tough",
-        "name": "Tough",
-        "desc": [
-            "Your hit point maximum increases by an amount equal to twice your level when you gain this feat. Whenever you gain a level thereafter, your hit point maximum increases by an additional 2 hit points."
-        ],
-        "prerequisites": []
-    },
-    {
-        "id": "war-caster",
-        "name": "War Caster",
-        "desc": [
-            "Prerequisite: The ability to cast at least one spell.",
-            "You have practiced casting spells in the midst of combat, learning techniques that grant you the following benefits:",
-            "- You have advantage on Constitution saving throws that you make to maintain your concentration on a spell when you take damage.",
-            "- You can perform the somatic components of spells even when you have weapons or a shield in one or both hands.",
-            "- When a hostile creature\u2019s movement provokes an opportunity attack from you, you can use your reaction to cast a spell at the creature, rather than making an opportunity attack. The spell must have a casting time of 1 action and must target only that creature."
-        ],
-        "prerequisites": []
-    },
-    {
-        "id": "weapon-master",
-        "name": "Weapon Master",
-        "desc": [
-            "You have practiced extensively with a variety of weapons, gaining the following benefits:",
-            "- Increase your Strength or Dexterity score by 1, to a maximum of 20.",
-            "- You gain proficiency with four weapons of your choice. Each one must be a simple or a martial weapon."
-        ],
-        "prerequisites": []
+        "minimumValue": 13,
+        "atLeastOne": true
+      }
+    ],
+    "abilityBonusChoice": {
+      "type": "ability-bonus",
+      "from": [
+        {
+          "str": 1
+        },
+        {
+          "dex": 1
+        }
+      ],
+      "choose": 1
     }
+  },
+  {
+    "id": "charger",
+    "name": "Charger",
+    "desc": [
+      "When you use your action to Dash, you can use a bonus action to make one melee weapon attack or to shove a creature.",
+      "- If you move at least 10 feet in a straight line immediately before taking this bonus action, you either gain a +5 bonus to the attack\u2019s damage roll (if you chose to make a melee attack and hit) or push the target up to 10 feet away from you (if you chose to shove and you succeed)."
+    ],
+    "prerequisites": []
+  },
+  {
+    "id": "crossbow-expert",
+    "name": "Crossbow Expert",
+    "desc": [
+      "Thanks to extensive practice with the crossbow, you gain the following benefits:",
+      "- You ignore the loading quality of crossbows with which you are proficient.",
+      "- Being within 5 feet of a hostile creature doesn\u2019t impose disadvantage on your ranged attack rolls.",
+      "- When you use the Attack action and attack with a one-handed weapon, you can use a bonus action to attack with a loaded hand crossbow you are holding."
+    ],
+    "prerequisites": []
+  },
+  {
+    "id": "defensive-duelist",
+    "name": "Defensive Duelist",
+    "desc": [
+      "Prerequisite: Dexterity 13 or higher.",
+      "When you are wielding a finesse weapon with which you are proficient and another creature hits you with a melee attack, you can use your reaction to add your proficiency bonus to your AC for that attack, potentially causing the attack to miss you."
+    ],
+    "prerequisites": [
+      {
+        "type": "ability-score",
+        "abilityScore": [
+          "dex"
+        ],
+        "minimumValue": 13,
+        "atLeastOne": false
+      }
+    ]
+  },
+  {
+    "id": "dual-wielder",
+    "name": "Dual Wielder",
+    "desc": [
+      "You master fighting with two weapons, gaining the following benefits:",
+      "- You gain a +1 bonus to AC while you are wielding a separate melee weapon in each hand.",
+      "- You can use two-weapon fighting even when the one-handed melee weapons you are wielding aren\u2019t light.",
+      "- You can draw or stow two one-handed weapons when you would normally be able to draw or stow only one."
+    ],
+    "prerequisites": []
+  },
+  {
+    "id": "dungeon-delver",
+    "name": "Dungeon Delver",
+    "desc": [
+      "Alert to the hidden traps and secret doors found in many dungeons, you gain the following benefits:",
+      "- You have advantage on Wisdom (Perception) and Intelligence (Investigation) checks made to detect the presence of secret doors.",
+      "- You have advantage on saving throws made to avoid or resist traps.",
+      "- You have resistance to the damage dealt by traps.",
+      "- You can search for traps while traveling at a normal pace, instead of only at a slow pace."
+    ],
+    "prerequisites": []
+  },
+  {
+    "id": "durable",
+    "name": "Durable",
+    "desc": [
+      "Hardy and resilient, you gain the following benefits:",
+      "- Increase your Constitution score by 1, to a maximum of 20.",
+      "- When you roll a Hit Die to regain hit points, the minimum number of hit points you regain from the roll equals twice your Constitution modifier (minimum of 2)."
+    ],
+    "prerequisites": [
+      {
+        "type": "ability-score",
+        "abilityScore": [
+          "con"
+        ],
+        "minimumValue": 13,
+        "atLeastOne": false
+      }
+    ],
+    "effects": [
+      {
+        "type": "modify-abilities",
+        "abilities": {
+          "con": 1
+        }
+      }
+    ]
+  },
+  {
+    "id": "elemental-adept",
+    "name": "Elemental Adept",
+    "desc": [
+      "Prerequisite: The ability to cast at least one spell.",
+      "When you gain this feat, choose one of the following damage types: acid, cold, fire, lightning, or thunder.",
+      "- Spells you cast ignore resistance to damage of the chosen type.",
+      "- When you roll damage for a spell you cast that deals damage of the chosen type, you can treat any 1 on a damage die as a 2.",
+      "You can select this feat multiple times. Each time you do so, you must choose a different damage type."
+    ],
+    "prerequisites": []
+  },
+  {
+    "id": "grappler",
+    "name": "Grappler",
+    "prerequisites": [
+      {
+        "abilityScore": {
+          "id": "str"
+        },
+        "minimumScore": 13
+      }
+    ],
+    "desc": [
+      "Prerequisite: Strength 13 or higher.",
+      "You\u2019ve developed the skills necessary to hold your own in close-quarters grappling. You gain the following benefits:",
+      "- You have advantage on attack rolls against a creature you are grappling.",
+      "- You can use your action to try to pin a creature grappled by you. To do so, make another grapple check. If you succeed, you and the creature are both restrained until the grapple ends."
+    ]
+  },
+  {
+    "id": "great-weapon-master",
+    "name": "Great Weapon Master",
+    "desc": [
+      "You\u2019ve learned to put the weight of a weapon to your advantage, letting its momentum empower your strikes. You gain the following benefits:",
+      "- On your turn, when you score a critical hit with a melee weapon or reduce a creature to 0 hit points with one, you can make one melee weapon attack as a bonus action.",
+      "- Before you make a melee attack with a heavy weapon that you are proficient with, you can choose to take a -5 penalty to the attack roll. If the attack hits, you add +10 to the attack\u2019s damage."
+    ],
+    "prerequisites": []
+  },
+  {
+    "id": "healer",
+    "name": "Healer",
+    "desc": [
+      "You are an able physician, allowing you to mend wounds quickly and get your allies back in the fight. You gain the following benefits:",
+      "- When you use a healer\u2019s kit to stabilize a dying creature, that creature also regains 1 hit point.",
+      "- As an action, you can spend one use of a healer\u2019s kit to tend to a creature and restore 1d6 + 4 hit points to it, plus additional hit points equal to the creature\u2019s maximum number of Hit Dice. The creature can\u2019t regain hit points from this feat again until it finishes a short or long rest."
+    ],
+    "prerequisites": []
+  },
+  {
+    "id": "heavily-armored",
+    "name": "Heavily Armored",
+    "desc": [
+      "Prerequisite: Proficiency with medium armor.",
+      "You have trained to master the use of heavy armor, gaining the following benefits:",
+      "- Increase your Strength score by 1, to a maximum of 20.",
+      "- You gain proficiency with heavy armor."
+    ],
+    "prerequisites": [
+      {
+        "type": "proficiency",
+        "id": "medium-armor"
+      }
+    ],
+    "effects": [
+      {
+        "type": "modify-abilities",
+        "abilities": {
+          "str": 1
+        }
+      },
+      {
+        "type": "add-proficiencies",
+        "proficiencies": [
+          "heavy-armor"
+        ]
+      }
+    ]
+  },
+  {
+    "id": "heavy-armor-master",
+    "name": "Heavy Armor Master",
+    "desc": [
+      "Prerequisite: Proficiency with heavy armor.",
+      "You can use your armor to deflect strikes that would kill others. You gain the following benefits:",
+      "- Increase your Strength score by 1, to a maximum of 20.",
+      "- While you are wearing heavy armor, bludgeoning, piercing, and slashing damage that you take from nonmagical weapons is reduced by 3."
+    ],
+    "prerequisites": [
+      {
+        "type": "proficiency",
+        "id": "heavy-armor"
+      }
+    ],
+    "effects": [
+      {
+        "type": "modify-abilities",
+        "abilities": {
+          "str": 1
+        }
+      }
+    ]
+  },
+  {
+    "id": "inspiring-leader",
+    "name": "Inspiring Leader",
+    "desc": [
+      "Prerequisite: Charisma 13 or higher.",
+      "You can spend 10 minutes inspiring your companions, shoring up their resolve to fight. When you do so, choose up to six friendly creatures (which can include yourself) within 30 feet of you who can see or hear you and who can understand you. Each creature can gain temporary hit points equal to your level + your Charisma modifier. A creature can\u2019t gain temporary hit points from this feat again until it has finished a short or long rest."
+    ],
+    "prerequisites": [
+      {
+        "type": "ability-score",
+        "abilityScore": [
+          "cha"
+        ],
+        "minimumValue": 13,
+        "atLeastOne": false
+      }
+    ]
+  },
+  {
+    "id": "keen-mind",
+    "name": "Keen Mind",
+    "desc": [
+      "You have a mind that can track time, direction, and detail with uncanny precision. You gain the following benefits:",
+      "- Increase your Intelligence score by 1, to a maximum of 20.",
+      "- You always know which way is north.",
+      "- You always know the number of hours left before the next sunrise or sunset.",
+      "- You can accurately recall anything you have seen or heard within the past month."
+    ],
+    "prerequisites": [
+      {
+        "type": "ability-score",
+        "abilityScore": [
+          "int"
+        ],
+        "minimumValue": 13,
+        "atLeastOne": false
+      }
+    ],
+    "effects": [
+      {
+        "type": "modify-abilities",
+        "abilities": {
+          "int": 1
+        }
+      }
+    ]
+  },
+  {
+    "id": "lightly-armored",
+    "name": "Lightly Armored",
+    "desc": [
+      "You have trained to master the use of light armor, gaining the following benefits:",
+      "- Increase your Strength or Dexterity score by 1, to a maximum of 20.",
+      "- You gain proficiency with light armor."
+    ],
+    "prerequisites": [],
+    "effects": [
+      {
+        "type": "add-proficiencies",
+        "proficiencies": [
+          "light-armor"
+        ]
+      }
+    ],
+    "abilityBonusChoice": {
+      "type": "ability-bonus",
+      "from": [
+        {
+          "str": 1
+        },
+        {
+          "dex": 1
+        }
+      ],
+      "choose": 1
+    }
+  },
+  {
+    "id": "linguist",
+    "name": "Linguist",
+    "desc": [
+      "You have studied languages and codes, gaining the following benefits:",
+      "- Increase your Intelligence score by 1, to a maximum of 20.",
+      "- You learn three languages of your choice.",
+      "- You can ably create written ciphers. Others can\u2019t decipher a code you create unless you teach them, they succeed on an Intelligence check (DC equal to your Intelligence score + your proficiency bonus), or they use magic to decipher it."
+    ],
+    "prerequisites": [
+      {
+        "type": "ability-score",
+        "abilityScore": [
+          "int"
+        ],
+        "minimumValue": 13,
+        "atLeastOne": false
+      }
+    ],
+    "effects": [
+      {
+        "type": "modify-abilities",
+        "abilities": {
+          "int": 1
+        }
+      }
+    ],
+    "languageChoice": {
+      "type": "resource-list",
+      "from": "languages",
+      "choose": 3
+    }
+  },
+  {
+    "id": "lucky",
+    "name": "Lucky",
+    "desc": [
+      "You have inexplicable luck that seems to kick in at just the right moment.",
+      "- You have 3 luck points. Whenever you make an attack roll, an ability check, or a saving throw, you can spend one luck point to roll an additional d20. You can choose to spend one of your luck points after you roll the die, but before the outcome is determined. You choose which of the d20s is used for the attack roll, ability check, or saving throw.",
+      "- You can also spend one luck point when an attack roll is made against you. Roll a d20, and then choose whether the attack uses the attacker\u2019s roll or yours.",
+      "- If more than one creature spends a luck point to influence the outcome of a roll, the points cancel each other out; no additional dice are rolled.",
+      "You regain your expended luck points when you finish a long rest."
+    ],
+    "prerequisites": []
+  },
+  {
+    "id": "mage-slayer",
+    "name": "Mage Slayer",
+    "desc": [
+      "You have practiced techniques useful in melee combat against spellcasters, gaining the following benefits:",
+      "- When a creature within 5 feet of you casts a spell, you can use your reaction to make a melee weapon attack against that creature.",
+      "- When you damage a creature that is concentrating on a spell, that creature has disadvantage on the saving throw it makes to maintain its concentration.",
+      "- You have advantage on saving throws against spells cast by creatures within 5 feet of you."
+    ],
+    "prerequisites": []
+  },
+  {
+    "id": "magic-initiate",
+    "name": "Magic Initiate",
+    "desc": [
+      "Choose a class: bard, cleric, druid, sorcerer, warlock, or wizard. You learn two cantrips of your choice from that class\u2019s spell list.",
+      "- In addition, choose one 1st-level spell to learn from that same list. Using this feat, you can cast the spell at its lowest level. Once you cast it, you must finish a long rest before you can cast it in this way again.",
+      "- Your spellcasting ability for these spells depends on the class you chose: Charisma for bard, sorcerer, or warlock; Wisdom for cleric or druid; or Intelligence for wizard."
+    ],
+    "prerequisites": []
+  },
+  {
+    "id": "martial-adept",
+    "name": "Martial Adept",
+    "desc": [
+      "You have martial training that allows you to perform special combat maneuvers. You gain the following benefits:",
+      "- You learn two maneuvers of your choice from among those available to the Battle Master archetype in the fighter class. If a maneuver you use requires your target to make a saving throw to resist the maneuver\u2019s effects, the saving throw DC equals 8 + your proficiency bonus + your Strength or Dexterity modifier (your choice).",
+      "- If you already have a superiority dice, you gain one more; otherwise, you have one superiority die, which is a d6. This die is used to fuel your maneuvers. A superiority die is expended when you use it. You regain your expended superiority dice when you finish a short or long rest."
+    ],
+    "prerequisites": []
+  },
+  {
+    "id": "medium-armor-master",
+    "name": "Medium Armor Master",
+    "desc": [
+      "Prerequisite: Proficiency with medium armor.",
+      "You have practiced moving in medium armor to gain the following benefits:",
+      "- Wearing medium armor doesn\u2019t impose disadvantage on your Dexterity (Stealth) checks.",
+      "- When you wear medium armor, you can add 3, rather than 2, to your AC if you have a Dexterity of 16 or higher."
+    ],
+    "prerequisites": [
+      {
+        "type": "proficiency",
+        "id": "medium-armor"
+      }
+    ]
+  },
+  {
+    "id": "mobile",
+    "name": "Mobile",
+    "desc": [
+      "You are exceptionally speedy and agile. You gain the following benefits:",
+      "- Your speed increases by 10 feet.",
+      "- When you use the Dash action, difficult terrain doesn\u2019t cost you extra movement on that turn.",
+      "- When you make a melee attack against a creature, you don\u2019t provoke opportunity attacks from that creature for the rest of the turn, whether you hit or not."
+    ],
+    "prerequisites": []
+  },
+  {
+    "id": "moderately-armored",
+    "name": "Moderately Armored",
+    "desc": [
+      "Prerequisite: Proficiency with light armor.",
+      "You have trained to master the use of medium armor and shields, gaining the following benefits:",
+      "- Increase your Strength or Dexterity score by 1, to a maximum of 20.",
+      "- You gain proficiency with medium armor and shields."
+    ],
+    "prerequisites": [
+      {
+        "type": "proficiency",
+        "id": "light-armor"
+      }
+    ],
+    "effects": [
+      {
+        "type": "add-proficiencies",
+        "proficiencies": [
+          "medium-armor",
+          "shields"
+        ]
+      }
+    ],
+    "abilityBonusChoice": {
+      "type": "ability-bonus",
+      "from": [
+        {
+          "str": 1
+        },
+        {
+          "dex": 1
+        }
+      ],
+      "choose": 1
+    }
+  },
+  {
+    "id": "mounted-combatant",
+    "name": "Mounted Combatant",
+    "desc": [
+      "You are a dangerous foe to face while mounted. While you are mounted and aren\u2019t incapacitated, you gain the following benefits:",
+      "- You have advantage on melee attack rolls against any unmounted creature that is smaller than your mount.",
+      "- You can force an attack targeted at your mount to target you instead.",
+      "- If your mount is subjected to an effect that allows it to make a Dexterity saving throw to take only half damage, it instead takes no damage if it succeeds on the saving throw, and only half damage if it fails."
+    ],
+    "prerequisites": []
+  },
+  {
+    "id": "observant",
+    "name": "Observant",
+    "desc": [
+      "Quick to notice details of your environment, you gain the following benefits:",
+      "- Increase your Intelligence or Wisdom score by 1, to a maximum of 20.",
+      "- If you can see a creature\u2019s mouth while it is speaking a language you understand, you can interpret what it\u2019s saying by reading its lips.",
+      "- You have a +5 bonus to your passive Wisdom (Perception) and passive Intelligence (Investigation) scores."
+    ],
+    "prerequisites": [
+      {
+        "type": "ability-score",
+        "abilityScore": [
+          "int",
+          "wis"
+        ],
+        "minimumValue": 13,
+        "atLeastOne": true
+      }
+    ],
+    "abilityBonusChoice": {
+      "type": "ability-bonus",
+      "from": [
+        {
+          "int": 1
+        },
+        {
+          "wis": 1
+        }
+      ],
+      "choose": 1
+    }
+  },
+  {
+    "id": "polearm-master",
+    "name": "Polearm Master",
+    "desc": [
+      "You can keep your enemies at bay with reach weapons. You gain the following benefits:",
+      "- When you take the Attack action and attack with only a glaive, halberd, quarterstaff, or spear, you can use a bonus action to make a melee attack with the opposite end of the weapon. This attack uses the same ability modifier as the primary attack. The weapon\u2019s damage die for this attack is a d4, and the attack deals bludgeoning damage.",
+      "- While you are wielding a glaive, halberd, pike, quarterstaff, or spear, other creatures provoke an opportunity attack from you when they enter your reach."
+    ],
+    "prerequisites": []
+  },
+  {
+    "id": "resilient",
+    "name": "Resilient",
+    "desc": [
+      "Choose one ability score. You gain the following benefits:",
+      "- Increase the chosen ability score by 1, to a maximum of 20.",
+      "- You gain proficiency in saving throws using the chosen ability."
+    ],
+    "prerequisites": [],
+    "abilityBonusChoice": {
+      "type": "ability-bonus",
+      "from": [
+        {
+          "str": 1
+        },
+        {
+          "dex": 1
+        },
+        {
+          "con": 1
+        },
+        {
+          "int": 1
+        },
+        {
+          "wis": 1
+        },
+        {
+          "cha": 1
+        }
+      ],
+      "choose": 1
+    },
+    "proficiencyChoice": {
+      "type": "options-array",
+      "from": [
+        "saving-throw-str",
+        "saving-throw-dex",
+        "saving-throw-con",
+        "saving-throw-int",
+        "saving-throw-wis",
+        "saving-throw-cha"
+      ],
+      "choose": 1
+    }
+  },
+  {
+    "id": "ritual-caster",
+    "name": "Ritual Caster",
+    "desc": [
+      "Prerequisite: Intelligence or Wisdom 13 or higher.",
+      "You have learned a number of spells that you can cast as rituals. These spells are written in a ritual book, which you must have in hand while casting one of them.",
+      "- Choose one of the following classes: bard, cleric, druid, sorcerer, warlock, or wizard. You acquire a ritual book holding two 1st-level spells of your choice. You must choose your spells from that class\u2019s spell list, and the spells you choose must have the ritual tag.",
+      "- If you come across a spell in written form, you might be able to add it to your ritual book. The spell must be on the spell list for the class you chose, the spell\u2019s level can be no higher than half your level (rounded up), and it must have the ritual tag. The process of copying the spell takes 2 hours per level of the spell, and costs 50 gp per level."
+    ],
+    "prerequisites": [
+      {
+        "type": "ability-score",
+        "abilityScore": [
+          "int",
+          "wis"
+        ],
+        "minimumValue": 13,
+        "atLeastOne": true
+      }
+    ]
+  },
+  {
+    "id": "savage-attacker",
+    "name": "Savage Attacker",
+    "desc": [
+      "Once per turn when you roll damage for a melee weapon attack, you can reroll the weapon\u2019s damage dice and use either total."
+    ],
+    "prerequisites": []
+  },
+  {
+    "id": "sentinel",
+    "name": "Sentinel",
+    "desc": [
+      "You have mastered techniques to take advantage of every drop in any enemy\u2019s guard, gaining the following benefits:",
+      "- When you hit a creature with an opportunity attack, the creature\u2019s speed becomes 0 for the rest of the turn.",
+      "- Creatures provoke opportunity attacks from you even if they take the Disengage action before leaving your reach.",
+      "- When a creature within 5 feet of you makes an attack against a target other than you (and that target doesn\u2019t have this feat), you can use your reaction to make a melee weapon attack against the attacking creature."
+    ],
+    "prerequisites": []
+  },
+  {
+    "id": "sharpshooter",
+    "name": "Sharpshooter",
+    "desc": [
+      "You have mastered ranged weapons and can make shots that others find impossible. You gain the following benefits:",
+      "- Attacking at long range doesn\u2019t impose disadvantage on your ranged weapon attack rolls.",
+      "- Your ranged weapon attacks ignore half cover and three-quarters cover.",
+      "- Before you make an attack with a ranged weapon that you are proficient with, you can choose to take a -5 penalty to the attack roll. If the attack hits, you add +10 to the attack\u2019s damage."
+    ],
+    "prerequisites": []
+  },
+  {
+    "id": "shield-master",
+    "name": "Shield Master",
+    "desc": [
+      "You use shields not just for protection but also for offense. You gain the following benefits while you are wielding a shield:",
+      "- If you take the Attack action on your turn, you can use a bonus action to try to shove a creature within 5 feet of you with your shield.",
+      "- If you aren\u2019t incapacitated, you can add your shield\u2019s AC bonus to any Dexterity saving throw you make against a spell or other harmful effect that targets only you.",
+      "- If you are subjected to an effect that allows you to make a Dexterity saving throw to take only half damage, you can use your reaction to take no damage if you succeed on the saving throw, interposing your shield between yourself and the source of the effect."
+    ],
+    "prerequisites": []
+  },
+  {
+    "id": "skilled",
+    "name": "Skilled",
+    "desc": [
+      "You gain proficiency in any combination of three skills or tools of your choice."
+    ],
+    "prerequisites": [],
+    "proficiencyChoice": {
+      "type": "options-array",
+      "from": [
+        "alchemists-supplies",
+        "brewers-supplies",
+        "calligraphers-supplies",
+        "carpenters-tools",
+        "cartographers-tools",
+        "cobblers-tools",
+        "cooks-utensils",
+        "glassblowers-tools",
+        "jewelers-tools",
+        "leatherworkers-tools",
+        "masons-tools",
+        "painters-supplies",
+        "potters-tools",
+        "smiths-tools",
+        "tinkers-tools",
+        "weavers-tools",
+        "woodcarvers-tools",
+        "disguise-kit",
+        "forgery-kit",
+        "dice-set",
+        "playing-card-set",
+        "bagpipes",
+        "drum",
+        "dulcimer",
+        "flute",
+        "lute",
+        "lyre",
+        "horn",
+        "pan-flute",
+        "shawm",
+        "viol",
+        "herbalism-kit",
+        "navigators-tools",
+        "poisoners-kit",
+        "thieves-tools",
+        "land-vehicles",
+        "water-vehicles",
+        "skill-acrobatics",
+        "skill-animal-handling",
+        "skill-arcana",
+        "skill-athletics",
+        "skill-deception",
+        "skill-history",
+        "skill-insight",
+        "skill-intimidation",
+        "skill-investigation",
+        "skill-medicine",
+        "skill-nature",
+        "skill-perception",
+        "skill-performance",
+        "skill-persuasion",
+        "skill-religion",
+        "skill-sleight-of-hand",
+        "skill-stealth",
+        "skill-survival"
+      ],
+      "choose": 3
+    }
+  },
+  {
+    "id": "skulker",
+    "name": "Skulker",
+    "desc": [
+      "Prerequisite: Dexterity 13 or higher.",
+      "You are expert at slinking through shadows. You gain the following benefits:",
+      "- You can try to hide when you are lightly obscured from the creature from which you are hiding.",
+      "- When you are hidden from a creature and miss it with a ranged weapon attack, making the attack doesn\u2019t reveal your position.",
+      "- Dim light doesn\u2019t impose disadvantage on your Wisdom (Perception) checks relying on sight."
+    ],
+    "prerequisites": [
+      {
+        "type": "proficiency",
+        "id": "skill-stealth"
+      }
+    ]
+  },
+  {
+    "id": "spell-sniper",
+    "name": "Spell Sniper",
+    "desc": [
+      "Prerequisite: The ability to cast at least one spell.",
+      "You have learned techniques to enhance your attacks with certain kinds of spells, gaining the following benefits:",
+      "- When you cast a spell that requires you to make an attack roll, the spell\u2019s range is doubled.",
+      "- Your ranged spell attacks ignore half cover and three-quarters cover.",
+      "- You learn one cantrip that requires an attack roll. Choose the cantrip from the bard, cleric, druid, sorcerer, warlock, or wizard spell list. Your spellcasting ability for this cantrip depends on the spell list you chose."
+    ],
+    "prerequisites": []
+  },
+  {
+    "id": "tavern-brawler",
+    "name": "Tavern Brawler",
+    "desc": [
+      "Accustomed to rough-and-tumble fighting using whatever weapons happen to be at hand, you gain the following benefits:",
+      "- Increase your Strength or Constitution score by 1, to a maximum of 20.",
+      "- You are proficient with improvised weapons.",
+      "- Your unarmed strike uses a d4 for damage.",
+      "- When you hit a creature with an unarmed strike or an improvised weapon on your turn, you can use a bonus action to attempt to grapple the target."
+    ],
+    "prerequisites": [],
+    "abilityBonusChoice": {
+      "type": "ability-bonus",
+      "from": [
+        {
+          "str": 1
+        },
+        {
+          "con": 1
+        }
+      ],
+      "choose": 1
+    }
+  },
+  {
+    "id": "tough",
+    "name": "Tough",
+    "desc": [
+      "Your hit point maximum increases by an amount equal to twice your level when you gain this feat. Whenever you gain a level thereafter, your hit point maximum increases by an additional 2 hit points."
+    ],
+    "prerequisites": [],
+    "effects": [
+      {
+        "type": "add-hp",
+        "value": 2,
+        "perLevel": true
+      }
+    ]
+  },
+  {
+    "id": "war-caster",
+    "name": "War Caster",
+    "desc": [
+      "Prerequisite: The ability to cast at least one spell.",
+      "You have practiced casting spells in the midst of combat, learning techniques that grant you the following benefits:",
+      "- You have advantage on Constitution saving throws that you make to maintain your concentration on a spell when you take damage.",
+      "- You can perform the somatic components of spells even when you have weapons or a shield in one or both hands.",
+      "- When a hostile creature\u2019s movement provokes an opportunity attack from you, you can use your reaction to cast a spell at the creature, rather than making an opportunity attack. The spell must have a casting time of 1 action and must target only that creature."
+    ],
+    "prerequisites": []
+  },
+  {
+    "id": "weapon-master",
+    "name": "Weapon Master",
+    "desc": [
+      "You have practiced extensively with a variety of weapons, gaining the following benefits:",
+      "- Increase your Strength or Dexterity score by 1, to a maximum of 20.",
+      "- You gain proficiency with four weapons of your choice. Each one must be a simple or a martial weapon."
+    ],
+    "prerequisites": [],
+    "abilityBonusChoice": {
+      "type": "ability-bonus",
+      "from": [
+        {
+          "str": 1
+        },
+        {
+          "dex": 1
+        }
+      ],
+      "choose": 1
+    },
+    "proficiencyChoice": {
+      "type": "options-array",
+      "from": [
+        "simple-weapons",
+        "martial-weapons",
+        "clubs",
+        "daggers",
+        "greatclubs",
+        "handaxes",
+        "javelins",
+        "light-hammers",
+        "maces",
+        "quarterstaffs",
+        "sickles",
+        "spears",
+        "crossbows-light",
+        "darts",
+        "shortbows",
+        "slings",
+        "battleaxes",
+        "flails",
+        "glaives",
+        "greataxes",
+        "greatswords",
+        "halberds",
+        "lances",
+        "longswords",
+        "mauls",
+        "morningstars",
+        "pikes",
+        "rapiers",
+        "scimitars",
+        "shortswords",
+        "tridents",
+        "war-picks",
+        "warhammers",
+        "whips",
+        "blowguns",
+        "hand-crossbows",
+        "crossbows-heavy",
+        "longbows",
+        "nets"
+      ],
+      "choose": 4
+    }
+  }
 ]

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/data/model/Feat.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/data/model/Feat.kt
@@ -7,5 +7,10 @@ data class Feat(
     val id: String,
     val name: String,
     val desc: List<String>,
-    val prerequisites: List<FeatPrerequisite>
+    val prerequisites: List<Prerequisite> = emptyList(),
+    val effects: List<Effect>? = null,
+    val abilityBonusChoice: Choice? = null,
+    val spellChoice: Choice? = null,
+    val languageChoice: Choice? = null,
+    val proficiencyChoice: Choice? = null,
 )

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/data/model/FeatPrerequisite.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/data/model/FeatPrerequisite.kt
@@ -1,9 +1,0 @@
-package com.github.arhor.spellbindr.data.model
-
-import kotlinx.serialization.Serializable
-
-@Serializable
-data class FeatPrerequisite(
-    val abilityScore: EntityRef,
-    val minimumScore: Int
-)


### PR DESCRIPTION
## Summary
- add structured prerequisites, effects, and choices to feats assets
- extend the feat model to surface effect and choice metadata
- remove the obsolete FeatPrerequisite class

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69396f1eaecc833091cdbdc580b2165a)