### PR TITLE
Revert JUnit 5 migration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,7 @@ guidelines to stay aligned with the maintainers’ expectations.
     - `./gradlew installDebug` – deploy to the connected emulator/device.
     - `./gradlew lint` – Android lint (resolve/wjustify every warning).
     - `./gradlew testDebugUnitTest` – JVM tests.
-    - `./gradlew connectedAndroidTest` – Instrumented UI tests on JUnit 5 (android-junit5 runner builder). Requires an
+    - `./gradlew connectedAndroidTest` – Instrumented UI tests on the standard JUnit 4 runner. Requires an
       API 26+ emulator/device; an API 33+ emulator with animations disabled remains preferred for stability.
 4. Android Studio run configurations should map to the same Gradle tasks; enable “Use Gradle JDK” (17) and “Optimize
    Gradle for smaller projects” for faster sync.
@@ -63,13 +63,11 @@ guidelines to stay aligned with the maintainers’ expectations.
 
 ## Testing
 
-- **Unit tests (`app/src/test`)**: Use JUnit Jupiter with `useJUnitPlatform()` and `kotlinx-coroutines-test`’s
-  `runTest`. Favor pure Kotlin tests for repositories, mappers, and utility logic.
-- **Instrumented / Compose UI tests (`app/src/androidTest`)**: Run via `connectedAndroidTest` on the JUnit Platform
-  through the Android JUnit5 runner builder. Compose UI still relies on `androidx.compose.ui.test.junit4` artifacts for
-  rules, but execution happens under JUnit 5. Use JUnit Platform tag filters (e.g., include/exclude tags) instead of
-  legacy JUnit4 annotations when wiring custom Gradle invocations. Espresso is available for hybrid flows. Hilt
-  injection is enabled through `HiltAndroidRule` and `HiltApplicationTestRunner`.
+- **Unit tests (`app/src/test`)**: Use JUnit 4 with `kotlinx-coroutines-test`’s `runTest`. Favor pure Kotlin tests for
+  repositories, mappers, and utility logic.
+- **Instrumented / Compose UI tests (`app/src/androidTest`)**: Run via `connectedAndroidTest` on the standard JUnit 4
+  runner. Compose UI relies on `androidx.compose.ui.test.junit4` artifacts for rules. Espresso is available for hybrid
+  flows. Hilt injection is enabled through `HiltAndroidRule` and `HiltApplicationTestRunner`.
 - **Fakes & dispatchers**: Mock external dependencies with fake repositories or in-memory DAOs, and rely on coroutine
   test dispatchers/`runTest` to control timing deterministically.
 - **Test data**: Prefer real SRD assets when possible; otherwise, use fixture builders under `data/model` or `utils`.

--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ Verification commands for agents after setup:
 
 ## 🧪 Testing strategy and JUnit support
 
