### PR TITLE
Remove unsupported android-junit5 runner runtime dependency

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -92,8 +92,6 @@ dependencies {
     androidTestImplementation(libs.truth)
     androidTestImplementation(libs.mockk.android)
     androidTestImplementation(libs.hilt.android.testing)
-    androidTestRuntimeOnly(libs.mannodermaus.android.test.runner)
-
     debugImplementation(libs.androidx.ui.tooling)
     debugImplementation(libs.androidx.ui.test.manifest)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -51,7 +51,6 @@ junit-jupiter-api = { group = "org.junit.jupiter", name = "junit-jupiter-api", v
 junit-jupiter-engine = { group = "org.junit.jupiter", name = "junit-jupiter-engine", version.ref = "junit-jupiter" }
 junit-jupiter-params = { group = "org.junit.jupiter", name = "junit-jupiter-params", version.ref = "junit-jupiter" }
 junit-platform-launcher = { group = "org.junit.platform", name = "junit-platform-launcher", version.ref = "junit-platform" }
-mannodermaus-android-test-runner = { module = "de.mannodermaus.junit5:android-test-runner", version.ref = "kotlinAndroidJunit5" }
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "kotlinxCoroutinesAndroid" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinxCoroutinesAndroid" }


### PR DESCRIPTION
## Summary
- remove the android-junit5 runtime dependency that no longer exists in Maven Central
- keep the plugin configuration while relying on its built-in instrumentation setup

## Testing
- ./gradlew lintDebug testDebugUnitTest --stacktrace *(fails in CI environment: Android SDK not installed)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693bc0e0c6ac83308447cff1ebceeb07)