### PR TITLE
refactor: introduce domain CharacterClassRepository and test fakes

### DIFF
--- a/app/src/main/kotlin/com/github/arhor/spellbindr/data/repository/CharacterClassRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/data/repository/CharacterClassRepositoryImpl.kt
@@ -1,19 +1,20 @@
 package com.github.arhor.spellbindr.data.repository
 
 import com.github.arhor.spellbindr.data.local.assets.CharacterClassAssetDataStore
-import com.github.arhor.spellbindr.data.model.EntityRef
+import com.github.arhor.spellbindr.domain.model.EntityRef
+import com.github.arhor.spellbindr.domain.repository.CharacterClassRepository
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class CharacterClassRepository @Inject constructor(
+class CharacterClassRepositoryImpl @Inject constructor(
     characterClassesDataStore: CharacterClassAssetDataStore,
-) {
-    val allClasses = characterClassesDataStore.data.map { it ?: emptyList() }
+) : CharacterClassRepository {
+    private val allClasses = characterClassesDataStore.data.map { it ?: emptyList() }
 
-    suspend fun findSpellcastingClassesRefs(): List<EntityRef> =
+    override suspend fun findSpellcastingClassesRefs(): List<EntityRef> =
         allClasses.firstOrNull()
             ?.let { data ->
                 data.filter { it.spellcasting != null }

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/di/CharacterClassesDomainModule.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/di/CharacterClassesDomainModule.kt
@@ -1,0 +1,18 @@
+package com.github.arhor.spellbindr.di
+
+import com.github.arhor.spellbindr.data.repository.CharacterClassRepositoryImpl
+import com.github.arhor.spellbindr.domain.repository.CharacterClassRepository
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class CharacterClassesDomainModule {
+
+    @Binds
+    abstract fun bindCharacterClassRepository(
+        impl: CharacterClassRepositoryImpl,
+    ): CharacterClassRepository
+}

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/domain/repository/CharacterClassRepository.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/domain/repository/CharacterClassRepository.kt
@@ -1,0 +1,7 @@
+package com.github.arhor.spellbindr.domain.repository
+
+import com.github.arhor.spellbindr.domain.model.EntityRef
+
+interface CharacterClassRepository {
+    suspend fun findSpellcastingClassesRefs(): List<EntityRef>
+}

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/characters/CharacterSpellPickerViewModel.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/characters/CharacterSpellPickerViewModel.kt
@@ -4,9 +4,9 @@ import androidx.compose.runtime.Immutable
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.github.arhor.spellbindr.data.repository.CharacterClassRepository
 import com.github.arhor.spellbindr.domain.model.EntityRef
 import com.github.arhor.spellbindr.domain.model.Spell
+import com.github.arhor.spellbindr.domain.repository.CharacterClassRepository
 import com.github.arhor.spellbindr.domain.repository.CharacterRepository
 import com.github.arhor.spellbindr.domain.usecase.ObserveAllSpellsUseCase
 import com.github.arhor.spellbindr.domain.usecase.ObserveFavoriteSpellIdsUseCase

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/compendium/CompendiumViewModel.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/compendium/CompendiumViewModel.kt
@@ -6,12 +6,12 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.github.arhor.spellbindr.data.model.predefined.Condition
-import com.github.arhor.spellbindr.data.repository.CharacterClassRepository
 import com.github.arhor.spellbindr.domain.model.Alignment
 import com.github.arhor.spellbindr.domain.model.EntityRef
 import com.github.arhor.spellbindr.domain.model.Race
 import com.github.arhor.spellbindr.domain.model.Spell
 import com.github.arhor.spellbindr.domain.model.Trait
+import com.github.arhor.spellbindr.domain.repository.CharacterClassRepository
 import com.github.arhor.spellbindr.domain.repository.ReferenceDataRepository
 import com.github.arhor.spellbindr.domain.usecase.ObserveAllSpellsUseCase
 import com.github.arhor.spellbindr.domain.usecase.ObserveFavoriteSpellIdsUseCase

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/domain/repository/FakeCharacterClassRepository.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/domain/repository/FakeCharacterClassRepository.kt
@@ -1,0 +1,9 @@
+package com.github.arhor.spellbindr.domain.repository
+
+import com.github.arhor.spellbindr.domain.model.EntityRef
+
+class FakeCharacterClassRepository(
+    var spellcastingClassesRefs: List<EntityRef> = emptyList(),
+) : CharacterClassRepository {
+    override suspend fun findSpellcastingClassesRefs(): List<EntityRef> = spellcastingClassesRefs
+}

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/domain/repository/FakeThemeRepository.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/domain/repository/FakeThemeRepository.kt
@@ -1,0 +1,18 @@
+package com.github.arhor.spellbindr.domain.repository
+
+import com.github.arhor.spellbindr.domain.model.ThemeMode
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+class FakeThemeRepository(
+    initialMode: ThemeMode? = null,
+) : ThemeRepository {
+    private val modeState = MutableStateFlow(initialMode)
+
+    override val themeMode: Flow<ThemeMode?> = modeState.asStateFlow()
+
+    override suspend fun setThemeMode(mode: ThemeMode?) {
+        modeState.value = mode
+    }
+}

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/settings/SettingsViewModelTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/settings/SettingsViewModelTest.kt
@@ -1,9 +1,8 @@
 package com.github.arhor.spellbindr.ui.feature.settings
 
-import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import com.github.arhor.spellbindr.MainDispatcherRule
-import com.github.arhor.spellbindr.data.repository.ThemeRepositoryImpl
 import com.github.arhor.spellbindr.domain.model.ThemeMode
+import com.github.arhor.spellbindr.domain.repository.FakeThemeRepository
 import com.github.arhor.spellbindr.domain.usecase.ObserveThemeModeUseCase
 import com.github.arhor.spellbindr.domain.usecase.SetThemeModeUseCase
 import com.google.common.truth.Truth.assertThat
@@ -13,8 +12,6 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
-import java.io.File
-import kotlin.io.path.createTempFile
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class SettingsViewModelTest {
@@ -24,45 +21,35 @@ class SettingsViewModelTest {
 
     @Test
     fun `state is loaded when repository emits empty preference`() = runTest(mainDispatcherRule.dispatcher) {
-        val (viewModel, file) = createViewModel()
-        try {
-            advanceUntilIdle()
-            val state = viewModel.state.value
-            assertThat(state.loaded).isTrue()
-            assertThat(state.themeMode).isNull()
-        } finally {
-            file.delete()
-        }
+        val viewModel = createViewModel()
+        advanceUntilIdle()
+        val state = viewModel.state.value
+        assertThat(state.loaded).isTrue()
+        assertThat(state.themeMode).isNull()
     }
 
     @Test
     fun `onThemeModeSelected updates preference`() = runTest(mainDispatcherRule.dispatcher) {
-        val (viewModel, file) = createViewModel()
-        try {
-            advanceUntilIdle()
+        val viewModel = createViewModel()
+        advanceUntilIdle()
 
-            viewModel.onThemeModeSelected(ThemeMode.DARK)
-            advanceUntilIdle()
-            assertThat(viewModel.state.value.themeMode).isEqualTo(ThemeMode.DARK)
+        viewModel.onThemeModeSelected(ThemeMode.DARK)
+        advanceUntilIdle()
+        assertThat(viewModel.state.value.themeMode).isEqualTo(ThemeMode.DARK)
 
-            viewModel.onThemeModeSelected(ThemeMode.LIGHT)
-            advanceUntilIdle()
-            assertThat(viewModel.state.value.themeMode).isEqualTo(ThemeMode.LIGHT)
+        viewModel.onThemeModeSelected(ThemeMode.LIGHT)
+        advanceUntilIdle()
+        assertThat(viewModel.state.value.themeMode).isEqualTo(ThemeMode.LIGHT)
 
-            viewModel.onThemeModeSelected(null)
-            advanceUntilIdle()
-            assertThat(viewModel.state.value.themeMode).isNull()
-        } finally {
-            file.delete()
-        }
+        viewModel.onThemeModeSelected(null)
+        advanceUntilIdle()
+        assertThat(viewModel.state.value.themeMode).isNull()
     }
 }
 
-private fun TestScope.createViewModel(): Pair<SettingsViewModel, File> {
-    val file = createTempFile(prefix = "settings-vm", suffix = ".preferences_pb").toFile()
-    val dataStore = PreferenceDataStoreFactory.create(scope = this) { file }
-    val repository = ThemeRepositoryImpl(dataStore)
+private fun TestScope.createViewModel(): SettingsViewModel {
+    val repository = FakeThemeRepository()
     val observeThemeModeUseCase = ObserveThemeModeUseCase(repository)
     val setThemeModeUseCase = SetThemeModeUseCase(repository)
-    return SettingsViewModel(observeThemeModeUseCase, setThemeModeUseCase) to file
+    return SettingsViewModel(observeThemeModeUseCase, setThemeModeUseCase)
 }


### PR DESCRIPTION
### Motivation

- Decouple UI from concrete data-layer repositories so ViewModels depend on domain abstractions instead of `data/repository/*` types.
- Provide Hilt bindings for domain interfaces so implementations are injected through DI and the UI never references data-layer classes directly.
- Make ViewModel unit tests simpler and more deterministic by supplying lightweight fakes for domain repositories.
- Align with the project’s clean architecture rules and prepare for easier testing and future refactors.

### Description

- Added domain interface `CharacterClassRepository` under `domain/repository` and introduced `CharacterClassRepositoryImpl` (renamed from the previous data class) that implements the interface and returns domain `EntityRef`.
- Added Hilt module `CharacterClassesDomainModule` to bind `CharacterClassRepositoryImpl` to `CharacterClassRepository` at `SingletonComponent` scope.
- Updated `CompendiumViewModel` and `CharacterSpellPickerViewModel` to inject `com.github.arhor.spellbindr.domain.repository.CharacterClassRepository` instead of the data-layer repository type.
- Added test fakes `FakeCharacterClassRepository` and `FakeThemeRepository` under `app/src/test/kotlin/...` and updated `SettingsViewModelTest` to use the `FakeThemeRepository`.

### Testing

- No automated tests were executed as part of this change.
- Unit test `SettingsViewModelTest` was updated to use `FakeThemeRepository` (changes landed but the test was not run here).
- Recommend running `./gradlew lint testDebugUnitTest` (and `./gradlew connectedAndroidTest` if UI/navigation changes are introduced) before merging.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947c28ff0d48330a701bc0278dbe9ed)