### PR TITLE
Fix Robolectric imports and update serializer test assertion

### DIFF
--- a/app/src/test/kotlin/com/github/arhor/spellbindr/ui/SpellbindrAppViewModelTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/ui/SpellbindrAppViewModelTest.kt
@@ -14,7 +14,7 @@ import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.RegisterExtension
-import org.robolectric.RobolectricExtension
+import org.robolectric.junit5.RobolectricExtension
 import kotlin.io.path.createTempFile
 
 @OptIn(ExperimentalCoroutinesApi::class)

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/utils/CaseInsensitiveEnumSerializerTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/utils/CaseInsensitiveEnumSerializerTest.kt
@@ -37,7 +37,7 @@ class CaseInsensitiveEnumSerializerTest {
         val serializer = CaseInsensitiveEnumSerializer<Example>()
 
         // When
-        val result = assertThrows(IllegalArgumentException::class.java) {
+        val result = assertThrows<IllegalArgumentException> {
             Json.decodeFromString(serializer, "\"missing\"")
         }
 

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/utils/EllipseShapeTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/utils/EllipseShapeTest.kt
@@ -7,7 +7,7 @@ import androidx.compose.ui.unit.LayoutDirection
 import com.google.common.truth.Truth.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
-import org.robolectric.RobolectricExtension
+import org.robolectric.junit5.RobolectricExtension
 
 @ExtendWith(RobolectricExtension::class)
 class EllipseShapeTest {


### PR DESCRIPTION
## Summary
- update unit tests to use the JUnit 5 Robolectric extension import
- adjust serializer test to use the JUnit assertion helper correctly

## Testing
- ./gradlew testDebugUnitTest --no-daemon (fails: Android SDK not configured in CI environment)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693bc382eff48330818032026220a631)