### PR TITLE
test: migrate junit4 tests to jupiter

### DIFF
--- a/app/src/androidTest/kotlin/com/github/arhor/spellbindr/data/local/assets/StaticAssetDataStoreBaseTest.kt
+++ b/app/src/androidTest/kotlin/com/github/arhor/spellbindr/data/local/assets/StaticAssetDataStoreBaseTest.kt
@@ -3,21 +3,22 @@ package com.github.arhor.spellbindr.data.local.assets
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import kotlinx.coroutines.test.runTest
-import org.junit.Assert.fail
-import org.junit.Before
-import org.junit.Rule
-import org.junit.Test
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Assertions.fail
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 import javax.inject.Inject
 
 @HiltAndroidTest
 class StaticAssetDataStoreBaseTest {
-    @get:Rule
-    var hiltRule = HiltAndroidRule(this)
+    @JvmField
+    @RegisterExtension
+    val hiltRule = HiltAndroidRule(this)
 
     @Inject
     lateinit var stores: Set<@JvmSuppressWildcards InitializableStaticAssetDataStore>
 
-    @Before
+    @BeforeEach
     fun init() {
         hiltRule.inject()
     }

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/data/model/CharacterSheetWeaponSerializationTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/data/model/CharacterSheetWeaponSerializationTest.kt
@@ -3,7 +3,7 @@ package com.github.arhor.spellbindr.data.model
 import com.github.arhor.spellbindr.data.model.predefined.Ability
 import com.github.arhor.spellbindr.data.model.predefined.DamageType
 import com.google.common.truth.Truth.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class CharacterSheetWeaponSerializationTest {
 

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/data/repository/ThemeRepositoryTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/data/repository/ThemeRepositoryTest.kt
@@ -10,7 +10,7 @@ import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
-import org.junit.Test
+import org.junit.jupiter.api.Test
 import java.io.File
 import kotlin.io.path.createTempFile
 

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/ui/SpellbindrAppViewModelTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/ui/SpellbindrAppViewModelTest.kt
@@ -11,17 +11,18 @@ import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
-import org.junit.Rule
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.RegisterExtension
+import org.robolectric.RobolectricExtension
 import kotlin.io.path.createTempFile
 
-@RunWith(RobolectricTestRunner::class)
 @OptIn(ExperimentalCoroutinesApi::class)
+@ExtendWith(RobolectricExtension::class)
 class SpellbindrAppViewModelTest {
 
-    @get:Rule
+    @JvmField
+    @RegisterExtension
     val mainDispatcherRule = MainDispatcherRule()
 
     @Test

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/characters/CharacterSheetDeathSavesLogicTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/characters/CharacterSheetDeathSavesLogicTest.kt
@@ -4,7 +4,7 @@ import com.github.arhor.spellbindr.data.model.CharacterSheet
 import com.github.arhor.spellbindr.data.model.DeathSaveState
 import com.github.arhor.spellbindr.ui.feature.characters.sheet.clearDeathSavesIfConscious
 import com.google.common.truth.Truth.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class CharacterSheetDeathSavesLogicTest {
 

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/characters/sheet/WeaponsTabMappingTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/characters/sheet/WeaponsTabMappingTest.kt
@@ -6,7 +6,7 @@ import com.github.arhor.spellbindr.data.model.Weapon
 import com.github.arhor.spellbindr.data.model.predefined.Ability
 import com.github.arhor.spellbindr.data.model.predefined.DamageType
 import com.google.common.truth.Truth.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class WeaponsTabMappingTest {
 

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/settings/SettingsViewModelTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/settings/SettingsViewModelTest.kt
@@ -9,15 +9,16 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
-import org.junit.Rule
-import org.junit.Test
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 import java.io.File
 import kotlin.io.path.createTempFile
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class SettingsViewModelTest {
 
-    @get:Rule
+    @JvmField
+    @RegisterExtension
     val mainDispatcherRule = MainDispatcherRule()
 
     @Test

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/utils/AbilityScoreUtilsTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/utils/AbilityScoreUtilsTest.kt
@@ -2,7 +2,7 @@ package com.github.arhor.spellbindr.utils
 
 import com.github.arhor.spellbindr.data.model.predefined.Ability
 import com.google.common.truth.Truth.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class AbilityScoreUtilsTest {
 

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/utils/CaseInsensitiveEnumSerializerTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/utils/CaseInsensitiveEnumSerializerTest.kt
@@ -2,8 +2,8 @@ package com.github.arhor.spellbindr.utils
 
 import com.google.common.truth.Truth.assertThat
 import kotlinx.serialization.json.Json
-import org.junit.Assert.assertThrows
-import org.junit.Test
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 
 class CaseInsensitiveEnumSerializerTest {
 

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/utils/EllipseShapeTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/utils/EllipseShapeTest.kt
@@ -5,11 +5,11 @@ import androidx.compose.ui.graphics.Outline
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.LayoutDirection
 import com.google.common.truth.Truth.assertThat
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.robolectric.RobolectricExtension
 
-@RunWith(RobolectricTestRunner::class)
+@ExtendWith(RobolectricExtension::class)
 class EllipseShapeTest {
 
     @Test

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/utils/MapExtTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/utils/MapExtTest.kt
@@ -1,7 +1,7 @@
 package com.github.arhor.spellbindr.utils
 
 import com.google.common.truth.Truth.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class MapExtTest {
 

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/utils/ReferenceSerializerTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/utils/ReferenceSerializerTest.kt
@@ -3,7 +3,7 @@ package com.github.arhor.spellbindr.utils
 import com.github.arhor.spellbindr.data.model.next.Reference
 import com.google.common.truth.Truth.assertThat
 import kotlinx.serialization.json.Json
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class ReferenceSerializerTest {
 

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/utils/StringExtTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/utils/StringExtTest.kt
@@ -1,7 +1,7 @@
 package com.github.arhor.spellbindr.utils
 
 import com.google.common.truth.Truth.assertThat
-import org.junit.Test
+import org.junit.jupiter.api.Test
 
 class StringExtTest {
 


### PR DESCRIPTION
## Summary
- replace JUnit4 runners/rules with JUnit Jupiter extensions across unit and instrumented tests
- update imports to use JUnit Jupiter annotations and assertions

## Testing
- ./gradlew testDebugUnitTest --no-build-cache

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a78c9514c833088a7841ea8e62c9d)