### PR TITLE
fix: implement favorites API in FakeSpellsRepository for unit tests

### DIFF
--- a/app/src/test/kotlin/com/github/arhor/spellbindr/domain/usecase/SpellsUseCasesTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/domain/usecase/SpellsUseCasesTest.kt
@@ -184,6 +184,29 @@ class SpellsUseCasesTest {
             lastFindSpellsFavoriteOnly = favoriteOnly
             return findSpellsResult
         }
+
+        override suspend fun toggleFavorite(spellId: String) {
+            lastToggledSpellId = spellId
+            val current = favoriteSpellIdsState.value.toMutableList()
+            if (current.contains(spellId)) {
+                current.remove(spellId)
+            } else {
+                current.add(spellId)
+            }
+            favoriteSpellIdsState.value = current
+        }
+
+        override suspend fun isFavorite(
+            spellId: String?,
+            favoriteSpellIds: List<String>?,
+        ): Boolean {
+            lastIsFavoriteSpellId = spellId
+            if (spellId == null) {
+                return false
+            }
+            val ids = favoriteSpellIds ?: favoriteSpellIdsState.value
+            return ids.contains(spellId)
+        }
     }
 
     private class FakeFavoritesRepository : FavoritesRepository {


### PR DESCRIPTION
### Motivation

- The test-suite was failing to compile because `SpellsRepository` gained favorites-related methods that the test fake did not implement. 
- The change aims to keep the in-test fake repository API aligned with the production `SpellsRepository` so unit tests can compile and exercise favorite-related behavior.

### Description

- Implemented `toggleFavorite` on the test `FakeSpellsRepository` and update `favoriteSpellIdsState` to reflect toggles. 
- Implemented `isFavorite` on the test `FakeSpellsRepository` to consult the provided `favoriteSpellIds` or the internal `favoriteSpellIdsState`. 
- Preserved existing test bookkeeping by updating `lastToggledSpellId` and `lastIsFavoriteSpellId` when the new methods are invoked. 
- Changes are localized to `app/src/test/kotlin/com/github/arhor/spellbindr/domain/usecase/SpellsUseCasesTest.kt` and do not modify production code.

### Testing

- No automated tests were executed as part of this change. 
- Please run `./gradlew lint testDebugUnitTest` (or rely on CI) to validate that the prior compile-time failure for `:app:compileDebugUnitTestKotlin` is resolved.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6946a160d8a88330a5ae5d35259e8f06)