### PR TITLE
feat: add domain use cases for spells

### DIFF
--- a/app/src/main/kotlin/com/github/arhor/spellbindr/data/repository/SpellsRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/data/repository/SpellsRepositoryImpl.kt
@@ -1,0 +1,67 @@
+package com.github.arhor.spellbindr.data.repository
+
+import com.github.arhor.spellbindr.data.local.assets.FavoriteSpellsDataStore
+import com.github.arhor.spellbindr.data.local.assets.SpellAssetDataStore
+import com.github.arhor.spellbindr.domain.model.EntityRef
+import com.github.arhor.spellbindr.domain.model.Spell
+import com.github.arhor.spellbindr.domain.repository.SpellsRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class SpellsRepositoryImpl @Inject constructor(
+    private val allSpellsDataStore: SpellAssetDataStore,
+    private val favoriteSpellsDataStore: FavoriteSpellsDataStore,
+) : SpellsRepository {
+    override val allSpells: Flow<List<Spell>>
+        get() = allSpellsDataStore.data.map { it ?: emptyList() }
+
+    override val favoriteSpellIds: Flow<List<String>>
+        get() = favoriteSpellsDataStore.data.map { it ?: emptyList() }
+
+    override suspend fun getSpellById(id: String): Spell? =
+        allSpells.firstOrNull()?.find { it.id == id }
+
+    override suspend fun findSpells(
+        query: String,
+        classes: Set<EntityRef>,
+        favoriteOnly: Boolean,
+    ): List<Spell> =
+        allSpells.firstOrNull()?.let { spells ->
+            if (favoriteOnly) {
+                val favorites = favoriteSpellIds.first()
+
+                spells.filter { it.shouldBeIncluded(query, classes) && it.id in favorites }
+            } else {
+                spells.filter { it.shouldBeIncluded(query, classes) }
+            }
+        } ?: emptyList()
+
+    override suspend fun toggleFavorite(spellId: String) {
+        favoriteSpellIds.first()
+            .let { if (spellId in it) it - spellId else it + spellId }
+            .let { favoriteSpellsDataStore.store(it) }
+    }
+
+    override suspend fun isFavorite(
+        spellId: String?,
+        favoriteSpellIds: List<String>?,
+    ): Boolean {
+        val targetSpellId = spellId ?: return false
+        val ids = favoriteSpellIds ?: this.favoriteSpellIds.first()
+
+        return targetSpellId in ids
+    }
+
+    private fun Spell.shouldBeIncluded(
+        query: String,
+        classes: Set<EntityRef>,
+    ): Boolean {
+        return (query.isBlank() || query.let { this.name.contains(it, ignoreCase = true) })
+            && (classes.isEmpty() || classes.all { this.classes.contains(it) })
+    }
+}

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/di/SpellsDomainModule.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/di/SpellsDomainModule.kt
@@ -1,0 +1,16 @@
+package com.github.arhor.spellbindr.di
+
+import com.github.arhor.spellbindr.data.repository.SpellsRepositoryImpl
+import com.github.arhor.spellbindr.domain.repository.SpellsRepository
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class SpellsDomainModule {
+
+    @Binds
+    abstract fun bindSpellsRepository(impl: SpellsRepositoryImpl): SpellsRepository
+}

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/domain/model/EntityRef.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/domain/model/EntityRef.kt
@@ -1,0 +1,3 @@
+package com.github.arhor.spellbindr.domain.model
+
+typealias EntityRef = com.github.arhor.spellbindr.data.model.EntityRef

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/domain/model/Spell.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/domain/model/Spell.kt
@@ -1,0 +1,3 @@
+package com.github.arhor.spellbindr.domain.model
+
+typealias Spell = com.github.arhor.spellbindr.data.model.Spell

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/domain/repository/SpellsRepository.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/domain/repository/SpellsRepository.kt
@@ -1,0 +1,22 @@
+package com.github.arhor.spellbindr.domain.repository
+
+import com.github.arhor.spellbindr.domain.model.EntityRef
+import com.github.arhor.spellbindr.domain.model.Spell
+import kotlinx.coroutines.flow.Flow
+
+interface SpellsRepository {
+    val allSpells: Flow<List<Spell>>
+    val favoriteSpellIds: Flow<List<String>>
+
+    suspend fun getSpellById(id: String): Spell?
+
+    suspend fun findSpells(
+        query: String = "",
+        classes: Set<EntityRef> = emptySet(),
+        favoriteOnly: Boolean = false,
+    ): List<Spell>
+
+    suspend fun toggleFavorite(spellId: String)
+
+    suspend fun isFavorite(spellId: String?, favoriteSpellIds: List<String>? = null): Boolean
+}

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/domain/usecase/GetSpellByIdUseCase.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/domain/usecase/GetSpellByIdUseCase.kt
@@ -1,0 +1,11 @@
+package com.github.arhor.spellbindr.domain.usecase
+
+import com.github.arhor.spellbindr.domain.model.Spell
+import com.github.arhor.spellbindr.domain.repository.SpellsRepository
+import javax.inject.Inject
+
+class GetSpellByIdUseCase @Inject constructor(
+    private val spellsRepository: SpellsRepository,
+) {
+    suspend operator fun invoke(id: String): Spell? = spellsRepository.getSpellById(id)
+}

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/domain/usecase/IsSpellFavoriteUseCase.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/domain/usecase/IsSpellFavoriteUseCase.kt
@@ -1,0 +1,13 @@
+package com.github.arhor.spellbindr.domain.usecase
+
+import com.github.arhor.spellbindr.domain.repository.SpellsRepository
+import javax.inject.Inject
+
+class IsSpellFavoriteUseCase @Inject constructor(
+    private val spellsRepository: SpellsRepository,
+) {
+    suspend operator fun invoke(
+        spellId: String?,
+        favoriteSpellIds: List<String>? = null,
+    ): Boolean = spellsRepository.isFavorite(spellId, favoriteSpellIds)
+}

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/domain/usecase/ObserveAllSpellsUseCase.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/domain/usecase/ObserveAllSpellsUseCase.kt
@@ -1,0 +1,12 @@
+package com.github.arhor.spellbindr.domain.usecase
+
+import com.github.arhor.spellbindr.domain.model.Spell
+import com.github.arhor.spellbindr.domain.repository.SpellsRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class ObserveAllSpellsUseCase @Inject constructor(
+    private val spellsRepository: SpellsRepository,
+) {
+    operator fun invoke(): Flow<List<Spell>> = spellsRepository.allSpells
+}

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/domain/usecase/ObserveFavoriteSpellIdsUseCase.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/domain/usecase/ObserveFavoriteSpellIdsUseCase.kt
@@ -1,0 +1,11 @@
+package com.github.arhor.spellbindr.domain.usecase
+
+import com.github.arhor.spellbindr.domain.repository.SpellsRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class ObserveFavoriteSpellIdsUseCase @Inject constructor(
+    private val spellsRepository: SpellsRepository,
+) {
+    operator fun invoke(): Flow<List<String>> = spellsRepository.favoriteSpellIds
+}

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/domain/usecase/SearchSpellsUseCase.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/domain/usecase/SearchSpellsUseCase.kt
@@ -1,0 +1,20 @@
+package com.github.arhor.spellbindr.domain.usecase
+
+import com.github.arhor.spellbindr.domain.model.EntityRef
+import com.github.arhor.spellbindr.domain.model.Spell
+import com.github.arhor.spellbindr.domain.repository.SpellsRepository
+import javax.inject.Inject
+
+class SearchSpellsUseCase @Inject constructor(
+    private val spellsRepository: SpellsRepository,
+) {
+    suspend operator fun invoke(
+        query: String = "",
+        classes: Set<EntityRef> = emptySet(),
+        favoriteOnly: Boolean = false,
+    ): List<Spell> = spellsRepository.findSpells(
+        query = query,
+        classes = classes,
+        favoriteOnly = favoriteOnly,
+    )
+}

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/domain/usecase/ToggleFavoriteSpellUseCase.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/domain/usecase/ToggleFavoriteSpellUseCase.kt
@@ -1,0 +1,12 @@
+package com.github.arhor.spellbindr.domain.usecase
+
+import com.github.arhor.spellbindr.domain.repository.SpellsRepository
+import javax.inject.Inject
+
+class ToggleFavoriteSpellUseCase @Inject constructor(
+    private val spellsRepository: SpellsRepository,
+) {
+    suspend operator fun invoke(spellId: String) {
+        spellsRepository.toggleFavorite(spellId)
+    }
+}

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/domain/usecase/SpellsUseCasesTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/domain/usecase/SpellsUseCasesTest.kt
@@ -1,0 +1,174 @@
+package com.github.arhor.spellbindr.domain.usecase
+
+import com.github.arhor.spellbindr.domain.model.EntityRef
+import com.github.arhor.spellbindr.domain.model.Spell
+import com.github.arhor.spellbindr.domain.repository.SpellsRepository
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class SpellsUseCasesTest {
+
+    private val repository = FakeSpellsRepository()
+
+    @Test
+    fun `observeAllSpells emits latest spells`() = runTest {
+        // Given
+        val spell = sampleSpell(id = "magic-missile", name = "Magic Missile")
+        repository.allSpellsState.value = listOf(spell)
+
+        // When
+        val result = ObserveAllSpellsUseCase(repository)().first()
+
+        // Then
+        assertThat(result).containsExactly(spell)
+    }
+
+    @Test
+    fun `observeFavoriteSpellIds emits latest favorites`() = runTest {
+        // Given
+        repository.favoriteSpellIdsState.value = listOf("fireball", "mage-armor")
+
+        // When
+        val result = ObserveFavoriteSpellIdsUseCase(repository)().first()
+
+        // Then
+        assertThat(result).containsExactly("fireball", "mage-armor").inOrder()
+    }
+
+    @Test
+    fun `getSpellById returns matching spell`() = runTest {
+        // Given
+        val spell = sampleSpell(id = "shield", name = "Shield")
+        repository.spellsById[spell.id] = spell
+
+        // When
+        val result = GetSpellByIdUseCase(repository)(spell.id)
+
+        // Then
+        assertThat(result).isEqualTo(spell)
+    }
+
+    @Test
+    fun `getSpellById returns null for unknown spell`() = runTest {
+        // When
+        val result = GetSpellByIdUseCase(repository)("missing")
+
+        // Then
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `searchSpells forwards filters to repository`() = runTest {
+        // Given
+        val classes = setOf(EntityRef("cleric"), EntityRef("wizard"))
+        val expected = listOf(sampleSpell(id = "cure-wounds", name = "Cure Wounds"))
+        repository.findSpellsResult = expected
+
+        // When
+        val result = SearchSpellsUseCase(repository)(
+            query = "Cure",
+            classes = classes,
+            favoriteOnly = true,
+        )
+
+        // Then
+        assertThat(result).isEqualTo(expected)
+        assertThat(repository.lastFindSpellsQuery).isEqualTo("Cure")
+        assertThat(repository.lastFindSpellsClasses).isEqualTo(classes)
+        assertThat(repository.lastFindSpellsFavoriteOnly).isTrue()
+    }
+
+    @Test
+    fun `toggleFavoriteSpell forwards id`() = runTest {
+        // When
+        ToggleFavoriteSpellUseCase(repository)("fireball")
+
+        // Then
+        assertThat(repository.lastToggledSpellId).isEqualTo("fireball")
+    }
+
+    @Test
+    fun `isSpellFavorite returns false for null id`() = runTest {
+        // When
+        val result = IsSpellFavoriteUseCase(repository)(null)
+
+        // Then
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun `isSpellFavorite returns repository value`() = runTest {
+        // Given
+        repository.isFavoriteResult = true
+
+        // When
+        val result = IsSpellFavoriteUseCase(repository)("fireball")
+
+        // Then
+        assertThat(result).isTrue()
+        assertThat(repository.lastIsFavoriteSpellId).isEqualTo("fireball")
+    }
+
+    private fun sampleSpell(
+        id: String,
+        name: String,
+    ): Spell = Spell(
+        id = id,
+        name = name,
+        desc = listOf("A sample spell."),
+        level = 1,
+        range = "Self",
+        ritual = false,
+        school = EntityRef("evocation"),
+        duration = "Instantaneous",
+        castingTime = "1 action",
+        classes = listOf(EntityRef("wizard")),
+        components = listOf("V", "S"),
+        concentration = false,
+        source = "SRD",
+    )
+
+    private class FakeSpellsRepository : SpellsRepository {
+        val allSpellsState = MutableStateFlow<List<Spell>>(emptyList())
+        val favoriteSpellIdsState = MutableStateFlow<List<String>>(emptyList())
+        val spellsById = mutableMapOf<String, Spell>()
+
+        var findSpellsResult: List<Spell> = emptyList()
+        var lastFindSpellsQuery: String? = null
+        var lastFindSpellsClasses: Set<EntityRef>? = null
+        var lastFindSpellsFavoriteOnly: Boolean? = null
+
+        var lastToggledSpellId: String? = null
+        var lastIsFavoriteSpellId: String? = null
+        var isFavoriteResult: Boolean = false
+
+        override val allSpells: Flow<List<Spell>> = allSpellsState
+        override val favoriteSpellIds: Flow<List<String>> = favoriteSpellIdsState
+
+        override suspend fun getSpellById(id: String): Spell? = spellsById[id]
+
+        override suspend fun findSpells(
+            query: String,
+            classes: Set<EntityRef>,
+            favoriteOnly: Boolean,
+        ): List<Spell> {
+            lastFindSpellsQuery = query
+            lastFindSpellsClasses = classes
+            lastFindSpellsFavoriteOnly = favoriteOnly
+            return findSpellsResult
+        }
+
+        override suspend fun toggleFavorite(spellId: String) {
+            lastToggledSpellId = spellId
+        }
+
+        override suspend fun isFavorite(spellId: String?, favoriteSpellIds: List<String>?): Boolean {
+            lastIsFavoriteSpellId = spellId
+            return spellId != null && isFavoriteResult
+        }
+    }
+}


### PR DESCRIPTION
### Motivation

- Introduce a domain-level use-case API for the spells/compendium feature so business logic can be called from ViewModels without depending on data-layer details.
- Infer minimal set of operations used by the app today: observe available spells, observe favorites, query/search, fetch by id, toggle/check favorites.
- Keep existing app behavior unchanged and keep mapping/asset access inside the data layer.

### Description

- Add a domain `SpellsRepository` interface and simple domain type aliases: `domain.model.Spell` and `domain.model.EntityRef`.
- Implement focused use cases (each a single responsibility class): `ObserveAllSpellsUseCase`, `ObserveFavoriteSpellIdsUseCase`, `GetSpellByIdUseCase`, `SearchSpellsUseCase`, `ToggleFavoriteSpellUseCase`, `IsSpellFavoriteUseCase` (all injectable via Hilt).
- Provide a data-layer implementation `SpellsRepositoryImpl` that adapts the existing `SpellAssetDataStore` and `FavoriteSpellsDataStore` and keeps DTO -> domain mapping in data layer.
- Add a Hilt binding module `SpellsDomainModule` and unit tests for the use-case surface (`SpellsUseCasesTest`). Not wired into ViewModels/UI yet.

Key files added/changed

- `app/src/main/kotlin/com/github/arhor/spellbindr/domain/repository/SpellsRepository.kt`
- `app/src/main/kotlin/com/github/arhor/spellbindr/domain/model/Spell.kt`
- `app/src/main/kotlin/com/github/arhor/spellbindr/domain/model/EntityRef.kt`
- `app/src/main/kotlin/com/github/arhor/spellbindr/domain/usecase/*` (new use-case classes)
- `app/src/main/kotlin/com/github/arhor/spellbindr/data/repository/SpellsRepositoryImpl.kt`
- `app/src/main/kotlin/com/github/arhor/spellbindr/di/SpellsDomainModule.kt`
- `app/src/test/kotlin/com/github/arhor/spellbindr/domain/usecase/SpellsUseCasesTest.kt`

### Testing

- Ran `./gradlew lint testDebugUnitTest` (lint + JVM unit tests). Build and tests completed successfully.
- Added `SpellsUseCasesTest` exercising the happy paths and edge cases: observing flows, searching, get-by-id, toggle favorite and favorite checks.
- All new unit tests passed as part of `testDebugUnitTest`.
- No UI/behavior changes introduced; use cases are not wired into existing ViewModels/screens in this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694590de19f48330912a53dcbcb77bdd)