### PR TITLE
Extract character sheet logic into domain use cases

### DIFF
--- a/app/src/main/kotlin/com/github/arhor/spellbindr/di/UseCasesModule.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/di/UseCasesModule.kt
@@ -10,6 +10,9 @@ import com.github.arhor.spellbindr.domain.usecase.ObserveCharacterSheetsUseCase
 import com.github.arhor.spellbindr.domain.usecase.ObserveThemeModeUseCase
 import com.github.arhor.spellbindr.domain.usecase.SaveCharacterSheetUseCase
 import com.github.arhor.spellbindr.domain.usecase.SetThemeModeUseCase
+import com.github.arhor.spellbindr.domain.usecase.ToggleSpellSlotUseCase
+import com.github.arhor.spellbindr.domain.usecase.UpdateHitPointsUseCase
+import com.github.arhor.spellbindr.domain.usecase.UpdateWeaponListUseCase
 import com.github.arhor.spellbindr.domain.usecase.ValidateCharacterSheetUseCase
 import dagger.Module
 import dagger.Provides
@@ -59,4 +62,13 @@ object UseCasesModule {
     @Provides
     fun provideBuildCharacterSheetFromInputsUseCase(): BuildCharacterSheetFromInputsUseCase =
         BuildCharacterSheetFromInputsUseCase()
+
+    @Provides
+    fun provideUpdateHitPointsUseCase(): UpdateHitPointsUseCase = UpdateHitPointsUseCase()
+
+    @Provides
+    fun provideToggleSpellSlotUseCase(): ToggleSpellSlotUseCase = ToggleSpellSlotUseCase()
+
+    @Provides
+    fun provideUpdateWeaponListUseCase(): UpdateWeaponListUseCase = UpdateWeaponListUseCase()
 }

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/domain/usecase/UpdateHitPointsUseCase.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/domain/usecase/UpdateHitPointsUseCase.kt
@@ -1,0 +1,28 @@
+package com.github.arhor.spellbindr.domain.usecase
+
+import com.github.arhor.spellbindr.domain.model.CharacterSheet
+
+class UpdateHitPointsUseCase {
+
+    sealed interface Action {
+        data class AdjustCurrentHp(val delta: Int) : Action
+        data class SetTemporaryHp(val value: Int) : Action
+        data class SetDeathSaveSuccesses(val count: Int) : Action
+        data class SetDeathSaveFailures(val count: Int) : Action
+    }
+
+    operator fun invoke(sheet: CharacterSheet, action: Action): CharacterSheet = when (action) {
+        is Action.AdjustCurrentHp -> {
+            val maxHp = sheet.maxHitPoints.coerceAtLeast(0)
+            val next = (sheet.currentHitPoints + action.delta).coerceIn(0, maxHp)
+            sheet.copy(currentHitPoints = next)
+        }
+        is Action.SetTemporaryHp -> sheet.copy(temporaryHitPoints = action.value.coerceAtLeast(0))
+        is Action.SetDeathSaveSuccesses -> sheet.copy(
+            deathSaves = sheet.deathSaves.copy(successes = action.count.coerceIn(0, 3)),
+        )
+        is Action.SetDeathSaveFailures -> sheet.copy(
+            deathSaves = sheet.deathSaves.copy(failures = action.count.coerceIn(0, 3)),
+        )
+    }
+}

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/domain/usecase/UpdateWeaponListUseCase.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/domain/usecase/UpdateWeaponListUseCase.kt
@@ -1,0 +1,26 @@
+package com.github.arhor.spellbindr.domain.usecase
+
+import com.github.arhor.spellbindr.domain.model.CharacterSheet
+import com.github.arhor.spellbindr.domain.model.Weapon
+
+class UpdateWeaponListUseCase {
+
+    sealed interface Action {
+        data class Save(val weapon: Weapon) : Action
+        data class Delete(val id: String) : Action
+    }
+
+    operator fun invoke(sheet: CharacterSheet, action: Action): CharacterSheet = when (action) {
+        is Action.Save -> {
+            val updated = sheet.weapons.toMutableList()
+            val existingIndex = updated.indexOfFirst { it.id == action.weapon.id }
+            if (existingIndex >= 0) {
+                updated[existingIndex] = action.weapon
+            } else {
+                updated += action.weapon
+            }
+            sheet.copy(weapons = updated)
+        }
+        is Action.Delete -> sheet.copy(weapons = sheet.weapons.filterNot { it.id == action.id })
+    }
+}

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/domain/usecase/ToggleSpellSlotUseCaseTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/domain/usecase/ToggleSpellSlotUseCaseTest.kt
@@ -1,0 +1,56 @@
+package com.github.arhor.spellbindr.domain.usecase
+
+import com.github.arhor.spellbindr.MainDispatcherRule
+import com.github.arhor.spellbindr.domain.model.CharacterSheet
+import com.github.arhor.spellbindr.domain.model.SpellSlotState
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+
+class ToggleSpellSlotUseCaseTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private val useCase = ToggleSpellSlotUseCase()
+
+    @Test
+    fun `toggle spell slot updates expended count`() {
+        val sheet = CharacterSheet(
+            id = "hero",
+            spellSlots = listOf(SpellSlotState(level = 1, total = 2, expended = 0)),
+        )
+
+        val toggled = useCase(sheet, ToggleSpellSlotUseCase.Action.Toggle(level = 1, slotIndex = 0))
+        val reset = useCase(toggled, ToggleSpellSlotUseCase.Action.Toggle(level = 1, slotIndex = 0))
+
+        assertThat(toggled.spellSlots.first { it.level == 1 }.expended).isEqualTo(1)
+        assertThat(reset.spellSlots.first { it.level == 1 }.expended).isEqualTo(0)
+    }
+
+    @Test
+    fun `set total clamps expended and total`() {
+        val sheet = CharacterSheet(
+            id = "hero",
+            spellSlots = listOf(SpellSlotState(level = 1, total = 3, expended = 3)),
+        )
+
+        val updated = useCase(sheet, ToggleSpellSlotUseCase.Action.SetTotal(level = 1, total = -1))
+
+        val slot = updated.spellSlots.first { it.level == 1 }
+        assertThat(slot.total).isEqualTo(0)
+        assertThat(slot.expended).isEqualTo(0)
+    }
+
+    @Test
+    fun `toggle does nothing when total is zero`() {
+        val sheet = CharacterSheet(
+            id = "hero",
+            spellSlots = listOf(SpellSlotState(level = 2, total = 0, expended = 0)),
+        )
+
+        val updated = useCase(sheet, ToggleSpellSlotUseCase.Action.Toggle(level = 2, slotIndex = 0))
+
+        assertThat(updated.spellSlots.first { it.level == 2 }.expended).isEqualTo(0)
+    }
+}

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/domain/usecase/UpdateHitPointsUseCaseTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/domain/usecase/UpdateHitPointsUseCaseTest.kt
@@ -1,0 +1,46 @@
+package com.github.arhor.spellbindr.domain.usecase
+
+import com.github.arhor.spellbindr.MainDispatcherRule
+import com.github.arhor.spellbindr.domain.model.CharacterSheet
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+
+class UpdateHitPointsUseCaseTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private val useCase = UpdateHitPointsUseCase()
+
+    @Test
+    fun `adjustCurrentHp clamps to valid range`() {
+        val sheet = CharacterSheet(id = "hero", maxHitPoints = 10, currentHitPoints = 9)
+
+        val increased = useCase(sheet, UpdateHitPointsUseCase.Action.AdjustCurrentHp(5))
+        val decreased = useCase(sheet, UpdateHitPointsUseCase.Action.AdjustCurrentHp(-20))
+
+        assertThat(increased.currentHitPoints).isEqualTo(10)
+        assertThat(decreased.currentHitPoints).isEqualTo(0)
+    }
+
+    @Test
+    fun `setTemporaryHp prevents negatives`() {
+        val sheet = CharacterSheet(id = "hero", temporaryHitPoints = 4)
+
+        val updated = useCase(sheet, UpdateHitPointsUseCase.Action.SetTemporaryHp(-3))
+
+        assertThat(updated.temporaryHitPoints).isEqualTo(0)
+    }
+
+    @Test
+    fun `setDeathSaves clamps values between zero and three`() {
+        val sheet = CharacterSheet(id = "hero")
+
+        val successes = useCase(sheet, UpdateHitPointsUseCase.Action.SetDeathSaveSuccesses(4))
+        val failures = useCase(sheet, UpdateHitPointsUseCase.Action.SetDeathSaveFailures(-1))
+
+        assertThat(successes.deathSaves.successes).isEqualTo(3)
+        assertThat(failures.deathSaves.failures).isEqualTo(0)
+    }
+}

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/domain/usecase/UpdateWeaponListUseCaseTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/domain/usecase/UpdateWeaponListUseCaseTest.kt
@@ -1,0 +1,40 @@
+package com.github.arhor.spellbindr.domain.usecase
+
+import com.github.arhor.spellbindr.MainDispatcherRule
+import com.github.arhor.spellbindr.domain.model.CharacterSheet
+import com.github.arhor.spellbindr.domain.model.Weapon
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+
+class UpdateWeaponListUseCaseTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private val useCase = UpdateWeaponListUseCase()
+
+    @Test
+    fun `save weapon upserts by id`() {
+        val weapon = Weapon(id = "w1", name = "Sword")
+        val initial = CharacterSheet(id = "hero")
+
+        val added = useCase(initial, UpdateWeaponListUseCase.Action.Save(weapon))
+        val updated = useCase(added, UpdateWeaponListUseCase.Action.Save(weapon.copy(name = "Longsword")))
+
+        assertThat(added.weapons).hasSize(1)
+        assertThat(updated.weapons).hasSize(1)
+        assertThat(updated.weapons.first().name).isEqualTo("Longsword")
+    }
+
+    @Test
+    fun `delete weapon removes matching id`() {
+        val weapon = Weapon(id = "w1", name = "Sword")
+        val other = Weapon(id = "w2", name = "Axe")
+        val initial = CharacterSheet(id = "hero", weapons = listOf(weapon, other))
+
+        val updated = useCase(initial, UpdateWeaponListUseCase.Action.Delete("w1"))
+
+        assertThat(updated.weapons).containsExactly(other)
+    }
+}