--   **JVM unit tests** use JUnit Jupiter via Gradle's `useJUnitPlatform()` configuration and the `testImplementation`/`testRuntimeOnly` Jupiter dependencies declared in `app/build.gradle.kts`.
--   **Instrumentation and Compose UI tests** now run on JUnit 5 through the Android JUnit5 runner builder configured in `defaultConfig`. Execute them with `./gradlew connectedAndroidTest` on an emulator or device running API level **26+** (android-junit5 minimum); an API 33+ emulator with animations disabled remains recommended for stability. Compose testing utilities continue to come from `androidx.compose.ui:ui-test-junit4`, but execution is handled by the JUnit Platform.
+-   **JVM unit tests** use the classic JUnit 4 runner with dependencies declared in `app/build.gradle.kts`.
+-   **Instrumentation and Compose UI tests** run on JUnit 4 using the custom `HiltApplicationTestRunner`. Execute them with `./gradlew connectedAndroidTest` on an emulator or device running API level **26+**. Compose testing utilities continue to come from `androidx.compose.ui:ui-test-junit4`.
 
 ## 📜 Data Source
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -7,7 +7,6 @@ plugins {
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.kotlin.ksp)
-    alias(libs.plugins.android.junit5)
 }
 
 android {
@@ -21,7 +20,6 @@ android {
         versionCode = 1
         versionName = "1.0"
         testInstrumentationRunner = "com.github.arhor.spellbindr.HiltApplicationTestRunner"
-        testInstrumentationRunnerArgument("runnerBuilder", "de.mannodermaus.junit5.AndroidJUnit5Builder")
     }
 
     buildTypes {
@@ -73,19 +71,15 @@ dependencies {
     implementation(libs.kotlinx.coroutines.android)
     implementation(libs.kotlinx.serialization.json)
 
-    testImplementation(libs.junit.jupiter)
+    testImplementation(libs.junit)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.truth)
     testImplementation(libs.mockk)
     testImplementation(libs.robolectric)
-    testRuntimeOnly(libs.junit.jupiter.engine)
-    testRuntimeOnly(libs.junit.platform.launcher)
 
     kspAndroidTest(libs.hilt.android.compiler)
 
     androidTestImplementation(platform(libs.androidx.compose.bom))
-    androidTestImplementation(libs.junit.jupiter.api)
-    androidTestImplementation(libs.junit.jupiter.params)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(libs.androidx.ui.test.junit4)
@@ -94,8 +88,4 @@ dependencies {
     androidTestImplementation(libs.hilt.android.testing)
     debugImplementation(libs.androidx.ui.tooling)
     debugImplementation(libs.androidx.ui.test.manifest)
-}
-
-tasks.withType<Test>().configureEach {
-    useJUnitPlatform()
 }

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/ExampleJUnitTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/ExampleJUnitTest.kt
@@ -1,9 +1,9 @@
 package com.github.arhor.spellbindr
 
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.Assert.assertEquals
+import org.junit.Test
 
-class ExampleJupiterTest {
+class ExampleJUnitTest {
 
     @Test
     fun addsNumbers() {

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/MainDispatcherRule.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/MainDispatcherRule.kt
@@ -6,20 +6,19 @@ import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
-import org.junit.jupiter.api.extension.AfterEachCallback
-import org.junit.jupiter.api.extension.BeforeEachCallback
-import org.junit.jupiter.api.extension.ExtensionContext
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class MainDispatcherRule(
     val dispatcher: TestDispatcher = StandardTestDispatcher(),
-) : BeforeEachCallback, AfterEachCallback {
+) : TestWatcher() {
 
-    override fun beforeEach(context: ExtensionContext) {
+    override fun starting(description: Description?) {
         Dispatchers.setMain(dispatcher)
     }
 
-    override fun afterEach(context: ExtensionContext) {
+    override fun finished(description: Description?) {
         Dispatchers.resetMain()
     }
 }

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/ui/SpellbindrAppViewModelTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/ui/SpellbindrAppViewModelTest.kt
@@ -11,18 +11,17 @@ import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.ExtendWith
-import org.junit.jupiter.api.extension.RegisterExtension
-import org.robolectric.junit5.RobolectricExtension
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 import kotlin.io.path.createTempFile
 
 @OptIn(ExperimentalCoroutinesApi::class)
-@ExtendWith(RobolectricExtension::class)
+@RunWith(RobolectricTestRunner::class)
 class SpellbindrAppViewModelTest {
 
-    @JvmField
-    @RegisterExtension
+    @get:Rule
     val mainDispatcherRule = MainDispatcherRule()
 
     @Test

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/utils/EllipseShapeTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/utils/EllipseShapeTest.kt
@@ -5,11 +5,11 @@ import androidx.compose.ui.graphics.Outline
 import androidx.compose.ui.unit.Density
 import androidx.compose.ui.unit.LayoutDirection
 import com.google.common.truth.Truth.assertThat
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.ExtendWith
-import org.robolectric.junit5.RobolectricExtension
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
 
-@ExtendWith(RobolectricExtension::class)
+@RunWith(RobolectricTestRunner::class)
 class EllipseShapeTest {
 
     @Test

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,10 +7,8 @@ hiltNavigationCompose = "1.3.0"
 kotlin = "2.2.20"
 coreKtx = "1.17.0"
 junitVersion = "1.3.0"
-"junit-jupiter" = "5.11.4"
-"junit-platform" = "1.11.4"
+junit4 = "4.13.2"
 espressoCore = "3.7.0"
-kotlinAndroidJunit5 = "1.14.0.0"
 kotlinxCoroutinesAndroid = "1.10.2"
 kotlinxSerializationJson = "1.9.0"
 lifecycleRuntimeKtx = "2.9.4"
@@ -46,11 +44,7 @@ androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-toolin
 hilt-android = { module = "com.google.dagger:hilt-android", version.ref = "hilt" }
 hilt-android-compiler = { module = "com.google.dagger:hilt-android-compiler", version.ref = "hilt" }
 hilt-android-testing = { module = "com.google.dagger:hilt-android-testing", version.ref = "hilt" }
-junit-jupiter = { group = "org.junit.jupiter", name = "junit-jupiter", version.ref = "junit-jupiter" }
-junit-jupiter-api = { group = "org.junit.jupiter", name = "junit-jupiter-api", version.ref = "junit-jupiter" }
-junit-jupiter-engine = { group = "org.junit.jupiter", name = "junit-jupiter-engine", version.ref = "junit-jupiter" }
-junit-jupiter-params = { group = "org.junit.jupiter", name = "junit-jupiter-params", version.ref = "junit-jupiter" }
-junit-platform-launcher = { group = "org.junit.platform", name = "junit-platform-launcher", version.ref = "junit-platform" }
+junit = { group = "junit", name = "junit", version.ref = "junit4" }
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "kotlinxCoroutinesAndroid" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinxCoroutinesAndroid" }
@@ -71,4 +65,3 @@ kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 kotlin-ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
-android-junit5 = { id = "de.mannodermaus.android-junit5", version.ref = "kotlinAndroidJunit5" }


### PR DESCRIPTION
## Summary
- remove android-junit5 plugin usage and revert test dependencies to JUnit 4
- update test utilities and Robolectric tests to use JUnit 4 runners and rules
- refresh project docs to reflect the JUnit 4 testing setup

## Testing
- `./gradlew testDebugUnitTest` *(fails: Android SDK not configured in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6940330ab8b48330951b5dd71f56f0b9)