### PR TITLE
Add android command line tools archive to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ google-services.json
 /captures
 .externalNativeBuild
 .cxx
+android-commandlinetools.zip


### PR DESCRIPTION
## Summary
- ignore the android-commandlinetools.zip archive to keep it out of version control

## Testing
- not run (not needed for gitignore-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e7863a56c8330a61713d24fc82d9a)