### PR TITLE
Add ability assets and repository integration

### DIFF
--- a/app/src/main/kotlin/com/github/arhor/spellbindr/data/local/assets/AbilityAssetDataStore.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/data/local/assets/AbilityAssetDataStore.kt
@@ -1,0 +1,20 @@
+package com.github.arhor.spellbindr.data.local.assets
+
+import android.content.Context
+import com.github.arhor.spellbindr.data.model.AbilityAssetModel
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.serialization.json.Json
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class AbilityAssetDataStore @Inject constructor(
+    @ApplicationContext
+    context: Context,
+    json: Json,
+) : StaticAssetDataStoreBase<AbilityAssetModel>(
+    json = json,
+    path = "data/abilities.json",
+    context = context,
+    serializer = AbilityAssetModel.serializer(),
+)

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/data/mapper/AbilityMapper.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/data/mapper/AbilityMapper.kt
@@ -1,0 +1,10 @@
+package com.github.arhor.spellbindr.data.mapper
+
+import com.github.arhor.spellbindr.data.model.AbilityAssetModel
+import com.github.arhor.spellbindr.domain.model.Ability
+
+fun AbilityAssetModel.toDomainAbilityOrNull(): Ability? {
+    return Ability.entries.firstOrNull { ability ->
+        ability.id.equals(id, ignoreCase = true) || ability.displayName.equals(name, ignoreCase = true)
+    }
+}

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/data/model/AbilityAssetModel.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/data/model/AbilityAssetModel.kt
@@ -1,0 +1,12 @@
+package com.github.arhor.spellbindr.data.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class AbilityAssetModel(
+    val id: String,
+    @SerialName("displayName")
+    val name: String,
+    val description: List<String>,
+)

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/data/repository/AbilityRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/data/repository/AbilityRepositoryImpl.kt
@@ -1,0 +1,21 @@
+package com.github.arhor.spellbindr.data.repository
+
+import com.github.arhor.spellbindr.data.local.assets.AbilityAssetDataStore
+import com.github.arhor.spellbindr.data.mapper.toDomainAbilityOrNull
+import com.github.arhor.spellbindr.domain.model.Ability
+import com.github.arhor.spellbindr.domain.repository.AbilityRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class AbilityRepositoryImpl @Inject constructor(
+    private val abilityAssetDataStore: AbilityAssetDataStore,
+) : AbilityRepository {
+
+    override val allAbilities: Flow<List<Ability>>
+        get() = abilityAssetDataStore.data.map { abilities ->
+            abilities.orEmpty().mapNotNull { it.toDomainAbilityOrNull() }
+        }
+}

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/di/CommonDomainModule.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/di/CommonDomainModule.kt
@@ -1,5 +1,6 @@
 package com.github.arhor.spellbindr.di
 
+import com.github.arhor.spellbindr.data.repository.AbilityRepositoryImpl
 import com.github.arhor.spellbindr.data.repository.AlignmentRepositoryImpl
 import com.github.arhor.spellbindr.data.repository.CharacterClassRepositoryImpl
 import com.github.arhor.spellbindr.data.repository.CharacterRepositoryImpl
@@ -10,6 +11,7 @@ import com.github.arhor.spellbindr.data.repository.SpellsRepositoryImpl
 import com.github.arhor.spellbindr.data.repository.ThemeRepositoryImpl
 import com.github.arhor.spellbindr.data.repository.TraitsRepositoryImpl
 import com.github.arhor.spellbindr.data.repository.WeaponCatalogRepositoryImpl
+import com.github.arhor.spellbindr.domain.repository.AbilityRepository
 import com.github.arhor.spellbindr.domain.repository.AlignmentRepository
 import com.github.arhor.spellbindr.domain.repository.CharacterClassRepository
 import com.github.arhor.spellbindr.domain.repository.CharacterRepository
