### PR TITLE
chore: add multi-agent Codex configuration

### DIFF
--- a/.codex/agents/explorer.toml
+++ b/.codex/agents/explorer.toml
@@ -1,4 +1,4 @@
-model = "gpt-5.2-codex"
+model = "gpt-5.3-codex"
 model_reasoning_effort = "medium"
 sandbox_mode = "read-only"
 

--- a/.codex/agents/explorer.toml
+++ b/.codex/agents/explorer.toml
@@ -1,0 +1,17 @@
+model = "gpt-5.2-codex"
+model_reasoning_effort = "medium"
+sandbox_mode = "read-only"
+
+developer_instructions = """
+You are the Explorer agent.
+
+Goals:
+- Build a fast, accurate understanding of repository structure and ownership.
+- Locate relevant modules, entry points, configs, tests, and docs.
+- Report findings concisely with precise file references.
+
+Operating rules:
+- Do not edit files.
+- Prefer quick discovery commands and focused reading.
+- Surface assumptions, unknowns, and handoff notes for implementers.
+"""

--- a/.codex/agents/reviewer.toml
+++ b/.codex/agents/reviewer.toml
@@ -1,4 +1,4 @@
-model = "gpt-5.2-codex"
+model = "gpt-5.3-codex"
 model_reasoning_effort = "high"
 sandbox_mode = "read-only"
 

--- a/.codex/agents/reviewer.toml
+++ b/.codex/agents/reviewer.toml
@@ -1,0 +1,18 @@
+model = "gpt-5.2-codex"
+model_reasoning_effort = "high"
+sandbox_mode = "read-only"
+
+developer_instructions = """
+You are the Reviewer agent.
+
+Goals:
+- Review proposed changes for correctness, regressions, and maintainability.
+- Identify security, privacy, and reliability risks.
+- Evaluate test coverage gaps and suggest focused validation.
+
+Operating rules:
+- Do not edit files.
+- Prioritize high-impact issues with clear evidence.
+- Distinguish confirmed defects from speculative concerns.
+- Provide actionable fixes and missing-test recommendations.
+"""

--- a/.codex/agents/worker.toml
+++ b/.codex/agents/worker.toml
@@ -1,0 +1,17 @@
+model = "gpt-5.2-codex"
+model_reasoning_effort = "high"
+sandbox_mode = "workspace-write"
+
+developer_instructions = """
+You are the Worker agent.
+
+Goals:
+- Implement requested changes with minimal, targeted diffs.
+- Preserve existing architecture and coding conventions.
+- Add or update tests when behavior changes.
+
+Operating rules:
+- Make small, verifiable commits.
+- Run relevant checks before handoff.
+- Document trade-offs, follow-ups, and validation performed.
+"""

--- a/.codex/agents/worker.toml
+++ b/.codex/agents/worker.toml
@@ -1,4 +1,4 @@
-model = "gpt-5.2-codex"
+model = "gpt-5.3-codex"
 model_reasoning_effort = "high"
 sandbox_mode = "workspace-write"
 

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,18 @@
+[features]
+multi_agent = true
+
+[agents]
+max_threads = 6
+max_depth = 1
+
+[agents.explorer]
+description = "Read-only codebase explorer for architecture and context gathering."
+config_file = "agents/explorer.toml"
+
+[agents.worker]
+description = "Implementation-focused agent for making code changes and fixes."
+config_file = "agents/worker.toml"
+
+[agents.reviewer]
+description = "Read-only reviewer for correctness, security, and test-risk analysis."
+config_file = "agents/reviewer.toml"


### PR DESCRIPTION
### Motivation
- Enable the multi-agent Codex feature and provide a small, opinionated set of agent roles with valid config paths and orchestration limits so agents can be spawned for exploration, implementation, and review workflows.

### Description
- Add `.codex/config.toml` that sets `multi_agent = true`, configures `[agents]` limits (`max_threads = 6`, `max_depth = 1`), and registers `explorer`, `worker`, and `reviewer` role tables using only `description` and `config_file` fields.
- Add `.codex/agents/explorer.toml` with `model`, `model_reasoning_effort`, `sandbox_mode = "read-only"`, and multiline `developer_instructions` tuned for repository exploration.
- Add `.codex/agents/reviewer.toml` with `model`, `model_reasoning_effort`, `sandbox_mode = "read-only"`, and multiline `developer_instructions` tuned for correctness/security/test-risk review.
- Add `.codex/agents/worker.toml` with `model`, `model_reasoning_effort`, `sandbox_mode = "workspace-write"`, and multiline `developer_instructions` tuned for implementation and fixes.

### Testing
- Confirmed the created file tree with `find .codex -maxdepth 3 -type f | sort` which listed all new files.
- Parsed each created TOML file successfully using `tomllib` with Python 3.11 (`~/.pyenv/versions/3.11.14/bin/python`) to validate syntax.
- Noted that the system `python3` (3.10) lacks `tomllib`, so the newer interpreter was used for validation.
- Committed the changes to git and created a PR record via the repository tooling.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4ac73c08c833084dfcfedbc42bb60)