### PR TITLE
Revert JUnit5 migration to restore JUnit4 tests

### DIFF
--- a/app/src/androidTest/kotlin/com/github/arhor/spellbindr/data/local/assets/StaticAssetDataStoreBaseTest.kt
+++ b/app/src/androidTest/kotlin/com/github/arhor/spellbindr/data/local/assets/StaticAssetDataStoreBaseTest.kt
@@ -3,22 +3,21 @@ package com.github.arhor.spellbindr.data.local.assets
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Assertions.fail
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.RegisterExtension
+import org.junit.Assert.fail
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
 import javax.inject.Inject
 
 @HiltAndroidTest
 class StaticAssetDataStoreBaseTest {
-    @JvmField
-    @RegisterExtension
-    val hiltRule = HiltAndroidRule(this)
+    @get:Rule
+    var hiltRule = HiltAndroidRule(this)
 
     @Inject
     lateinit var stores: Set<@JvmSuppressWildcards InitializableStaticAssetDataStore>
 
-    @BeforeEach
+    @Before
     fun init() {
         hiltRule.inject()
     }

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/ExampleUnitTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/ExampleUnitTest.kt
@@ -1,8 +1,7 @@
 package com.github.arhor.spellbindr
 
 import com.google.common.truth.Truth.assertThat
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.RegisterExtension
+import org.junit.Test
 
 /**
  * Example local unit test, which will execute on the development machine (host).
@@ -10,11 +9,6 @@ import org.junit.jupiter.api.extension.RegisterExtension
  * See [testing documentation](http://d.android.com/tools/testing).
  */
 class ExampleUnitTest {
-
-    @JvmField
-    @RegisterExtension
-    val mainDispatcherRule = MainDispatcherRule()
-
     @Test
     fun addition_isCorrect() {
         assertThat(2 + 2).isEqualTo(4)

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/data/model/CharacterSheetWeaponSerializationTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/data/model/CharacterSheetWeaponSerializationTest.kt
@@ -3,7 +3,7 @@ package com.github.arhor.spellbindr.data.model
 import com.github.arhor.spellbindr.data.model.predefined.Ability
 import com.github.arhor.spellbindr.data.model.predefined.DamageType
 import com.google.common.truth.Truth.assertThat
-import org.junit.jupiter.api.Test
+import org.junit.Test
 
 class CharacterSheetWeaponSerializationTest {
 

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/data/repository/ThemeRepositoryTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/data/repository/ThemeRepositoryTest.kt
@@ -10,7 +10,7 @@ import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.Test
+import org.junit.Test
 import java.io.File
 import kotlin.io.path.createTempFile
 

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/characters/CharacterSheetDeathSavesLogicTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/characters/CharacterSheetDeathSavesLogicTest.kt
@@ -4,7 +4,7 @@ import com.github.arhor.spellbindr.data.model.CharacterSheet
 import com.github.arhor.spellbindr.data.model.DeathSaveState
 import com.github.arhor.spellbindr.ui.feature.characters.sheet.clearDeathSavesIfConscious
 import com.google.common.truth.Truth.assertThat
-import org.junit.jupiter.api.Test
+import org.junit.Test
 
 class CharacterSheetDeathSavesLogicTest {
 

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/characters/sheet/WeaponsTabMappingTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/characters/sheet/WeaponsTabMappingTest.kt
@@ -6,7 +6,7 @@ import com.github.arhor.spellbindr.data.model.Weapon
 import com.github.arhor.spellbindr.data.model.predefined.Ability
 import com.github.arhor.spellbindr.data.model.predefined.DamageType
 import com.google.common.truth.Truth.assertThat
-import org.junit.jupiter.api.Test
+import org.junit.Test
 
 class WeaponsTabMappingTest {
 

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/settings/SettingsViewModelTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/settings/SettingsViewModelTest.kt
@@ -9,16 +9,15 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.RegisterExtension
+import org.junit.Rule
+import org.junit.Test
 import java.io.File
 import kotlin.io.path.createTempFile
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class SettingsViewModelTest {
 
-    @JvmField
-    @RegisterExtension
+    @get:Rule
     val mainDispatcherRule = MainDispatcherRule()
 
     @Test

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/utils/AbilityScoreUtilsTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/utils/AbilityScoreUtilsTest.kt
@@ -2,7 +2,7 @@ package com.github.arhor.spellbindr.utils
 
 import com.github.arhor.spellbindr.data.model.predefined.Ability
 import com.google.common.truth.Truth.assertThat
-import org.junit.jupiter.api.Test
+import org.junit.Test
 
 class AbilityScoreUtilsTest {
 

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/utils/CaseInsensitiveEnumSerializerTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/utils/CaseInsensitiveEnumSerializerTest.kt
@@ -2,8 +2,8 @@ package com.github.arhor.spellbindr.utils
 
 import com.google.common.truth.Truth.assertThat
 import kotlinx.serialization.json.Json
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
+import org.junit.Assert.assertThrows
+import org.junit.Test
 
 class CaseInsensitiveEnumSerializerTest {
 
@@ -37,7 +37,7 @@ class CaseInsensitiveEnumSerializerTest {
         val serializer = CaseInsensitiveEnumSerializer<Example>()
 
         // When
-        val result = assertThrows<IllegalArgumentException> {
+        val result = assertThrows(IllegalArgumentException::class.java) {
             Json.decodeFromString(serializer, "\"missing\"")
         }
 

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/utils/MapExtTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/utils/MapExtTest.kt
@@ -1,7 +1,7 @@
 package com.github.arhor.spellbindr.utils
 
 import com.google.common.truth.Truth.assertThat
-import org.junit.jupiter.api.Test
+import org.junit.Test
 
 class MapExtTest {
 

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/utils/ReferenceSerializerTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/utils/ReferenceSerializerTest.kt
@@ -3,7 +3,7 @@ package com.github.arhor.spellbindr.utils
 import com.github.arhor.spellbindr.data.model.next.Reference
 import com.google.common.truth.Truth.assertThat
 import kotlinx.serialization.json.Json
-import org.junit.jupiter.api.Test
+import org.junit.Test
 
 class ReferenceSerializerTest {
 

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/utils/StringExtTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/utils/StringExtTest.kt
@@ -1,7 +1,7 @@
 package com.github.arhor.spellbindr.utils
 
 import com.google.common.truth.Truth.assertThat
-import org.junit.jupiter.api.Test
+import org.junit.Test
 
 class StringExtTest {
 


### PR DESCRIPTION
## Summary
- switch all test classes back to JUnit4 annotations and rules
- restore Hilt instrumentation rule usage for asset store test
- align assertions with JUnit4 helpers

## Testing
- ./gradlew testDebugUnitTest *(fails: Android SDK not configured in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69403c31f0d88330b28fe9dc75b63597)