### PR DESCRIPTION
### Motivation

- Move pure logic (HP adjustments, spell-slot state, weapon list edits) out of the ViewModel into testable domain use cases to improve separation of concerns and maintainability.
- Keep `CharacterSheetViewModel` focused on orchestration, state updates, and persistence while making business rules reusable.

### Description

- Add domain use cases: `UpdateHitPointsUseCase`, `ToggleSpellSlotUseCase`, and `UpdateWeaponListUseCase` under `domain/usecase` encapsulating the previous inline logic for HP, spell slots, and weapons respectively.
- Wire new use cases into DI by adding providers in `di/UseCasesModule.kt` and inject them into `CharacterSheetViewModel` as `updateHitPointsUseCase`, `toggleSpellSlotUseCase`, and `updateWeaponListUseCase`.
- Replace inline logic in `CharacterSheetViewModel` with calls to the new use cases (e.g., `updateHitPointsUseCase(sheet, ...)`, `toggleSpellSlotUseCase(sheet, ...)`, `updateWeaponListUseCase(sheet, ...)`) and remove the duplicated `updateSpellSlot` helper from the ViewModel.
- Add unit tests for each use case: `UpdateHitPointsUseCaseTest`, `ToggleSpellSlotUseCaseTest`, and `UpdateWeaponListUseCaseTest` under `app/src/test/kotlin/com/github/arhor/spellbindr/domain/usecase` using `MainDispatcherRule` and `Truth` assertions.

### Testing

- Unit tests were added for `UpdateHitPointsUseCase`, `ToggleSpellSlotUseCase`, and `UpdateWeaponListUseCase` at `app/src/test/kotlin/com/github/arhor/spellbindr/domain/usecase` and use the existing `MainDispatcherRule`.
- No test suite was executed as part of this change (tests were created but not run during the rollout).
- The new use cases are pure functions and exercised by the unit tests which assert expected state transformations.
- DI was updated in `di/UseCasesModule.kt` to provide the new use cases so runtime injection is available for the ViewModel.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694804215acc83308ef1c98cd25bb8f8)