@@ -36,6 +38,9 @@ abstract class CommonDomainModule {
 
     @Binds
     abstract fun bindFavoritesRepository(impl: FavoritesRepositoryImpl): FavoritesRepository
+
+    @Binds
+    abstract fun bindAbilityRepository(impl: AbilityRepositoryImpl): AbilityRepository
 
     @Binds
     abstract fun bindAlignmentRepository(impl: AlignmentRepositoryImpl): AlignmentRepository

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/di/StaticAssetsModule.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/di/StaticAssetsModule.kt
@@ -1,5 +1,6 @@
 package com.github.arhor.spellbindr.di
 
+import com.github.arhor.spellbindr.data.local.assets.AbilityAssetDataStore
 import com.github.arhor.spellbindr.data.local.assets.AlignmentAssetDataStore
 import com.github.arhor.spellbindr.data.local.assets.BackgroundsAssetDataStore
 import com.github.arhor.spellbindr.data.local.assets.CharacterClassAssetDataStore
@@ -64,5 +65,10 @@ abstract class StaticAssetsModule {
     @Binds
     @IntoSet
     abstract fun bindLanguagesAssetDataStore(languagesAssetDataStore: LanguagesAssetDataStore)
+        : InitializableStaticAssetDataStore
+
+    @Binds
+    @IntoSet
+    abstract fun bindAbilitiesAssetDataStore(abilitiesAssetDataStore: AbilityAssetDataStore)
         : InitializableStaticAssetDataStore
 }

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/domain/model/Ability.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/domain/model/Ability.kt
@@ -15,10 +15,12 @@ import kotlinx.serialization.Serializable
  */
 @Serializable(with = Ability.Companion::class)
 enum class Ability(
+    val id: String,
     val displayName: String,
     val description: List<String>,
 ) {
     STR(
+        id = "str",
         displayName = "Strength",
         description = listOf(
             "Strength measures bodily power, athletic training, and the extent to which you can exert raw physical force.",
@@ -28,6 +30,7 @@ enum class Ability(
         ),
     ),
     DEX(
+        id = "dex",
         displayName = "Dexterity",
         description = listOf(
             "Dexterity measures agility, reflexes, and balance.",
@@ -37,6 +40,7 @@ enum class Ability(
         ),
     ),
     CON(
+        id = "con",
         displayName = "Constitution",
         description = listOf(
             "Constitution measures health, stamina, and vital force.",
@@ -46,6 +50,7 @@ enum class Ability(
         ),
     ),
     INT(
+        id = "int",
         displayName = "Intelligence",
         description = listOf(
             "Intelligence measures mental acuity, accuracy of recall, and the ability to reason.",
@@ -55,6 +60,7 @@ enum class Ability(
         ),
     ),
     WIS(
+        id = "wis",
         displayName = "Wisdom",
         description = listOf(
             "Wisdom reflects how attuned you are to the world around you and represents perceptiveness and intuition.",
@@ -64,6 +70,7 @@ enum class Ability(
         ),
     ),
     CHA(
+        id = "cha",
         displayName = "Charisma",
         description = listOf(
             "Charisma measures your ability to interact effectively with others. It includes such factors as confidence " +
@@ -79,7 +86,7 @@ enum class Ability(
         get() = Skill.entries.filter { it.ability == this }
 
     val ref: EntityRef
-        get() = EntityRef(name)
+        get() = EntityRef(id)
 
     companion object : KSerializer<Ability> by CaseInsensitiveEnumSerializer.Companion()
 }

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/domain/repository/AbilityRepository.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/domain/repository/AbilityRepository.kt
@@ -1,0 +1,8 @@
+package com.github.arhor.spellbindr.domain.repository
+
+import com.github.arhor.spellbindr.domain.model.Ability
+import kotlinx.coroutines.flow.Flow
+
+interface AbilityRepository {
+    val allAbilities: Flow<List<Ability>>
+}


### PR DESCRIPTION
## Summary
- add a serializable ability asset model with a static data store for `abilities.json`
- map ability assets into domain abilities and expose them via a new repository with DI bindings
- align ability entity references with asset identifiers for consistent downstream usage

## Testing
- ./gradlew testDebugUnitTest
- ./gradlew lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e709774f883308320d14163ef4615)