### PR TITLE
test: align tests with repository guidelines

### DIFF
--- a/app/src/androidTest/kotlin/com/github/arhor/spellbindr/ui/NavigationBehaviorTest.kt
+++ b/app/src/androidTest/kotlin/com/github/arhor/spellbindr/ui/NavigationBehaviorTest.kt
@@ -45,7 +45,7 @@ class NavigationBehaviorTest {
     }
 
     @Test
-    fun `opening spell should keep top bar visible when navigating to details`() {
+    fun `MainActivity should keep top bar visible when navigating to spell details`() {
         // Given
         waitForContentDescription("Create character")
         composeTestRule.onNodeWithText("Compendium").performClick()
@@ -64,11 +64,10 @@ class NavigationBehaviorTest {
 
         // Then
         composeTestRule.onNodeWithContentDescription("Back").assertIsDisplayed()
-        composeTestRule.onNodeWithContentDescription("Back").assertIsDisplayed()
     }
 
     @Test
-    fun `dice roll details should dismiss when navigating away and returning`() {
+    fun `MainActivity should dismiss dice roll details when navigating away and returning`() {
         // Given
         waitForContentDescription("Create character")
         composeTestRule.onNodeWithText("Dice").performClick()
@@ -91,7 +90,7 @@ class NavigationBehaviorTest {
     }
 
     @Test
-    fun `character editor should reset when switching tabs`() {
+    fun `MainActivity should reset character editor when switching tabs`() {
         // Given
         waitForContentDescription("Create character")
         composeTestRule.onNodeWithContentDescription("Create character").performClick()
@@ -111,7 +110,7 @@ class NavigationBehaviorTest {
     }
 
     @Test
-    fun `character sheet navigation should remain stable when adding spells`() {
+    fun `MainActivity should clear character sheet navigation when switching tabs from spell picker`() {
         // Given
         waitForContentDescription("Create character")
         createCharacter("Test Hero")
@@ -119,7 +118,10 @@ class NavigationBehaviorTest {
         // When
         composeTestRule.onNodeWithText("Test Hero").performClick()
         waitForContentDescription("Back")
-        val backVisibleDuringSheet = composeTestRule.onAllNodesWithContentDescription("Back").fetchSemanticsNodes().isNotEmpty()
+        val backVisibleDuringSheet = composeTestRule
+            .onAllNodesWithContentDescription("Back")
+            .fetchSemanticsNodes()
+            .isNotEmpty()
 
         composeTestRule.onNodeWithText("Spells").performClick()
         composeTestRule.onNodeWithText("Add spells").performClick()
@@ -135,7 +137,7 @@ class NavigationBehaviorTest {
     }
 
     @Test
-    fun `compendium sections should open conditions and render description`() {
+    fun `MainActivity should render condition description when compendium condition is opened`() {
         // Given
         waitForContentDescription("Create character")
         composeTestRule.onNodeWithText("Compendium").performClick()
@@ -149,11 +151,15 @@ class NavigationBehaviorTest {
 
         // Then
         waitForText("- A blinded creature can't see and automatically fails any ability check that requires sight.")
-        composeTestRule.onNodeWithText("- A blinded creature can't see and automatically fails any ability check that requires sight.").assertIsDisplayed()
+        composeTestRule
+            .onNodeWithText(
+                "- A blinded creature can't see and automatically fails any ability check that requires sight.",
+            )
+            .assertIsDisplayed()
     }
 
     @Test
-    fun `compendium sections should reappear when returning from other tabs`() {
+    fun `MainActivity should show compendium sections when returning from another tab`() {
         // Given
         waitForContentDescription("Create character")
         composeTestRule.onNodeWithText("Compendium").performClick()

--- a/app/src/androidTest/kotlin/com/github/arhor/spellbindr/ui/feature/character/WeaponCatalogSelectionTest.kt
+++ b/app/src/androidTest/kotlin/com/github/arhor/spellbindr/ui/feature/character/WeaponCatalogSelectionTest.kt
@@ -32,7 +32,7 @@ class WeaponCatalogSelectionTest {
     val composeTestRule = createAndroidComposeRule<ComponentActivity>()
 
     @Test
-    fun `WeaponCatalogDialog should prefill editor while allowing manual edits`() {
+    fun `WeaponCatalogDialog should prefill editor while allowing manual edits when weapon is selected`() {
         // Given
         val catalog = listOf(
             WeaponCatalogUiModel(

--- a/app/src/androidTest/kotlin/com/github/arhor/spellbindr/ui/feature/character/guided/GuidedChoiceStepsTest.kt
+++ b/app/src/androidTest/kotlin/com/github/arhor/spellbindr/ui/feature/character/guided/GuidedChoiceStepsTest.kt
@@ -25,7 +25,8 @@ class GuidedChoiceStepsTest {
     val composeTestRule = createAndroidComposeRule<ComponentActivity>()
 
     @Test
-    fun proficiencies_step_shows_merged_sources_conflict_and_independent_progress() {
+    fun `ProficienciesLanguagesStep should show merged sources and progress when requirements conflict`() {
+        // Given
         val grants = listOf(
             fixedGrant(GuidedChoiceSource.CLASS, "Class: Ranger"),
             fixedGrant(GuidedChoiceSource.RACE_TRAIT, "Race trait: Keen Senses"),
@@ -46,6 +47,7 @@ class GuidedChoiceStepsTest {
             ),
         )
 
+        // When
         composeTestRule.setContent {
             AppTheme {
                 ProficienciesLanguagesStep(
@@ -57,6 +59,7 @@ class GuidedChoiceStepsTest {
             }
         }
 
+        // Then
         composeTestRule.onNodeWithText("Granted by Class: Ranger, Race trait: Keen Senses").assertIsDisplayed()
         composeTestRule.onNodeWithText("Class").assertIsDisplayed()
         composeTestRule.onNodeWithText("Race & subrace").assertIsDisplayed()
@@ -71,7 +74,8 @@ class GuidedChoiceStepsTest {
     }
 
     @Test
-    fun ancestry_step_shows_trait_context_and_completed_state() {
+    fun `AncestryChoicesStep should show trait context and completion when choice is selected`() {
+        // Given
         val requirement = GuidedChoiceRequirement(
             key = "race/trait/draconic-ancestry/choice",
             source = GuidedChoiceSource.RACE_TRAIT,
@@ -91,6 +95,7 @@ class GuidedChoiceStepsTest {
             disabledOptions = emptyMap(),
         )
 
+        // When
         composeTestRule.setContent {
             AppTheme {
                 AncestryChoicesStep(
@@ -101,6 +106,7 @@ class GuidedChoiceStepsTest {
             }
         }
 
+        // Then
         composeTestRule.onNodeWithText("✓ Race trait: Draconic Ancestry").assertIsDisplayed()
         composeTestRule.onNodeWithText(
             "Choose the type of dragon in your ancestry. Choose 1. Complete.",

--- a/app/src/androidTest/kotlin/com/github/arhor/spellbindr/ui/feature/character/guided/RaceCarouselTest.kt
+++ b/app/src/androidTest/kotlin/com/github/arhor/spellbindr/ui/feature/character/guided/RaceCarouselTest.kt
@@ -25,9 +25,11 @@ class RaceCarouselTest {
     val composeTestRule = createAndroidComposeRule<ComponentActivity>()
 
     @Test
-    fun first_visible_page_is_not_selected_automatically() {
+    fun `RaceCarousel should not select first page when initially displayed`() {
+        // Given
         val selectedRaceIds = mutableListOf<String>()
 
+        // When
         composeTestRule.setContent {
             AppTheme {
                 RaceCarousel(
@@ -42,6 +44,7 @@ class RaceCarouselTest {
             }
         }
 
+        // Then
         composeTestRule.onNodeWithContentDescription("Elf, 1 of 2").assertIsDisplayed()
         composeTestRule.runOnIdle {
             assertThat(selectedRaceIds).isEmpty()
@@ -49,9 +52,9 @@ class RaceCarouselTest {
     }
 
     @Test
-    fun tapping_visible_page_selects_exactly_that_race() {
+    fun `RaceCarousel should select visible race once when page is tapped`() {
+        // Given
         val selectedRaceIds = mutableListOf<String>()
-
         composeTestRule.setContent {
             AppTheme {
                 RaceCarousel(
@@ -66,16 +69,19 @@ class RaceCarouselTest {
             }
         }
 
+        // When
         composeTestRule.onNodeWithContentDescription("Elf, 1 of 2").performClick()
+
+        // Then
         composeTestRule.runOnIdle {
             assertThat(selectedRaceIds).containsExactly("elf")
         }
     }
 
     @Test
-    fun settling_a_user_swipe_selects_the_new_page_once() {
+    fun `RaceCarousel should select new race once when user swipe settles`() {
+        // Given
         val selectedRaceIds = mutableListOf<String>()
-
         composeTestRule.setContent {
             AppTheme {
                 RaceCarousel(
@@ -90,11 +96,13 @@ class RaceCarouselTest {
             }
         }
 
+        // When
         composeTestRule
             .onNodeWithContentDescription("Elf, 1 of 2")
             .performTouchInput { swipeLeft() }
         composeTestRule.waitForIdle()
 
+        // Then
         composeTestRule.runOnIdle {
             assertThat(selectedRaceIds).containsExactly("dwarf")
         }

--- a/app/src/androidTest/kotlin/com/github/arhor/spellbindr/ui/feature/character/guided/StandardArrayAssignTest.kt
+++ b/app/src/androidTest/kotlin/com/github/arhor/spellbindr/ui/feature/character/guided/StandardArrayAssignTest.kt
@@ -26,12 +26,15 @@ class StandardArrayAssignTest {
     val composeTestRule = createAndroidComposeRule<ComponentActivity>()
 
     @Test
-    fun `assigning an available score updates the row and progress`() {
+    fun `StandardArrayAssign should update row and progress when available score is assigned`() {
+        // Given
         setContent()
 
+        // When
         composeTestRule.onNodeWithContentDescription("15 available. Tap to select.").performClick()
         composeTestRule.onNodeWithContentDescription("Strength: unassigned. Tap to assign 15.").performClick()
 
+        // Then
         composeTestRule.onNodeWithText("1 of 6 assigned").assertIsDisplayed()
         composeTestRule
             .onNodeWithContentDescription("Strength: 15, modifier +2. Tap to pick up 15.")
@@ -40,23 +43,29 @@ class StandardArrayAssignTest {
     }
 
     @Test
-    fun `picking up an assigned score clears its row and selects the score`() {
+    fun `StandardArrayAssign should clear row and select score when assigned score is picked up`() {
+        // Given
         setContent(assignments = assignments(strength = 15))
 
+        // When
         composeTestRule
             .onNodeWithContentDescription("Strength: 15, modifier +2. Tap to pick up 15.")
             .performClick()
 
+        // Then
         composeTestRule.onNodeWithText("0 of 6 assigned").assertIsDisplayed()
         composeTestRule.onNodeWithContentDescription("15 selected. Tap to cancel selection.").assertIsDisplayed()
         composeTestRule.onNodeWithContentDescription("Strength: unassigned. Tap to assign 15.").assertIsDisplayed()
     }
 
     @Test
-    fun `replacing an assigned score returns the displaced score to the tray`() {
+    fun `StandardArrayAssign should return displaced score when assigned score is replaced`() {
+        // Given
         setContent(assignments = assignments(strength = 15, dexterity = 14))
 
+        // When
         composeTestRule.onNodeWithContentDescription("13 available. Tap to select.").performClick()
+        // Then
         composeTestRule
             .onNodeWithContentDescription("Strength: 15, modifier +2. Tap to assign 13.")
             .performClick()

--- a/app/src/androidTest/kotlin/com/github/arhor/spellbindr/ui/feature/character/sheet/components/SpellsTabAccessibilityTest.kt
+++ b/app/src/androidTest/kotlin/com/github/arhor/spellbindr/ui/feature/character/sheet/components/SpellsTabAccessibilityTest.kt
@@ -21,11 +21,15 @@ class SpellsTabAccessibilityTest {
     val composeTestRule = createAndroidComposeRule<ComponentActivity>()
 
     @Test
-    fun `SpellsTab exposes slot control content descriptions`() {
+    fun `SpellsTab should expose slot control descriptions when edit mode is active`() {
+        // Given
+        val spellsState = CharacterSheetPreviewData.spells
+
+        // When
         composeTestRule.setContent {
             AppTheme {
                 SpellsTab(
-                    spellsState = CharacterSheetPreviewData.spells,
+                    spellsState = spellsState,
                     editMode = SheetEditMode.Edit,
                     onAddSpellsClick = {},
                     onCastSpellClick = {},
@@ -45,6 +49,7 @@ class SpellsTabAccessibilityTest {
             }
         }
 
+        // Then
         val context = composeTestRule.activity
         val increaseShared = context.getString(R.string.spells_shared_slots_increase, 1)
         val decreaseShared = context.getString(R.string.spells_shared_slots_decrease, 1)

--- a/app/src/androidTest/kotlin/com/github/arhor/spellbindr/ui/feature/character/sheet/components/SpellsTabScrollStateTest.kt
+++ b/app/src/androidTest/kotlin/com/github/arhor/spellbindr/ui/feature/character/sheet/components/SpellsTabScrollStateTest.kt
@@ -31,7 +31,8 @@ class SpellsTabScrollStateTest {
     val composeTestRule = createAndroidComposeRule<ComponentActivity>()
 
     @Test
-    fun `Spells tab preserves scroll position when switching tabs`() {
+    fun `CharacterSheetContent should preserve spells scroll position when switching tabs`() {
+        // Given
         val spellsState = buildSpellsState(spellCount = 60)
         composeTestRule.setContent {
             var selectedTab by remember { mutableStateOf(CharacterSheetTab.Spells) }
@@ -66,8 +67,10 @@ class SpellsTabScrollStateTest {
             }
         }
 
+        // When
         val targetSpell = "Spell 40"
         composeTestRule.onNodeWithText(targetSpell).performScrollTo()
+        // Then
         composeTestRule.onNodeWithText(targetSpell).assertIsDisplayed()
 
         composeTestRule.onNodeWithText("Overview").performClick()

--- a/app/src/androidTest/kotlin/com/github/arhor/spellbindr/ui/feature/compendium/alignments/AlignmentsScreenTest.kt
+++ b/app/src/androidTest/kotlin/com/github/arhor/spellbindr/ui/feature/compendium/alignments/AlignmentsScreenTest.kt
@@ -22,7 +22,7 @@ class AlignmentsScreenTest {
     val composeTestRule = createAndroidComposeRule<ComponentActivity>()
 
     @Test
-    fun `render should show loading indicator when state is loading`() {
+    fun `AlignmentsScreen should show loading indicator when state is loading`() {
         // Given
         val state = AlignmentsUiState.Loading
 
@@ -38,7 +38,7 @@ class AlignmentsScreenTest {
     }
 
     @Test
-    fun `render should show error message when state is error`() {
+    fun `AlignmentsScreen should show error message when state is error`() {
         // Given
         val state = AlignmentsUiState.Failure("Failed to load alignments")
 
@@ -54,7 +54,7 @@ class AlignmentsScreenTest {
     }
 
     @Test
-    fun `click should dispatch intent when alignment tile tapped`() {
+    fun `AlignmentsScreen should dispatch intent when alignment tile is tapped`() {
         // Given
         val alignment = Alignment(
             id = "lg",

--- a/app/src/androidTest/kotlin/com/github/arhor/spellbindr/ui/feature/compendium/conditions/ConditionsScreenTest.kt
+++ b/app/src/androidTest/kotlin/com/github/arhor/spellbindr/ui/feature/compendium/conditions/ConditionsScreenTest.kt
@@ -22,7 +22,7 @@ class ConditionsScreenTest {
     val composeTestRule = createAndroidComposeRule<ComponentActivity>()
 
     @Test
-    fun `render should show loading indicator when state is loading`() {
+    fun `ConditionsScreen should show loading indicator when state is loading`() {
         // Given
         val state = ConditionsUiState.Loading
 
@@ -40,7 +40,7 @@ class ConditionsScreenTest {
     }
 
     @Test
-    fun `render should show error message when state is error`() {
+    fun `ConditionsScreen should show error message when state is error`() {
         // Given
         val state = ConditionsUiState.Failure("Something went wrong")
 
@@ -58,7 +58,7 @@ class ConditionsScreenTest {
     }
 
     @Test
-    fun `render should show expanded description when selected item id matches`() {
+    fun `ConditionsScreen should show expanded description when selected item id matches`() {
         // Given
         val condition = Condition(
             id = "blinded",
@@ -84,7 +84,7 @@ class ConditionsScreenTest {
     }
 
     @Test
-    fun `click should dispatch intent when condition item tapped`() {
+    fun `ConditionsScreen should dispatch intent when condition item is tapped`() {
         // Given
         val condition = Condition(
             id = "blinded",

--- a/app/src/androidTest/kotlin/com/github/arhor/spellbindr/ui/feature/compendium/races/RacesScreenTest.kt
+++ b/app/src/androidTest/kotlin/com/github/arhor/spellbindr/ui/feature/compendium/races/RacesScreenTest.kt
@@ -24,7 +24,7 @@ class RacesScreenTest {
     val composeTestRule = createAndroidComposeRule<ComponentActivity>()
 
     @Test
-    fun `render should show loading indicator when state is loading`() {
+    fun `RacesScreen should show loading indicator when state is loading`() {
         // Given
         val state = RacesUiState.Loading
 
@@ -44,7 +44,7 @@ class RacesScreenTest {
     }
 
     @Test
-    fun `render should show error message when state is error`() {
+    fun `RacesScreen should show error message when state is error`() {
         // Given
         val state = RacesUiState.Failure("Something went wrong")
 
@@ -62,7 +62,7 @@ class RacesScreenTest {
     }
 
     @Test
-    fun `render should show trait description when selected item id matches`() {
+    fun `RacesScreen should show trait description when selected item id matches`() {
         // Given
         val trait = Trait(
             id = "darkvision",
@@ -95,7 +95,7 @@ class RacesScreenTest {
     }
 
     @Test
-    fun `click should dispatch intent when race item tapped`() {
+    fun `RacesScreen should dispatch intent when race item is tapped`() {
         // Given
         val trait = Trait(
             id = "keen_senses",

--- a/app/src/androidTest/kotlin/com/github/arhor/spellbindr/ui/feature/compendium/spells/SpellsScreenTest.kt
+++ b/app/src/androidTest/kotlin/com/github/arhor/spellbindr/ui/feature/compendium/spells/SpellsScreenTest.kt
@@ -41,7 +41,7 @@ class SpellsScreenTest {
     )
 
     @Test
-    fun `render should show loading indicator when state is loading`() {
+    fun `SpellsScreen should show loading indicator when state is loading`() {
         // Given
         val state = SpellsUiState.Loading
 
@@ -59,7 +59,7 @@ class SpellsScreenTest {
     }
 
     @Test
-    fun `render should show error message when state is failure`() {
+    fun `SpellsScreen should show error message when state is failure`() {
         // Given
         val state = SpellsUiState.Failure("Failed to load spells.")
 
@@ -75,7 +75,7 @@ class SpellsScreenTest {
     }
 
     @Test
-    fun `render should hide class filters when casting classes are empty`() {
+    fun `SpellsScreen should hide class filters when casting classes are empty`() {
         // Given
         val state = contentState(castingClasses = emptyList())
 
@@ -91,7 +91,7 @@ class SpellsScreenTest {
     }
 
     @Test
-    fun `input should call onQueryChanged when user types`() {
+    fun `SpellsScreen should call onQueryChanged when user types`() {
         // Given
         var capturedIntent: SpellsIntent? = null
         val state = contentState(query = "")
@@ -114,7 +114,7 @@ class SpellsScreenTest {
     }
 
     @Test
-    fun `click should call onFavoriteClick when favorite icon tapped`() {
+    fun `SpellsScreen should call onFavoriteClick when favorite icon is tapped`() {
         // Given
         var capturedIntent: SpellsIntent? = null
         val state = contentState(showFavoriteOnly = false)
@@ -137,7 +137,7 @@ class SpellsScreenTest {
     }
 
     @Test
-    fun `click should call onClassToggled when class chip tapped`() {
+    fun `SpellsScreen should call onClassToggled when class chip is tapped`() {
         // Given
         var capturedIntent: SpellsIntent? = null
         val state = contentState(castingClasses = listOf(wizard, cleric))
@@ -160,7 +160,7 @@ class SpellsScreenTest {
     }
 
     @Test
-    fun `click should call onSpellClick when spell card tapped`() {
+    fun `SpellsScreen should call onSpellClick when spell card is tapped`() {
         // Given
         var capturedIntent: SpellsIntent? = null
         val state = contentState(spells = spells)

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/data/local/assets/DefaultAssetBootstrapperTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/data/local/assets/DefaultAssetBootstrapperTest.kt
@@ -19,7 +19,7 @@ class DefaultAssetBootstrapperTest {
     val mainDispatcherRule = MainDispatcherRule()
 
     @Test
-    fun `readyForInteraction should wait for critical assets and initial delay`() = runTest {
+    fun `readyForInteraction should wait for critical assets and initial delay when bootstrap starts`() = runTest {
         // Given
         val criticalAssetStore = mockk<AssetDataStore<*>>()
         val deferredAssetStore = mockk<AssetDataStore<*>>()
@@ -51,45 +51,4 @@ class DefaultAssetBootstrapperTest {
         assertThat(finalState.readyForInteraction).isTrue()
         assertThat(finalState.deferredAssetsReady).isFalse()
     }
-
-//    @Test
-//    fun `fullyReady should flip after deferred assets finish`() = runTest {
-//        // Given
-//        val criticalLoader = FakeAssetLoader(AssetLoadingPriority.CRITICAL)
-//        val deferredLoader = FakeAssetLoader(AssetLoadingPriority.DEFERRED, initializationDelayMillis = 2_500)
-//        val bootstrapper = DefaultAssetBootstrapper(assetsDataStores = setOf(criticalLoader, deferredLoader))
-//
-//        // When
-//        bootstrapper.start(this)
-//        advanceTimeBy(1_600)
-//        runCurrent()
-//        val stateBeforeDeferredReady = bootstrapper.state.value
-//
-//        advanceUntilIdle()
-//        val stateAfterDeferredReady = bootstrapper.state.value
-//
-//        // Then
-//        assertThat(stateBeforeDeferredReady.readyForInteraction).isTrue()
-//        assertThat(stateBeforeDeferredReady.fullyReady).isFalse()
-//        assertThat(stateAfterDeferredReady.deferredAssetsReady).isTrue()
-//        assertThat(stateAfterDeferredReady.fullyReady).isTrue()
-//    }
-//
-//    @Test
-//    fun `critical readiness should resolve when no critical loaders are present`() = runTest {
-//        // Given
-//        val deferredLoader = FakeAssetLoader(AssetLoadingPriority.DEFERRED, initializationDelayMillis = 2_000)
-//        val bootstrapper = DefaultAssetBootstrapper(assetsDataStores = setOf(deferredLoader))
-// 
-//        // When
-//        bootstrapper.start(this)
-//        advanceTimeBy(1_500)
-//        runCurrent()
-//        val state = bootstrapper.state.value
-//
-//        // Then
-//        assertThat(state.criticalAssetsReady).isTrue()
-//        assertThat(state.readyForInteraction).isTrue()
-//        assertThat(state.deferredAssetsReady).isFalse()
-//    }
 }

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/data/model/AbilitySkillSerializationTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/data/model/AbilitySkillSerializationTest.kt
@@ -38,7 +38,7 @@ class AbilitySkillSerializationTest {
     }
 
     @Test
-    fun `abilities asset should expose ids names and descriptions when parsed from json`() {
+    fun `abilitiesFromAsset should expose ids names and descriptions when asset is decoded`() {
         // Given
         val abilitiesById = abilitiesFromAsset.associateBy(Ability::id)
 
@@ -73,7 +73,7 @@ class AbilitySkillSerializationTest {
     }
 
     @Test
-    fun `ability serializer should round trip when encoding and decoding object`() {
+    fun `decodeFromString should return original ability when encoded ability is decoded`() {
         // Given
         val ability = Ability(
             id = "str",
@@ -90,7 +90,7 @@ class AbilitySkillSerializationTest {
     }
 
     @Test
-    fun `ability serializer should decode from json object when attributes are provided`() {
+    fun `decodeFromString should create ability when required attributes are provided`() {
         // Given
         val encoded = """
             {
@@ -116,7 +116,7 @@ class AbilitySkillSerializationTest {
     }
 
     @Test
-    fun `skill serializer should serialize to kebab case when encoding value`() {
+    fun `encodeToString should use kebab case when skill is encoded`() {
         // Given
         val skill = Skill.ANIMAL_HANDLING
 
@@ -128,7 +128,7 @@ class AbilitySkillSerializationTest {
     }
 
     @Test
-    fun `skill serializer should deserialize case-insensitively when decoding value`() {
+    fun `decodeFromString should ignore case when skill is decoded`() {
         // Given
         val encoded = "\"PeRcEpTiOn\""
 

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/data/repository/RacesRepositoryImplTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/data/repository/RacesRepositoryImplTest.kt
@@ -15,14 +15,17 @@ class RacesRepositoryImplTest {
 
     @Test
     fun `findRaceById should return null when asset load fails`() = runTest {
+        // Given
         val stateFlow = MutableStateFlow<Loadable<List<Race>>>(Loadable.Failure(cause = IllegalStateException("Boom")))
         val dataStore = mockk<CharacterRaceAssetDataStore> {
             every { data } returns stateFlow
         }
         val repository = RacesRepositoryImpl(dataStore)
 
+        // When
         val result = withTimeout(1_000) { repository.findRaceById("missing") }
 
+        // Then
         assertThat(result).isNull()
     }
 }

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/data/repository/SpellsRepositoryImplTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/data/repository/SpellsRepositoryImplTest.kt
@@ -16,6 +16,7 @@ class SpellsRepositoryImplTest {
 
     @Test
     fun `getSpellById should return null when asset load fails`() = runTest {
+        // Given
         val stateFlow = MutableStateFlow<Loadable<List<Spell>>>(Loadable.Failure(cause = IllegalStateException("Boom")))
         val dataStore = mockk<SpellAssetDataStore> {
             every { data } returns stateFlow
@@ -23,8 +24,10 @@ class SpellsRepositoryImplTest {
         val favoritesRepository = mockk<FavoritesRepository>(relaxed = true)
         val repository = SpellsRepositoryImpl(dataStore, favoritesRepository)
 
+        // When
         val result = withTimeout(1_000) { repository.getSpellById("missing") }
 
+        // Then
         assertThat(result).isNull()
     }
 }

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/domain/model/AbilityScoresModifierTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/domain/model/AbilityScoresModifierTest.kt
@@ -6,7 +6,8 @@ import org.junit.Test
 class AbilityScoresModifierTest {
 
     @Test
-    fun `modifierFor should floor negative modifiers`() {
+    fun `modifierFor should floor negative modifiers when score is below ten`() {
+        // Given
         val cases = mapOf(
             8 to -1,
             9 to -1,
@@ -15,10 +16,13 @@ class AbilityScoresModifierTest {
             12 to 1,
         )
 
-        cases.forEach { (score, expected) ->
+        // When
+        val actual = cases.mapValues { (score, _) ->
             val scores = AbilityScores(strength = score)
-            assertThat(scores.modifierFor(AbilityIds.STR)).isEqualTo(expected)
+            scores.modifierFor(AbilityIds.STR)
         }
+
+        // Then
+        assertThat(actual).containsExactlyEntriesIn(cases)
     }
 }
-

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/domain/model/EffectTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/domain/model/EffectTest.kt
@@ -6,7 +6,7 @@ import org.junit.Test
 class EffectTest {
 
     @Test
-    fun `add hp effect should add flat value when not per level`() {
+    fun `applyTo should add flat hit points when effect is not per level`() {
         // Given
         val state = Character.State(level = 5, maximumHitPoints = 10)
         val effect = Effect.AddHpEffect(value = 2)
@@ -19,7 +19,7 @@ class EffectTest {
     }
 
     @Test
-    fun `add hp effect should scale value by level when marked per level`() {
+    fun `applyTo should scale hit points when effect is marked per level`() {
         // Given
         val state = Character.State(level = 3, maximumHitPoints = 7)
         val effect = Effect.AddHpEffect(value = 2, perLevel = true)
@@ -32,7 +32,7 @@ class EffectTest {
     }
 
     @Test
-    fun `add equipment effect should merge equipment ids and quantities`() {
+    fun `applyTo should merge equipment ids and quantities when effect adds existing and new equipment`() {
         // Given
         val state = Character.State(
             equipment = setOf(EntityRef("torch")),

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/domain/usecase/CharacterEditorUseCasesTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/domain/usecase/CharacterEditorUseCasesTest.kt
@@ -19,7 +19,7 @@ class CharacterEditorUseCasesTest {
     private val buildCharacterSheetFromInputsUseCase = BuildCharacterSheetFromInputsUseCase()
 
     @Test
-    fun `ValidateCharacterSheetUseCase should return errors when required fields or abilities are invalid`() {
+    fun `invoke should return errors when required fields or abilities are invalid`() {
         // Given
         val input = CharacterEditorInput(
             name = "",
@@ -42,7 +42,7 @@ class CharacterEditorUseCasesTest {
     }
 
     @Test
-    fun `ValidateCharacterSheetUseCase should return no errors when inputs are valid`() {
+    fun `invoke should return no errors when character inputs are valid`() {
         // Given
         val input = CharacterEditorInput(
             name = "Ayla",
@@ -62,7 +62,7 @@ class CharacterEditorUseCasesTest {
     }
 
     @Test
-    fun `ComputeDerivedBonusesUseCase should update saving throws and skills when proficiency applies`() {
+    fun `invoke should update saving throws and skills when proficiency applies`() {
         // Given
         val input = CharacterEditorInput(
             proficiencyBonus = "2",
@@ -92,7 +92,7 @@ class CharacterEditorUseCasesTest {
     }
 
     @Test
-    fun `BuildCharacterSheetFromInputsUseCase should build sheet when inputs are provided`() {
+    fun `invoke should build sheet when character inputs are provided`() {
         // Given
         val baseSheet = CharacterSheet(id = "base-id", maxHitPoints = 10)
         val input = CharacterEditorInput(
@@ -132,7 +132,7 @@ class CharacterEditorUseCasesTest {
     }
 
     @Test
-    fun `ValidateCharacterSheetUseCase should handle blank and invalid numeric values when validating`() {
+    fun `invoke should return errors when numeric values are blank or invalid`() {
         // Given
         val input = CharacterEditorInput(
             name = "Ayla",

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/domain/usecase/ObserveAlignmentsUseCaseTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/domain/usecase/ObserveAlignmentsUseCaseTest.kt
@@ -18,7 +18,7 @@ class ObserveAlignmentsUseCaseTest {
     private val observeAllAlignmentsUseCase = ObserveAllAlignmentsUseCase(alignmentRepository)
 
     @Test
-    fun `ObserveAlignmentsUseCase should emit latest alignments when repository updates`() = runTest {
+    fun `invoke should emit latest alignments when repository updates`() = runTest {
         // Given
         val alignment = Alignment(id = "lawful-good", name = "Lawful Good", desc = "Desc", abbr = "LG")
         val loadable = Loadable.Content(listOf(alignment))

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/domain/usecase/ReferenceDataUseCasesTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/domain/usecase/ReferenceDataUseCasesTest.kt
@@ -17,7 +17,7 @@ class ReferenceDataUseCasesTest {
     private val traitsRepository = FakeTraitsRepository()
 
     @Test
-    fun `ObserveRacesUseCase should emit latest races when repository updates`() = runTest {
+    fun `invoke should emit latest races when race repository updates`() = runTest {
         // Given
         val race = Race(
             id = "elf",
@@ -35,7 +35,7 @@ class ReferenceDataUseCasesTest {
     }
 
     @Test
-    fun `ObserveTraitsUseCase should emit latest traits when repository updates`() = runTest {
+    fun `invoke should emit latest traits when trait repository updates`() = runTest {
         // Given
         val trait = Trait(id = "darkvision", name = "Darkvision", desc = listOf("See in the dark."))
         traitsRepository.allTraitsState.value = Loadable.Content(listOf(trait))

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/domain/usecase/ToggleSpellSlotUseCaseTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/domain/usecase/ToggleSpellSlotUseCaseTest.kt
@@ -11,7 +11,8 @@ class ToggleSpellSlotUseCaseTest {
     private val useCase = ToggleSpellSlotUseCase()
 
     @Test
-    fun longRest_resetsSharedAndPactSlots_andClearsConcentration() {
+    fun `invoke should reset all slots and concentration when action is long rest`() {
+        // Given
         val sheet = CharacterSheet(
             id = "hero",
             concentrationSpellId = "hex",
@@ -26,8 +27,10 @@ class ToggleSpellSlotUseCaseTest {
             ),
         )
 
+        // When
         val updated = useCase(sheet, ToggleSpellSlotUseCase.Action.LongRest)
 
+        // Then
         assertThat(updated.concentrationSpellId).isNull()
         assertThat(updated.spellSlots).containsExactly(
             SpellSlotState(level = 1, total = 4, expended = 0),
@@ -43,7 +46,8 @@ class ToggleSpellSlotUseCaseTest {
     }
 
     @Test
-    fun shortRest_resetsOnlyPactSlots() {
+    fun `invoke should reset only pact slots when action is short rest`() {
+        // Given
         val sheet = CharacterSheet(
             id = "hero",
             concentrationSpellId = "hex",
@@ -57,8 +61,10 @@ class ToggleSpellSlotUseCaseTest {
             ),
         )
 
+        // When
         val updated = useCase(sheet, ToggleSpellSlotUseCase.Action.ShortRest)
 
+        // Then
         assertThat(updated.concentrationSpellId).isEqualTo("hex")
         assertThat(updated.spellSlots).containsExactly(
             SpellSlotState(level = 1, total = 4, expended = 2),
@@ -73,14 +79,17 @@ class ToggleSpellSlotUseCaseTest {
     }
 
     @Test
-    fun setPactSlotLevel_createsPactSlotsWhenMissing() {
+    fun `invoke should create pact slots when setting level without existing state`() {
+        // Given
         val sheet = CharacterSheet(
             id = "hero",
             pactSlots = null,
         )
 
+        // When
         val updated = useCase(sheet, ToggleSpellSlotUseCase.Action.SetPactSlotLevel(level = 5))
 
+        // Then
         assertThat(updated.pactSlots).isEqualTo(
             PactSlotState(
                 slotLevel = 5,
@@ -91,7 +100,8 @@ class ToggleSpellSlotUseCaseTest {
     }
 
     @Test
-    fun setPactSlotLevel_updatesExistingPactSlots() {
+    fun `invoke should retain pact slot usage when setting level with existing state`() {
+        // Given
         val sheet = CharacterSheet(
             id = "hero",
             pactSlots = PactSlotState(
@@ -101,8 +111,10 @@ class ToggleSpellSlotUseCaseTest {
             ),
         )
 
+        // When
         val updated = useCase(sheet, ToggleSpellSlotUseCase.Action.SetPactSlotLevel(level = 4))
 
+        // Then
         assertThat(updated.pactSlots).isEqualTo(
             PactSlotState(
                 slotLevel = 4,
@@ -112,4 +124,3 @@ class ToggleSpellSlotUseCaseTest {
         )
     }
 }
-

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/logging/AndroidLoggerFactoryTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/logging/AndroidLoggerFactoryTest.kt
@@ -8,7 +8,7 @@ import java.util.concurrent.TimeUnit
 class AndroidLoggerFactoryTest {
 
     @Test
-    fun `create should return same logger instance for the same tag`() {
+    fun `getLogger should return same logger instance when tag is unchanged`() {
         // Given
         val factory = AndroidLoggerFactory()
 
@@ -21,7 +21,7 @@ class AndroidLoggerFactoryTest {
     }
 
     @Test
-    fun `create should return same logger instance for the same tag under concurrent load`() {
+    fun `getLogger should return same logger instance when tag is requested concurrently`() {
         // Given
         val factory = AndroidLoggerFactory()
         val executor = Executors.newFixedThreadPool(8)
@@ -42,7 +42,7 @@ class AndroidLoggerFactoryTest {
     }
 
     @Test
-    fun `create should return different logger instances for different tags`() {
+    fun `getLogger should return different logger instances when tags differ`() {
         // Given
         val factory = AndroidLoggerFactory()
 

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/logging/LoggerTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/logging/LoggerTest.kt
@@ -23,7 +23,7 @@ class LoggerTest {
     }
 
     @Test
-    fun `error should pass throwable and message to logger backend`() {
+    fun `error should pass throwable and message to backend when error level is enabled`() {
         // Given
         val logger = CapturingLogger(enabledLevels = setOf(LogLevel.ERROR))
         val throwable = IllegalStateException("failed")
@@ -43,7 +43,7 @@ class LoggerTest {
     }
 
     @Test
-    fun `warn should pass throwable and message to logger backend`() {
+    fun `warn should pass throwable and message to backend when warn level is enabled`() {
         // Given
         val logger = CapturingLogger(enabledLevels = setOf(LogLevel.WARN))
         val throwable = IllegalArgumentException("invalid")
@@ -63,7 +63,7 @@ class LoggerTest {
     }
 
     @Test
-    fun `tagOf should return companion owner class name for companion type`() {
+    fun `tagOf should return owner class name when type is a companion`() {
         // Given
         val type = CompanionHost.Companion::class.java
 
@@ -75,7 +75,7 @@ class LoggerTest {
     }
 
     @Test
-    fun `tagOf should return simple class name for regular type`() {
+    fun `tagOf should return simple class name when type is regular`() {
         // Given
         val type = RegularType::class.java
 
@@ -87,7 +87,7 @@ class LoggerTest {
     }
 
     @Test
-    fun `tagOf should return non-empty fallback tag for anonymous type`() {
+    fun `tagOf should return non-empty fallback tag when type is anonymous`() {
         // Given
         val anonymousObject = object {}
 

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/settings/data/repository/SettingsRepositoryImplTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/settings/data/repository/SettingsRepositoryImplTest.kt
@@ -34,7 +34,7 @@ class SettingsRepositoryImplTest {
     }
 
     @Test
-    fun `setThemeMode should persist selected mode`() = runTest {
+    fun `setThemeMode should persist selected mode when mode is non-null`() = runTest {
         // Given
         val (repository, _, file) = createRepository()
         try {
@@ -50,7 +50,7 @@ class SettingsRepositoryImplTest {
     }
 
     @Test
-    fun `setThemeMode with null should clear stored mode`() = runTest {
+    fun `setThemeMode should clear stored mode when mode is null`() = runTest {
         // Given
         val (repository, _, file) = createRepository()
         try {
@@ -68,7 +68,7 @@ class SettingsRepositoryImplTest {
     }
 
     @Test
-    fun `settings should map invalid stored mode to null`() = runTest {
+    fun `settings should map stored mode to null when value is invalid`() = runTest {
         // Given
         val (repository, dataStore, file) = createRepository()
         try {

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/character/editor/CharacterEditorViewModelTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/character/editor/CharacterEditorViewModelTest.kt
@@ -16,7 +16,7 @@ class CharacterEditorViewModelTest {
     val mainDispatcherRule = MainDispatcherRule()
 
     @Test
-    fun `dispatch should update name field in content state`() {
+    fun `dispatch should update name in content state when name changes`() {
         // Given
         val vm = CharacterEditorViewModel(
             loadCharacterSheetUseCase = mockk(relaxed = true),

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/character/guided/GuidedCharacterSetupSheetBuilderTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/character/guided/GuidedCharacterSetupSheetBuilderTest.kt
@@ -45,196 +45,211 @@ class GuidedCharacterSetupSheetBuilderTest {
     val mainDispatcherRule = MainDispatcherRule()
 
     @Test
-    fun `buildCharacterSheet should apply per-level hp effects`() = runTest(mainDispatcherRule.dispatcher) {
-        val vm = buildViewModel()
+    fun `buildCharacterSheet should apply per-level hp effects when selected race grants one`() =
+        runTest(mainDispatcherRule.dispatcher) {
+            // Given
+            val vm = buildViewModel()
 
-        val toughTrait = Trait(
-            id = "dwarven-toughness",
-            name = "Dwarven Toughness",
-            desc = listOf("Your hit point maximum increases by 1, and it increases by 1 every time you gain a level."),
-            effects = listOf(Effect.AddHpEffect(value = 1, perLevel = true)),
-        )
-        val dwarf = Race(
-            id = "dwarf",
-            name = "Dwarf",
-            traits = listOf(EntityRef(toughTrait.id)),
-            subraces = emptyList(),
-        )
-        val fighter = CharacterClass(
-            id = "fighter",
-            name = "Fighter",
-            hitDie = 8,
-            proficiencies = emptyList(),
-            proficiencyChoices = emptyList(),
-            savingThrows = emptyList(),
-            spellcasting = null,
-            startingEquipment = null,
-            subclasses = emptyList(),
-            levels = listOf(
-                ClassLevel(
-                    id = "fighter-1",
-                    level = 1,
-                    features = emptyList(),
+            val toughTrait = Trait(
+                id = "dwarven-toughness",
+                name = "Dwarven Toughness",
+                desc = listOf(
+                    "Your hit point maximum increases by 1, and it increases by 1 every time you gain a level.",
                 ),
-            ),
-        )
-        val background = Background(
-            id = "acolyte",
-            name = "Acolyte",
-            feature = GenericInfo(name = "Shelter of the Faithful", desc = emptyList()),
-            effects = emptyList(),
-        )
-
-        val selection = GuidedSelection(
-            classId = fighter.id,
-            subclassId = null,
-            raceId = dwarf.id,
-            subraceId = null,
-            backgroundId = background.id,
-            abilityMethod = AbilityScoreMethod.POINT_BUY,
-            standardArrayAssignments = defaultStandardArrayAssignments(),
-            pointBuyScores = AbilityIds.standardOrder.associateWith { 10 },
-            choiceSelections = emptyMap(),
-        )
-        val content = buildContent(
-            name = "Test",
-            classes = listOf(fighter),
-            races = listOf(dwarf),
-            backgrounds = listOf(background),
-            traits = listOf(toughTrait),
-            features = emptyList(),
-            spells = emptyList(),
-            selection = selection,
-        )
-
-        val sheet = vm.buildCharacterSheet(content)
-
-        // Base HP at level 1: hit die + CON mod (0) = 8, plus racial bonus +1.
-        assertThat(sheet.maxHitPoints).isEqualTo(9)
-    }
-
-    @Test
-    fun `buildCharacterSheet should mark expertise on selected skills`() = runTest(mainDispatcherRule.dispatcher) {
-        val vm = buildViewModel()
-
-        val rogue = CharacterClass(
-            id = "rogue",
-            name = "Rogue",
-            hitDie = 8,
-            proficiencies = emptyList(),
-            proficiencyChoices = emptyList(),
-            savingThrows = emptyList(),
-            spellcasting = null,
-            startingEquipment = null,
-            subclasses = emptyList(),
-            levels = listOf(
-                ClassLevel(
-                    id = "rogue-1",
-                    level = 1,
-                    features = emptyList(),
-                ),
-            ),
-        )
-        val human = Race(
-            id = "human",
-            name = "Human",
-            traits = emptyList(),
-            subraces = emptyList(),
-        )
-        val background = Background(
-            id = "criminal",
-            name = "Criminal",
-            feature = GenericInfo(name = "Criminal Contact", desc = emptyList()),
-            effects = emptyList(),
-        )
-
-        val choiceKey = GuidedCharacterSetupViewModel.featureChoiceKey("rogue-expertise-1")
-        val selection = GuidedSelection(
-            classId = rogue.id,
-            subclassId = null,
-            raceId = human.id,
-            subraceId = null,
-            backgroundId = background.id,
-            abilityMethod = AbilityScoreMethod.POINT_BUY,
-            standardArrayAssignments = defaultStandardArrayAssignments(),
-            pointBuyScores = AbilityIds.standardOrder.associateWith { 10 },
-            choiceSelections = mapOf(
-                choiceKey to setOf("skill-stealth", "skill-perception"),
-            ),
-        )
-
-        val content = buildContent(
-            name = "Sneaky",
-            classes = listOf(rogue),
-            races = listOf(human),
-            backgrounds = listOf(background),
-            traits = emptyList(),
-            features = listOf(
-                Feature(
-                    id = "rogue-expertise-1",
-                    name = "Expertise",
-                    desc = emptyList(),
-                    choice = Choice.ProficiencyChoice(
-                        choose = 2,
-                        from = listOf("skill-stealth", "skill-perception"),
+                effects = listOf(Effect.AddHpEffect(value = 1, perLevel = true)),
+            )
+            val dwarf = Race(
+                id = "dwarf",
+                name = "Dwarf",
+                traits = listOf(EntityRef(toughTrait.id)),
+                subraces = emptyList(),
+            )
+            val fighter = CharacterClass(
+                id = "fighter",
+                name = "Fighter",
+                hitDie = 8,
+                proficiencies = emptyList(),
+                proficiencyChoices = emptyList(),
+                savingThrows = emptyList(),
+                spellcasting = null,
+                startingEquipment = null,
+                subclasses = emptyList(),
+                levels = listOf(
+                    ClassLevel(
+                        id = "fighter-1",
+                        level = 1,
+                        features = emptyList(),
                     ),
                 ),
-            ),
-            spells = emptyList(),
-            selection = selection,
-        )
+            )
+            val background = Background(
+                id = "acolyte",
+                name = "Acolyte",
+                feature = GenericInfo(name = "Shelter of the Faithful", desc = emptyList()),
+                effects = emptyList(),
+            )
 
-        val sheet = vm.buildCharacterSheet(content)
+            val selection = GuidedSelection(
+                classId = fighter.id,
+                subclassId = null,
+                raceId = dwarf.id,
+                subraceId = null,
+                backgroundId = background.id,
+                abilityMethod = AbilityScoreMethod.POINT_BUY,
+                standardArrayAssignments = defaultStandardArrayAssignments(),
+                pointBuyScores = AbilityIds.standardOrder.associateWith { 10 },
+                choiceSelections = emptyMap(),
+            )
+            val content = buildContent(
+                name = "Test",
+                classes = listOf(fighter),
+                races = listOf(dwarf),
+                backgrounds = listOf(background),
+                traits = listOf(toughTrait),
+                features = emptyList(),
+                spells = emptyList(),
+                selection = selection,
+            )
 
-        val stealth = sheet.skills.first { it.skill == Skill.STEALTH }
-        assertThat(stealth.expertise).isTrue()
-        assertThat(stealth.proficient).isTrue()
-        assertThat(stealth.bonus).isEqualTo(4)
+            // When
+            val sheet = vm.buildCharacterSheet(content)
 
-        val perception = sheet.skills.first { it.skill == Skill.PERCEPTION }
-        assertThat(perception.expertise).isTrue()
-        assertThat(perception.proficient).isTrue()
-        assertThat(perception.bonus).isEqualTo(4)
-    }
+            // Then
+            // Base HP at level 1: hit die + CON mod (0) = 8, plus racial bonus +1.
+            assertThat(sheet.maxHitPoints).isEqualTo(9)
+        }
 
     @Test
-    fun `validate should surface required selections and ability method`() = runTest(mainDispatcherRule.dispatcher) {
-        val vm = buildViewModel()
+    fun `buildCharacterSheet should mark expertise when expertise skills are selected`() =
+        runTest(mainDispatcherRule.dispatcher) {
+            // Given
+            val vm = buildViewModel()
 
-        val content = buildContent(
-            name = "",
-            classes = emptyList(),
-            races = emptyList(),
-            backgrounds = emptyList(),
-            traits = emptyList(),
-            features = emptyList(),
-            spells = emptyList(),
-            selection = GuidedSelection(
-                classId = null,
+            val rogue = CharacterClass(
+                id = "rogue",
+                name = "Rogue",
+                hitDie = 8,
+                proficiencies = emptyList(),
+                proficiencyChoices = emptyList(),
+                savingThrows = emptyList(),
+                spellcasting = null,
+                startingEquipment = null,
+                subclasses = emptyList(),
+                levels = listOf(
+                    ClassLevel(
+                        id = "rogue-1",
+                        level = 1,
+                        features = emptyList(),
+                    ),
+                ),
+            )
+            val human = Race(
+                id = "human",
+                name = "Human",
+                traits = emptyList(),
+                subraces = emptyList(),
+            )
+            val background = Background(
+                id = "criminal",
+                name = "Criminal",
+                feature = GenericInfo(name = "Criminal Contact", desc = emptyList()),
+                effects = emptyList(),
+            )
+
+            val choiceKey = GuidedCharacterSetupViewModel.featureChoiceKey("rogue-expertise-1")
+            val selection = GuidedSelection(
+                classId = rogue.id,
                 subclassId = null,
-                raceId = null,
+                raceId = human.id,
                 subraceId = null,
-                backgroundId = null,
-                abilityMethod = null,
+                backgroundId = background.id,
+                abilityMethod = AbilityScoreMethod.POINT_BUY,
                 standardArrayAssignments = defaultStandardArrayAssignments(),
-                pointBuyScores = defaultPointBuyScores(),
-                choiceSelections = emptyMap(),
-            ),
-        )
+                pointBuyScores = AbilityIds.standardOrder.associateWith { 10 },
+                choiceSelections = mapOf(
+                    choiceKey to setOf("skill-stealth", "skill-perception"),
+                ),
+            )
 
-        val result = vm.validate(content)
+            val content = buildContent(
+                name = "Sneaky",
+                classes = listOf(rogue),
+                races = listOf(human),
+                backgrounds = listOf(background),
+                traits = emptyList(),
+                features = listOf(
+                    Feature(
+                        id = "rogue-expertise-1",
+                        name = "Expertise",
+                        desc = emptyList(),
+                        choice = Choice.ProficiencyChoice(
+                            choose = 2,
+                            from = listOf("skill-stealth", "skill-perception"),
+                        ),
+                    ),
+                ),
+                spells = emptyList(),
+                selection = selection,
+            )
 
-        assertThat(result.hasErrors).isTrue()
-        assertThat(result.issues.map { it.message }).containsAtLeast(
-            "Choose a class.",
-            "Choose a race.",
-            "Choose a background.",
-            "Choose an ability score method.",
-        )
-    }
+            // When
+            val sheet = vm.buildCharacterSheet(content)
+
+            // Then
+            val stealth = sheet.skills.first { it.skill == Skill.STEALTH }
+            assertThat(stealth.expertise).isTrue()
+            assertThat(stealth.proficient).isTrue()
+            assertThat(stealth.bonus).isEqualTo(4)
+
+            val perception = sheet.skills.first { it.skill == Skill.PERCEPTION }
+            assertThat(perception.expertise).isTrue()
+            assertThat(perception.proficient).isTrue()
+            assertThat(perception.bonus).isEqualTo(4)
+        }
+
+    @Test
+    fun `validate should surface required selections when core setup is empty`() =
+        runTest(mainDispatcherRule.dispatcher) {
+            // Given
+            val vm = buildViewModel()
+
+            val content = buildContent(
+                name = "",
+                classes = emptyList(),
+                races = emptyList(),
+                backgrounds = emptyList(),
+                traits = emptyList(),
+                features = emptyList(),
+                spells = emptyList(),
+                selection = GuidedSelection(
+                    classId = null,
+                    subclassId = null,
+                    raceId = null,
+                    subraceId = null,
+                    backgroundId = null,
+                    abilityMethod = null,
+                    standardArrayAssignments = defaultStandardArrayAssignments(),
+                    pointBuyScores = defaultPointBuyScores(),
+                    choiceSelections = emptyMap(),
+                ),
+            )
+
+            // When
+            val result = vm.validate(content)
+
+            // Then
+            assertThat(result.hasErrors).isTrue()
+            assertThat(result.issues.map { it.message }).containsAtLeast(
+                "Choose a class.",
+                "Choose a race.",
+                "Choose a background.",
+                "Choose an ability score method.",
+            )
+        }
 
     @Test
     fun `validate should fail when point buy exceeds budget`() = runTest(mainDispatcherRule.dispatcher) {
+        // Given
         val vm = buildViewModel()
 
         val fighter = CharacterClass(
@@ -278,14 +293,17 @@ class GuidedCharacterSetupSheetBuilderTest {
             ),
         )
 
+        // When
         val result = vm.validate(content)
 
+        // Then
         assertThat(result.hasErrors).isTrue()
         assertThat(result.issues.map { it.message }).contains("Point buy exceeds 27 points.")
     }
 
     @Test
     fun `validate should fail when standard array assignments are invalid`() = runTest(mainDispatcherRule.dispatcher) {
+        // Given
         val vm = buildViewModel()
 
         val fighter = CharacterClass(
@@ -333,8 +351,10 @@ class GuidedCharacterSetupSheetBuilderTest {
             ),
         )
 
+        // When
         val result = vm.validate(content)
 
+        // Then
         assertThat(result.hasErrors).isTrue()
         assertThat(result.issues.map { it.message }).contains(
             "Assign all ability scores using the standard array (15, 14, 13, 12, 10, 8).",

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/character/guided/GuidedCharacterSetupViewModelTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/character/guided/GuidedCharacterSetupViewModelTest.kt
@@ -27,7 +27,7 @@ class GuidedCharacterSetupViewModelTest {
     val mainDispatcherRule = MainDispatcherRule()
 
     @Test
-    fun `dispatch should update name in content state`() =
+    fun `dispatch should update name in content state when name changes`() =
         runTest(mainDispatcherRule.dispatcher) {
             // Given
             val observeClasses = mockk<ObserveAllCharacterClassesUseCase>()

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/character/guided/components/race/RaceSummaryUiModelTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/character/guided/components/race/RaceSummaryUiModelTest.kt
@@ -11,7 +11,8 @@ import org.junit.Test
 class RaceSummaryUiModelTest {
 
     @Test
-    fun `summary resolves structured mechanics and counts deferred choices`() {
+    fun `raceSummaryUiModel should resolve mechanics and deferred choices when subrace is selected`() {
+        // Given
         val race = race()
         val traits = mapOf(
             "ability-score-increase-test" to trait(
@@ -53,12 +54,14 @@ class RaceSummaryUiModelTest {
             ),
         )
 
+        // When
         val result = raceSummaryUiModel(
             race = race,
             traitsById = traits,
             selectedSubraceId = "scholar-test",
         )
 
+        // Then
         assertThat(result.name).isEqualTo("Testfolk")
         assertThat(result.selectedSubraceName).isEqualTo("Scholar Testfolk")
         assertThat(result.size).isEqualTo("Medium")
@@ -73,7 +76,8 @@ class RaceSummaryUiModelTest {
     }
 
     @Test
-    fun `summary excludes subrace traits until that subrace is selected`() {
+    fun `raceSummaryUiModel should exclude subrace traits when subrace is not selected`() {
+        // Given
         val race = race()
         val subraceTrait = trait(
             id = "subrace-magic-test",
@@ -81,25 +85,32 @@ class RaceSummaryUiModelTest {
             spellChoice = Choice.OptionsArrayChoice(choose = 1, from = listOf("light")),
         )
 
+        // When
         val result = raceSummaryUiModel(
             race = race,
             traitsById = mapOf("subrace-magic-test" to subraceTrait),
             selectedSubraceId = null,
         )
 
+        // Then
         assertThat(result.selectedSubraceName).isNull()
         assertThat(result.traitDetails).isEmpty()
         assertThat(result.deferredChoices).isEmpty()
     }
 
     @Test
-    fun `summary ignores missing trait references without inventing mechanics`() {
+    fun `raceSummaryUiModel should omit mechanics when trait references are missing`() {
+        // Given
+        val race = race()
+
+        // When
         val result = raceSummaryUiModel(
-            race = race(),
+            race = race,
             traitsById = emptyMap(),
             selectedSubraceId = "unknown-subrace",
         )
 
+        // Then
         assertThat(result.size).isNull()
         assertThat(result.speedFeet).isNull()
         assertThat(result.abilityBonuses).isEmpty()

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/character/guided/internal/GuidedChoiceRequirementsTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/character/guided/internal/GuidedChoiceRequirementsTest.kt
@@ -18,7 +18,8 @@ import org.junit.Test
 class GuidedChoiceRequirementsTest {
 
     @Test
-    fun `class proficiency choices use stable keys and resolved skill names`() {
+    fun `deriveGuidedChoiceRequirements should resolve skills when class has proficiency choice`() {
+        // Given
         val clazz = characterClass(
             id = "rogue",
             name = "Rogue",
@@ -36,6 +37,7 @@ class GuidedChoiceRequirementsTest {
             ),
         )
 
+        // When
         val result = deriveGuidedChoiceRequirements(
             GuidedChoiceContext(
                 selection = selection,
@@ -43,6 +45,7 @@ class GuidedChoiceRequirementsTest {
             )
         )
 
+        // Then
         assertThat(result.requirements).hasSize(1)
         with(result.requirements.single()) {
             assertThat(key).isEqualTo("class/proficiency/0")
@@ -59,7 +62,8 @@ class GuidedChoiceRequirementsTest {
     }
 
     @Test
-    fun `race traits expose fixed grants and selectable proficiency and language conflicts`() {
+    fun `deriveGuidedChoiceRequirements should expose grants and conflicts when race trait has choices`() {
+        // Given
         val trait = Trait(
             id = "elf-training",
             name = "Elf Training",
@@ -80,6 +84,7 @@ class GuidedChoiceRequirementsTest {
             traitIds = listOf(trait.id),
         )
 
+        // When
         val result = deriveGuidedChoiceRequirements(
             GuidedChoiceContext(
                 selection = selection(raceId = race.id),
@@ -92,6 +97,7 @@ class GuidedChoiceRequirementsTest {
             )
         )
 
+        // Then
         assertThat(result.fixedGrants.map { it.optionId }).containsExactly(
             "skill-perception",
             "common",
@@ -115,7 +121,8 @@ class GuidedChoiceRequirementsTest {
     }
 
     @Test
-    fun `background exposes fixed grants and language and equipment requirements`() {
+    fun `deriveGuidedChoiceRequirements should expose grants and requirements when background has choices`() {
+        // Given
         val background = background(
             id = "artisan",
             name = "Guild Artisan",
@@ -130,6 +137,7 @@ class GuidedChoiceRequirementsTest {
             ),
         )
 
+        // When
         val result = deriveGuidedChoiceRequirements(
             GuidedChoiceContext(
                 selection = selection(backgroundId = background.id),
@@ -141,6 +149,7 @@ class GuidedChoiceRequirementsTest {
             )
         )
 
+        // Then
         assertThat(result.fixedGrants.map { it.optionId }).containsExactly(
             "skill-insight",
             "common",
@@ -156,7 +165,8 @@ class GuidedChoiceRequirementsTest {
     }
 
     @Test
-    fun `nested background equipment is expanded without flattening child limits`() {
+    fun `deriveGuidedChoiceRequirements should preserve child limits when background equipment choice is nested`() {
+        // Given
         val background = background(
             id = "soldier",
             name = "Soldier",
@@ -170,6 +180,7 @@ class GuidedChoiceRequirementsTest {
             ),
         )
 
+        // When
         val result = deriveGuidedChoiceRequirements(
             GuidedChoiceContext(
                 selection = selection(
@@ -180,6 +191,7 @@ class GuidedChoiceRequirementsTest {
             )
         )
 
+        // Then
         assertThat(result.requirements.map { it.key }).containsExactly(
             "background/equipment/0",
             "background/equipment/1",
@@ -193,7 +205,8 @@ class GuidedChoiceRequirementsTest {
     }
 
     @Test
-    fun `duplicate grants and selections retain every source in deterministic reasons`() {
+    fun `deriveGuidedChoiceRequirements should retain deterministic sources when grants and selections overlap`() {
+        // Given
         val clazz = characterClass(
             id = "ranger",
             name = "Ranger",
@@ -225,6 +238,7 @@ class GuidedChoiceRequirementsTest {
         val raceLanguageKey = GuidedCharacterSetupViewModel.raceTraitLanguageChoiceKey(trait.id)
         val backgroundLanguageKey = GuidedCharacterSetupViewModel.backgroundLanguageChoiceKey()
 
+        // When
         val result = deriveGuidedChoiceRequirements(
             GuidedChoiceContext(
                 selection = selection(
@@ -247,6 +261,7 @@ class GuidedChoiceRequirementsTest {
             )
         )
 
+        // Then
         assertThat(result.fixedGrants.filter { it.optionId == "skill-survival" }.map { it.sourceLabel })
             .containsExactly(
                 "Class: Ranger",
@@ -269,7 +284,8 @@ class GuidedChoiceRequirementsTest {
     }
 
     @Test
-    fun `only traits from the selected subrace are active`() {
+    fun `deriveGuidedChoiceRequirements should include only active traits when subrace is selected`() {
+        // Given
         val baseTrait = Trait(
             id = "base-choice",
             name = "Base Choice",
@@ -298,6 +314,7 @@ class GuidedChoiceRequirementsTest {
             ),
         )
 
+        // When
         val result = deriveGuidedChoiceRequirements(
             GuidedChoiceContext(
                 selection = selection(raceId = race.id, subraceId = "high-elf"),
@@ -306,6 +323,7 @@ class GuidedChoiceRequirementsTest {
             )
         )
 
+        // Then
         assertThat(result.requirements.map { it.sourceId }).containsExactly(
             baseTrait.id,
             highTrait.id,
@@ -316,7 +334,8 @@ class GuidedChoiceRequirementsTest {
     }
 
     @Test
-    fun `ability draconic ancestry and racial spell choices are classified as ancestry`() {
+    fun `deriveGuidedChoiceRequirements should classify ancestry choices when race trait provides them`() {
+        // Given
         val trait = Trait(
             id = "lineage-choices",
             name = "Lineage Choices",
@@ -341,6 +360,7 @@ class GuidedChoiceRequirementsTest {
         )
         val race = race("dragonborn", "Dragonborn", listOf(trait.id))
 
+        // When
         val result = deriveGuidedChoiceRequirements(
             GuidedChoiceContext(
                 selection = selection(raceId = race.id),
@@ -352,6 +372,7 @@ class GuidedChoiceRequirementsTest {
             )
         )
 
+        // Then
         assertThat(result.requirements).hasSize(3)
         assertThat(result.requirements.map { it.category }.distinct())
             .containsExactly(GuidedChoiceCategory.ANCESTRY)

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/character/guided/internal/GuidedSetupStepPlannerTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/character/guided/internal/GuidedSetupStepPlannerTest.kt
@@ -11,13 +11,18 @@ import org.junit.Test
 class GuidedSetupStepPlannerTest {
 
     @Test
-    fun `planner omits empty conditional choice steps`() {
+    fun `computeGuidedSetupSteps should omit conditional steps when choices are empty`() {
+        // Given
+        val choiceRequirements = GuidedChoiceRequirements(emptyList(), emptyList())
+
+        // When
         val steps = computeGuidedSetupSteps(
             selectedClass = null,
             featuresById = emptyMap(),
-            choiceRequirements = GuidedChoiceRequirements(emptyList(), emptyList()),
+            choiceRequirements = choiceRequirements,
         )
 
+        // Then
         assertThat(steps).containsExactly(
             GuidedStep.BASICS,
             GuidedStep.CLASS,
@@ -31,7 +36,8 @@ class GuidedSetupStepPlannerTest {
     }
 
     @Test
-    fun `planner places ancestry and proficiencies in target order`() {
+    fun `computeGuidedSetupSteps should order ancestry before proficiencies when both choices exist`() {
+        // Given
         val ancestry = requirement(
             key = "race/trait/ancestry",
             category = GuidedChoiceCategory.ANCESTRY,
@@ -41,6 +47,7 @@ class GuidedSetupStepPlannerTest {
             category = GuidedChoiceCategory.LANGUAGE,
         )
 
+        // When
         val steps = computeGuidedSetupSteps(
             selectedClass = null,
             featuresById = emptyMap(),
@@ -50,6 +57,7 @@ class GuidedSetupStepPlannerTest {
             ),
         )
 
+        // Then
         assertThat(steps).containsExactly(
             GuidedStep.BASICS,
             GuidedStep.CLASS,
@@ -65,7 +73,8 @@ class GuidedSetupStepPlannerTest {
     }
 
     @Test
-    fun `fixed grant retains proficiencies step without selectable requirements`() {
+    fun `computeGuidedSetupSteps should retain proficiencies step when only fixed grant exists`() {
+        // Given
         val grant = GuidedFixedGrant(
             optionId = "skill-perception",
             displayName = "Perception",
@@ -75,17 +84,20 @@ class GuidedSetupStepPlannerTest {
             sourceLabel = "Class: Fighter",
         )
 
+        // When
         val steps = computeGuidedSetupSteps(
             selectedClass = null,
             featuresById = emptyMap(),
             choiceRequirements = GuidedChoiceRequirements(emptyList(), listOf(grant)),
         )
 
+        // Then
         assertThat(steps).contains(GuidedStep.PROFICIENCIES_LANGUAGES)
     }
 
     @Test
-    fun `level one spellcaster with class choice gets both conditional steps`() {
+    fun `computeGuidedSetupSteps should include class and spell steps when class is level one spellcaster`() {
+        // Given
         val cleric = CharacterClass(
             id = "cleric",
             name = "Cleric",
@@ -102,12 +114,14 @@ class GuidedSetupStepPlannerTest {
             levels = emptyList(),
         )
 
+        // When
         val steps = computeGuidedSetupSteps(
             selectedClass = cleric,
             featuresById = emptyMap(),
             choiceRequirements = GuidedChoiceRequirements(emptyList(), emptyList()),
         )
 
+        // Then
         assertThat(steps).contains(GuidedStep.CLASS_CHOICES)
         assertThat(steps).contains(GuidedStep.SPELLS)
         assertThat(steps.indexOf(GuidedStep.CLASS_CHOICES)).isLessThan(steps.indexOf(GuidedStep.RACE))
@@ -115,7 +129,8 @@ class GuidedSetupStepPlannerTest {
     }
 
     @Test
-    fun `removed conditional destination resolves to closest preceding step`() {
+    fun `resolveGuidedSetupStep should return closest preceding step when destination was removed`() {
+        // Given
         val availableSteps = listOf(
             GuidedStep.BASICS,
             GuidedStep.CLASS,
@@ -127,12 +142,13 @@ class GuidedSetupStepPlannerTest {
             GuidedStep.REVIEW,
         )
 
-        assertThat(
-            resolveGuidedSetupStep(GuidedStep.ANCESTRY_CHOICES, availableSteps),
-        ).isEqualTo(GuidedStep.ABILITY_ASSIGN)
-        assertThat(
-            resolveGuidedSetupStep(GuidedStep.PROFICIENCIES_LANGUAGES, availableSteps),
-        ).isEqualTo(GuidedStep.ABILITY_ASSIGN)
+        // When
+        val ancestryDestination = resolveGuidedSetupStep(GuidedStep.ANCESTRY_CHOICES, availableSteps)
+        val proficienciesDestination = resolveGuidedSetupStep(GuidedStep.PROFICIENCIES_LANGUAGES, availableSteps)
+
+        // Then
+        assertThat(ancestryDestination).isEqualTo(GuidedStep.ABILITY_ASSIGN)
+        assertThat(proficienciesDestination).isEqualTo(GuidedStep.ABILITY_ASSIGN)
     }
 
     private fun requirement(

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/character/guided/internal/GuidedSetupValidationTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/character/guided/internal/GuidedSetupValidationTest.kt
@@ -11,7 +11,8 @@ import org.junit.Test
 class GuidedSetupValidationTest {
 
     @Test
-    fun `race completeness requires a valid subrace but ignores moved trait choices`() {
+    fun `isGuidedRaceSelectionComplete should require valid subrace when race has subraces`() {
+        // Given
         val race = Race(
             id = "elf",
             name = "Elf",
@@ -26,26 +27,28 @@ class GuidedSetupValidationTest {
             ),
         )
 
-        assertThat(
-            isGuidedRaceSelectionComplete(
-                selection = selection(
-                    raceId = race.id,
-                    subraceId = "high-elf",
-                    choiceSelections = emptyMap(),
-                ),
-                races = listOf(race),
+        // When
+        val validResult = isGuidedRaceSelectionComplete(
+            selection = selection(
+                raceId = race.id,
+                subraceId = "high-elf",
+                choiceSelections = emptyMap(),
             ),
-        ).isTrue()
-        assertThat(
-            isGuidedRaceSelectionComplete(
-                selection = selection(raceId = race.id, subraceId = "wood-elf"),
-                races = listOf(race),
-            ),
-        ).isFalse()
+            races = listOf(race),
+        )
+        val invalidResult = isGuidedRaceSelectionComplete(
+            selection = selection(raceId = race.id, subraceId = "wood-elf"),
+            races = listOf(race),
+        )
+
+        // Then
+        assertThat(validResult).isTrue()
+        assertThat(invalidResult).isFalse()
     }
 
     @Test
-    fun `requirement is complete only with exact legal non-disabled selections`() {
+    fun `isRequirementComplete should accept only exact legal selections when options can be disabled`() {
+        // Given
         val requirement = requirement(
             key = "class/proficiency/0",
             category = GuidedChoiceCategory.PROFICIENCY,
@@ -54,14 +57,22 @@ class GuidedSetupValidationTest {
             disabledOptions = mapOf("history" to "Granted by Race trait: Training"),
         )
 
-        assertThat(isRequirementComplete(requirement, mapOf(requirement.key to setOf("arcana")))).isTrue()
-        assertThat(isRequirementComplete(requirement, emptyMap())).isFalse()
-        assertThat(isRequirementComplete(requirement, mapOf(requirement.key to setOf("history")))).isFalse()
-        assertThat(isRequirementComplete(requirement, mapOf(requirement.key to setOf("unknown")))).isFalse()
+        // When
+        val legalResult = isRequirementComplete(requirement, mapOf(requirement.key to setOf("arcana")))
+        val emptyResult = isRequirementComplete(requirement, emptyMap())
+        val disabledResult = isRequirementComplete(requirement, mapOf(requirement.key to setOf("history")))
+        val unknownResult = isRequirementComplete(requirement, mapOf(requirement.key to setOf("unknown")))
+
+        // Then
+        assertThat(legalResult).isTrue()
+        assertThat(emptyResult).isFalse()
+        assertThat(disabledResult).isFalse()
+        assertThat(unknownResult).isFalse()
     }
 
     @Test
-    fun `first incomplete requirement and owner step use canonical categories`() {
+    fun `firstIncompleteRequirement should return matching incomplete requirement when earlier choice is complete`() {
+        // Given
         val completed = requirement(
             key = "race/trait/training/proficiency",
             category = GuidedChoiceCategory.PROFICIENCY,
@@ -74,23 +85,40 @@ class GuidedSetupValidationTest {
         )
         val selections = mapOf(completed.key to setOf("arcana"))
 
-        assertThat(
-            firstIncompleteRequirement(
-                requirements = listOf(completed, incomplete),
-                category = GuidedChoiceCategory.LANGUAGE,
-                selections = selections,
-            ),
-        ).isEqualTo(incomplete)
-        assertThat(guidedStepForChoiceCategory(GuidedChoiceCategory.LANGUAGE))
-            .isEqualTo(GuidedStep.PROFICIENCIES_LANGUAGES)
-        assertThat(guidedStepForChoiceCategory(GuidedChoiceCategory.ANCESTRY))
-            .isEqualTo(GuidedStep.ANCESTRY_CHOICES)
-        assertThat(guidedStepForChoiceCategory(GuidedChoiceCategory.EQUIPMENT))
-            .isEqualTo(GuidedStep.EQUIPMENT)
+        // When
+        val result = firstIncompleteRequirement(
+            requirements = listOf(completed, incomplete),
+            category = GuidedChoiceCategory.LANGUAGE,
+            selections = selections,
+        )
+
+        // Then
+        assertThat(result).isEqualTo(incomplete)
     }
 
     @Test
-    fun `reconciliation removes inactive keys but preserves legal active selections`() {
+    fun `guidedStepForChoiceCategory should return owner step when category is canonical`() {
+        // Given
+        val categories = listOf(
+            GuidedChoiceCategory.LANGUAGE,
+            GuidedChoiceCategory.ANCESTRY,
+            GuidedChoiceCategory.EQUIPMENT,
+        )
+
+        // When
+        val results = categories.map(::guidedStepForChoiceCategory)
+
+        // Then
+        assertThat(results).containsExactly(
+            GuidedStep.PROFICIENCIES_LANGUAGES,
+            GuidedStep.ANCESTRY_CHOICES,
+            GuidedStep.EQUIPMENT,
+        ).inOrder()
+    }
+
+    @Test
+    fun `reconcileGuidedChoiceSelections should remove inactive keys when active selections are legal`() {
+        // Given
         val retained = requirement(
             key = "race/trait/training/proficiency",
             category = GuidedChoiceCategory.PROFICIENCY,
@@ -102,12 +130,14 @@ class GuidedSetupValidationTest {
             "spells/cantrips" to setOf("fire-bolt"),
         )
 
+        // When
         val reconciled = reconcileGuidedChoiceSelections(
             choiceSelections = selections,
             choiceRequirements = GuidedChoiceRequirements(listOf(retained), emptyList()),
             additionalActiveKeys = setOf("spells/cantrips"),
         )
 
+        // Then
         assertThat(reconciled).containsExactly(
             retained.key, setOf("history"),
             "spells/cantrips", setOf("fire-bolt"),
@@ -115,7 +145,8 @@ class GuidedSetupValidationTest {
     }
 
     @Test
-    fun `reconciliation removes illegal and fixed duplicate options deterministically`() {
+    fun `reconcileGuidedChoiceSelections should remove illegal duplicates when fixed grants conflict`() {
+        // Given
         val first = requirement(
             key = "class/proficiency/0",
             category = GuidedChoiceCategory.PROFICIENCY,
@@ -136,6 +167,7 @@ class GuidedSetupValidationTest {
             sourceLabel = "Background: Sage",
         )
 
+        // When
         val reconciled = reconcileGuidedChoiceSelections(
             choiceSelections = mapOf(
                 first.key to setOf("arcana", "history", "not-an-option"),
@@ -147,23 +179,27 @@ class GuidedSetupValidationTest {
             ),
         )
 
+        // Then
         assertThat(reconciled[first.key]).containsExactly("arcana")
         assertThat(reconciled).doesNotContainKey(second.key)
     }
 
     @Test
-    fun `reconciliation preserves active selection while options are not loaded yet`() {
+    fun `reconcileGuidedChoiceSelections should preserve active selection when options are not loaded`() {
+        // Given
         val racialSpell = requirement(
             key = "race/trait/high-elf-cantrip/spell",
             category = GuidedChoiceCategory.ANCESTRY,
             options = emptyList(),
         )
 
+        // When
         val reconciled = reconcileGuidedChoiceSelections(
             choiceSelections = mapOf(racialSpell.key to setOf("minor-illusion")),
             choiceRequirements = GuidedChoiceRequirements(listOf(racialSpell), emptyList()),
         )
 
+        // Then
         assertThat(reconciled[racialSpell.key]).containsExactly("minor-illusion")
     }
 

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/character/sheet/CharacterSheetViewModelTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/character/sheet/CharacterSheetViewModelTest.kt
@@ -32,7 +32,8 @@ class CharacterSheetViewModelTest {
     val mainDispatcherRule = MainDispatcherRule()
 
     @Test
-    fun `persist should debounce consecutive updates and save latest sheet only`() = runTest {
+    fun `adjustCurrentHp should save latest sheet once when updates occur within debounce window`() = runTest {
+        // Given
         val saveCharacterSheetUseCase = mockk<SaveCharacterSheetUseCase>()
         coEvery { saveCharacterSheetUseCase(any()) } returns Unit
         val initialSheet = CharacterSheet(
@@ -49,6 +50,7 @@ class CharacterSheetViewModelTest {
 
         advanceUntilIdle()
 
+        // When
         vm.adjustCurrentHp(-1)
         vm.adjustCurrentHp(-1)
         vm.adjustCurrentHp(+1)
@@ -60,20 +62,24 @@ class CharacterSheetViewModelTest {
         advanceTimeBy(1)
         advanceUntilIdle()
 
+        // Then
         val captured = mutableListOf<CharacterSheet>()
         coVerify(exactly = 1) { saveCharacterSheetUseCase(capture(captured)) }
         assertThat(captured.single().currentHitPoints).isEqualTo(4)
     }
 
     @Test
-    fun `weapon catalog failure should be exposed in ui state error message`() = runTest {
+    fun `uiState should expose error message when weapon catalog loading fails`() = runTest {
+        // Given
         val vm = createViewModel(
             initialSheet = CharacterSheet(id = TEST_CHARACTER_ID),
             weaponCatalogState = Loadable.Failure(errorMessage = "boom"),
         )
 
+        // When
         advanceUntilIdle()
 
+        // Then
         val state = vm.uiState.value as CharacterSheetUiState.Content
         assertThat(state.errorMessage).isEqualTo("Unable to load weapon catalog")
     }

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/character/sheet/SpellsTabStateMapperTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/character/sheet/SpellsTabStateMapperTest.kt
@@ -11,16 +11,20 @@ import org.junit.Test
 class SpellsTabStateMapperTest {
 
     @Test
-    fun `toSpellsState marks shared slots unconfigured when totals are zero`() {
+    fun `toSpellsState should mark shared slots unconfigured when totals are zero`() {
+        // Given
         val sheet = CharacterSheet(id = "test")
 
+        // When
         val state = sheet.toSpellsState(allSpells = emptyList(), spellcastingClasses = emptyList())
 
+        // Then
         assertThat(state.hasConfiguredSharedSlots).isFalse()
     }
 
     @Test
-    fun `toSpellsState exposes pact slots when warlock spells exist`() {
+    fun `toSpellsState should expose unconfigured pact slots when warlock spells exist`() {
+        // Given
         val sheet = CharacterSheet(
             id = "test",
             characterSpells = listOf(CharacterSpell(spellId = "eldritch-blast", sourceClass = "Warlock")),
@@ -43,8 +47,10 @@ class SpellsTabStateMapperTest {
             levels = emptyList(),
         )
 
+        // When
         val state = sheet.toSpellsState(allSpells = emptyList(), spellcastingClasses = listOf(warlockClass))
 
+        // Then
         assertThat(state.pactSlots).isNotNull()
         assertThat(state.pactSlots?.isConfigured).isFalse()
     }

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/character/sheet/components/tabs/spells/SpellsTabFilteringTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/character/sheet/components/tabs/spells/SpellsTabFilteringTest.kt
@@ -8,21 +8,40 @@ import org.junit.Test
 class SpellsTabFilteringTest {
 
     @Test
-    fun `parseCastingTimeFilter maps action`() {
-        assertThat(parseCastingTimeFilter("Action")).isEqualTo(CastingTimeFilter.Action)
-        assertThat(parseCastingTimeFilter("1 action")).isEqualTo(CastingTimeFilter.Action)
-        assertThat(parseCastingTimeFilter("Cast")).isEqualTo(CastingTimeFilter.Action)
+    fun `parseCastingTimeFilter should return action when text uses action aliases`() {
+        // Given
+        val values = listOf("Action", "1 action", "Cast")
+
+        // When
+        val results = values.map(::parseCastingTimeFilter)
+
+        // Then
+        assertThat(results).containsExactly(
+            CastingTimeFilter.Action,
+            CastingTimeFilter.Action,
+            CastingTimeFilter.Action,
+        ).inOrder()
     }
 
     @Test
-    fun `parseCastingTimeFilter maps bonus and reaction`() {
-        assertThat(parseCastingTimeFilter("Bonus Action")).isEqualTo(CastingTimeFilter.Bonus)
-        assertThat(parseCastingTimeFilter("1 bonus action")).isEqualTo(CastingTimeFilter.Bonus)
-        assertThat(parseCastingTimeFilter("Reaction")).isEqualTo(CastingTimeFilter.Reaction)
+    fun `parseCastingTimeFilter should return bonus or reaction when text names those timings`() {
+        // Given
+        val values = listOf("Bonus Action", "1 bonus action", "Reaction")
+
+        // When
+        val results = values.map(::parseCastingTimeFilter)
+
+        // Then
+        assertThat(results).containsExactly(
+            CastingTimeFilter.Bonus,
+            CastingTimeFilter.Bonus,
+            CastingTimeFilter.Reaction,
+        ).inOrder()
     }
 
     @Test
-    fun `filterAndSortSpellLevels filters by casting time and tags`() {
+    fun `filterAndSortSpellLevels should retain matching spell when casting time and tags are selected`() {
+        // Given
         val spells = listOf(
             spell(name = "A", level = 0, castingTime = "Action", concentration = false, ritual = false),
             spell(name = "B", level = 1, castingTime = "Bonus Action", concentration = true, ritual = false),
@@ -33,6 +52,7 @@ class SpellsTabFilteringTest {
             SpellLevelUiModel(level = 1, spells = spells.filter { it.level == 1 }),
         )
 
+        // When
         val result = filterAndSortSpellLevels(
             spellLevels = levels,
             castingTime = CastingTimeFilter.Reaction,
@@ -41,13 +61,15 @@ class SpellsTabFilteringTest {
             sort = SpellSort.Level,
         )
 
+        // Then
         assertThat(result).hasSize(1)
         assertThat(result.single().level).isEqualTo(1)
         assertThat(result.single().spells.map { it.name }).containsExactly("C")
     }
 
     @Test
-    fun `filterAndSortSpellLevels sorts by level then name`() {
+    fun `filterAndSortSpellLevels should sort by level then name when level sort is selected`() {
+        // Given
         val spells = listOf(
             spell(name = "Zeta", level = 1, castingTime = "Action", concentration = false, ritual = false),
             spell(name = "Alpha", level = 0, castingTime = "Action", concentration = false, ritual = false),
@@ -58,6 +80,7 @@ class SpellsTabFilteringTest {
             SpellLevelUiModel(level = 1, spells = spells.filter { it.level == 1 }),
         )
 
+        // When
         val result = filterAndSortSpellLevels(
             spellLevels = levels,
             castingTime = null,
@@ -66,6 +89,7 @@ class SpellsTabFilteringTest {
             sort = SpellSort.Level,
         )
 
+        // Then
         assertThat(result.map { it.level }).containsExactly(0, 1).inOrder()
         assertThat(result.first().spells.map { it.name }).containsExactly("Alpha")
         assertThat(result[1].spells.map { it.name }).containsExactly("Beta", "Zeta").inOrder()
@@ -94,4 +118,3 @@ class SpellsTabFilteringTest {
         )
     }
 }
-

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/character/spellpicker/CharacterSpellPickerViewModelTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/character/spellpicker/CharacterSpellPickerViewModelTest.kt
@@ -24,7 +24,7 @@ class CharacterSpellPickerViewModelTest {
     val mainDispatcherRule = MainDispatcherRule()
 
     @Test
-    fun `dispatch should update query and favorites filter`() =
+    fun `dispatch should update query and favorites filter when matching intents arrive`() =
         runTest(mainDispatcherRule.dispatcher) {
             // Given
             val observeCharacterSheet = mockk<ObserveCharacterSheetUseCase>()

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/dice/DiceRollerViewModelTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/dice/DiceRollerViewModelTest.kt
@@ -7,7 +7,7 @@ import org.junit.Test
 class DiceRollerViewModelTest {
 
     @Test
-    fun `dispatch should toggle check section`() {
+    fun `dispatch should toggle check section when toggle check intent arrives`() {
         // Given
         val vm = DiceRollerViewModel()
 

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/utils/AbilityScoreUtilsTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/utils/AbilityScoreUtilsTest.kt
@@ -18,7 +18,7 @@ class AbilityScoreUtilsTest {
     }
 
     @Test
-    fun `standardArray should return canonical six values`() {
+    fun `standardArray should return canonical six values when invoked`() {
         // Given
         val expected = listOf(15, 14, 13, 12, 10, 8)
 


### PR DESCRIPTION
## Summary

- standardize all active Kotlin tests on the required `{function} should {expected behavior} when {context}` naming convention
- add exactly one `Given`, `When`, and `Then` section to each test
- replace generic test entry-point names with the observable function or composable under test
- split mixed-behavior coverage, remove obsolete commented-out tests, and remove a duplicate assertion
- bring changed test code within the repository's 120-character line limit

## Why

The test suite had accumulated tests written before the repository's current mandatory Kotlin testing format. This made naming and structure inconsistent across JVM and instrumentation tests and left some tests covering more than one behavior.

These changes make the suite easier to scan and maintain without changing production behavior.

## Validation

- structural audit: 180 active tests across 67 Kotlin test files, 0 naming or section violations
- `git diff --check`
- repository-wide test-source line-length audit
- scan for ignored tests, sleeps, `runBlocking`, `GlobalScope`, and Arrange/Act/Assert sections

`./gradlew testDebugUnitTest --stacktrace` could not run in the current environment because the project requires Android API 37 and the available Google SDK repository does not provide `platforms;android-37`. API 36 was not substituted because it would not provide reliable validation.