### PR TITLE
Update instrumentation testing guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,19 +55,21 @@ guidelines to stay aligned with the maintainers’ expectations.
     - `./gradlew installDebug` – deploy to the connected emulator/device.
     - `./gradlew lint` – Android lint (resolve/wjustify every warning).
     - `./gradlew testDebugUnitTest` – JVM tests.
-    - `./gradlew connectedAndroidTest` – Instrumented UI tests (requires an API 33+ emulator with animations disabled
-      for stability).
+    - `./gradlew connectedAndroidTest` – Instrumented UI tests on JUnit 5 (android-junit5 runner builder). Requires an
+      API 26+ emulator/device; an API 33+ emulator with animations disabled remains preferred for stability.
 4. Android Studio run configurations should map to the same Gradle tasks; enable “Use Gradle JDK” (17) and “Optimize
    Gradle for smaller projects” for faster sync.
 5. No external API keys are required.
 
 ## Testing
 
-- **Unit tests (`app/src/test`)**: Use JUnit4 + `kotlinx-coroutines-test`’s `runTest`. Favor pure Kotlin tests for
-  repositories, mappers, and utility logic.
-- **Instrumented / Compose UI tests (`app/src/androidTest`)**: Run via `connectedAndroidTest`. Compose UI uses
-  `androidx.compose.ui.test.junit4`. Espresso is available for hybrid flows. Hilt injection is enabled through
-  `HiltAndroidRule` and `HiltApplicationTestRunner`.
+- **Unit tests (`app/src/test`)**: Use JUnit Jupiter with `useJUnitPlatform()` and `kotlinx-coroutines-test`’s
+  `runTest`. Favor pure Kotlin tests for repositories, mappers, and utility logic.
+- **Instrumented / Compose UI tests (`app/src/androidTest`)**: Run via `connectedAndroidTest` on the JUnit Platform
+  through the Android JUnit5 runner builder. Compose UI still relies on `androidx.compose.ui.test.junit4` artifacts for
+  rules, but execution happens under JUnit 5. Use JUnit Platform tag filters (e.g., include/exclude tags) instead of
+  legacy JUnit4 annotations when wiring custom Gradle invocations. Espresso is available for hybrid flows. Hilt
+  injection is enabled through `HiltAndroidRule` and `HiltApplicationTestRunner`.
 - **Fakes & dispatchers**: Mock external dependencies with fake repositories or in-memory DAOs, and rely on coroutine
   test dispatchers/`runTest` to control timing deterministically.
 - **Test data**: Prefer real SRD assets when possible; otherwise, use fixture builders under `data/model` or `utils`.

--- a/README.md
+++ b/README.md
@@ -75,8 +75,7 @@ Verification commands for agents after setup:
 ## 🧪 Testing strategy and JUnit support
 
 -   **JVM unit tests** use JUnit Jupiter via Gradle's `useJUnitPlatform()` configuration and the `testImplementation`/`testRuntimeOnly` Jupiter dependencies declared in `app/build.gradle.kts`.
--   **Instrumentation and Compose UI tests** currently remain on the JUnit4 stack because Android instrumentation runners still expect JUnit4-based entry points. The project uses `androidx.test.ext:junit` and `androidx.compose.ui:ui-test-junit4` under `androidTestImplementation`, along with the existing `HiltApplicationTestRunner`.
--   **Future JUnit5 instrumentation plan:** Once Android tooling ships stable support for Jupiter-based instrumentation (e.g., an official JUnit5 runner and compatible Compose testing artifacts), migrate by swapping the JUnit4 androidTest dependencies for their Jupiter equivalents, updating the custom test runner, and validating compatibility across Compose and Hilt test rules. Until then, keep instrumentation tests on the current JUnit4 stack while JVM tests continue on JUnit5.
+-   **Instrumentation and Compose UI tests** now run on JUnit 5 through the Android JUnit5 runner builder configured in `defaultConfig`. Execute them with `./gradlew connectedAndroidTest` on an emulator or device running API level **26+** (android-junit5 minimum); an API 33+ emulator with animations disabled remains recommended for stability. Compose testing utilities continue to come from `androidx.compose.ui:ui-test-junit4`, but execution is handled by the JUnit Platform.
 
 ## 📜 Data Source
 


### PR DESCRIPTION
## Summary
- clarify that connectedAndroidTest now runs JUnit 5 instrumentation and document the minimum API level requirement
- align contributor guidance with JUnit Jupiter usage and JUnit Platform tagging for instrumentation filters

## Testing
- not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a7f621f0083309447e52ad4b8398d)