### PR TITLE
Configure AndroidJUnit5 instrumentation runner builder

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,6 +21,7 @@ android {
         versionCode = 1
         versionName = "1.0"
         testInstrumentationRunner = "com.github.arhor.spellbindr.HiltApplicationTestRunner"
+        testInstrumentationRunnerArgument("runnerBuilder", "de.mannodermaus.junit5.AndroidJUnit5Builder")
     }
 
     buildTypes {


### PR DESCRIPTION
## Summary
- add the AndroidJUnit5 runnerBuilder argument to the instrumentation runner configuration
- verified there are no other conflicting instrumentation runner arguments in manifests or Gradle files

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a75db2d0083308229b6a1d4e85e77)