### PR TITLE
feat: redesign guided race setup

### DIFF
--- a/app/src/main/kotlin/com/github/arhor/spellbindr/ui/SpellbindrApp.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/ui/SpellbindrApp.kt
@@ -84,7 +84,11 @@ fun SpellbindrApp(onReady: () -> Unit) {
         ) {
             Scaffold(
                 topBar = { AppTopBar(resolvedConfig) },
-                bottomBar = { AppBottomBar(controller) },
+                bottomBar = {
+                    if (!(destination matches AppDestination.GuidedCharacterSetup::class)) {
+                        AppBottomBar(controller)
+                    }
+                },
                 snackbarHost = { SnackbarHost(snackbarHostState) },
             ) { innerPadding ->
                 SpellbindrAppNavGraph(

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/guided/GuidedCharacterSetupScreen.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/guided/GuidedCharacterSetupScreen.kt
@@ -210,7 +210,7 @@ private fun GuidedCharacterSetupContent(
             null
         }
 
-        if (blockingReason != null) {
+        if (blockingReason != null && state.step != GuidedStep.RACE) {
             Text(
                 text = blockingReason,
                 style = MaterialTheme.typography.bodySmall,

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/guided/components/race/RaceCarousel.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/guided/components/race/RaceCarousel.kt
@@ -5,7 +5,6 @@ package com.github.arhor.spellbindr.ui.feature.character.guided.components.race
 import androidx.compose.foundation.interaction.collectIsDraggedAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
@@ -105,15 +104,12 @@ internal fun RaceCarousel(
         }
     }
 
-    Column(
-        modifier = modifier.fillMaxSize(),
-        verticalArrangement = Arrangement.spacedBy(4.dp),
-    ) {
+    Box(modifier = modifier.fillMaxSize()) {
         HorizontalPager(
             state = pagerState,
             modifier = Modifier
                 .fillMaxWidth()
-                .weight(1f),
+                .fillMaxSize(),
             contentPadding = PaddingValues(horizontal = 24.dp),
             pageSpacing = 12.dp,
             beyondViewportPageCount = 1,
@@ -154,6 +150,7 @@ internal fun RaceCarousel(
             pageCount = races.size,
             onPrevious = { selectPage(pagerState.currentPage - 1) },
             onNext = { selectPage(pagerState.currentPage + 1) },
+            modifier = Modifier.align(Alignment.BottomCenter),
         )
     }
 
@@ -180,11 +177,12 @@ private fun RaceCarouselNavigation(
     pageCount: Int,
     onPrevious: () -> Unit,
     onNext: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     Row(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
-            .padding(horizontal = 12.dp),
+            .padding(horizontal = 20.dp, vertical = 4.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.SpaceBetween,
     ) {

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/guided/components/race/RaceCarousel.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/guided/components/race/RaceCarousel.kt
@@ -42,6 +42,7 @@ import androidx.compose.ui.unit.dp
 import com.github.arhor.spellbindr.domain.model.Race
 import com.github.arhor.spellbindr.domain.model.Trait
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlin.math.absoluteValue
 
 @Composable
 internal fun RaceCarousel(
@@ -158,7 +159,7 @@ internal fun RaceCarousel(
                             val distanceFromCenter = (
                                 (pagerState.currentPage - page) +
                                     pagerState.currentPageOffsetFraction
-                                ).let(::kotlin.math.abs)
+                                ).absoluteValue
                                 .coerceIn(0f, 1f)
                             val prominence = 1f - distanceFromCenter
                             val scale = 0.94f + (0.06f * prominence)

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/guided/components/race/RaceCarousel.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/guided/components/race/RaceCarousel.kt
@@ -3,8 +3,10 @@
 package com.github.arhor.spellbindr.ui.feature.character.guided.components.race
 
 import androidx.compose.foundation.interaction.collectIsDraggedAsState
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
@@ -12,6 +14,8 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.ArrowBack
 import androidx.compose.material.icons.automirrored.outlined.ArrowForward
@@ -30,6 +34,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
@@ -65,6 +71,7 @@ internal fun RaceCarousel(
     )
     val isDragged by pagerState.interactionSource.collectIsDraggedAsState()
     val currentSelectedRaceId by rememberUpdatedState(selectedRaceId)
+    val pageShape = RoundedCornerShape(16.dp)
     var userDragStartPage by remember { mutableStateOf<Int?>(null) }
     var detailsRaceId by rememberSaveable { mutableStateOf<String?>(null) }
 
@@ -104,53 +111,83 @@ internal fun RaceCarousel(
         }
     }
 
-    Box(modifier = modifier.fillMaxSize()) {
-        HorizontalPager(
-            state = pagerState,
+    Column(modifier = modifier.fillMaxSize()) {
+        Box(
             modifier = Modifier
                 .fillMaxWidth()
-                .fillMaxSize(),
-            contentPadding = PaddingValues(horizontal = 24.dp),
-            pageSpacing = 12.dp,
-            beyondViewportPageCount = 1,
-            key = { races[it].id },
-        ) { page ->
-            val race = races[page]
-            val isSelected = race.id == selectedRaceId
-            val subraceId = selectedSubraceId.takeIf { isSelected }
-            val summary = remember(race, traitsById, subraceId) {
-                raceSummaryUiModel(
+                .weight(1f),
+        ) {
+            HorizontalPager(
+                state = pagerState,
+                modifier = Modifier.fillMaxSize(),
+                contentPadding = PaddingValues(horizontal = 24.dp),
+                pageSpacing = 12.dp,
+                beyondViewportPageCount = 1,
+                key = { races[it].id },
+            ) { page ->
+                val race = races[page]
+                val isSelected = race.id == selectedRaceId
+                val subraceId = selectedSubraceId.takeIf { isSelected }
+                val summary = remember(race, traitsById, subraceId) {
+                    raceSummaryUiModel(
+                        race = race,
+                        traitsById = traitsById,
+                        selectedSubraceId = subraceId,
+                    )
+                }
+                RaceCarouselPage(
                     race = race,
-                    traitsById = traitsById,
+                    summary = summary,
+                    position = page + 1,
+                    totalCount = races.size,
+                    selected = isSelected,
+                    focused = page == pagerState.currentPage,
                     selectedSubraceId = subraceId,
+                    onSelect = { selectPage(page) },
+                    onSubraceSelected = { onSubraceSelected(race.id, it) },
+                    onViewDetails = { detailsRaceId = race.id },
+                    onPrevious = (page - 1).takeIf { it >= 0 }?.let { previous ->
+                        { selectPage(previous) }
+                    },
+                    onNext = (page + 1).takeIf { it < races.size }?.let { next ->
+                        { selectPage(next) }
+                    },
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .graphicsLayer {
+                            val distanceFromCenter = (
+                                (pagerState.currentPage - page) +
+                                    pagerState.currentPageOffsetFraction
+                                ).let(::kotlin.math.abs)
+                                .coerceIn(0f, 1f)
+                            val prominence = 1f - distanceFromCenter
+                            val scale = 0.94f + (0.06f * prominence)
+                            scaleX = scale
+                            scaleY = scale
+                            alpha = 0.72f + (0.28f * prominence)
+                            shape = pageShape
+                            clip = true
+                        },
                 )
             }
-            RaceCarouselPage(
-                race = race,
-                summary = summary,
-                position = page + 1,
-                totalCount = races.size,
-                selected = isSelected,
-                selectedSubraceId = subraceId,
-                onSelect = { selectPage(page) },
-                onSubraceSelected = { onSubraceSelected(race.id, it) },
-                onViewDetails = { detailsRaceId = race.id },
-                onPrevious = (page - 1).takeIf { it >= 0 }?.let { previous ->
-                    { selectPage(previous) }
-                },
-                onNext = (page + 1).takeIf { it < races.size }?.let { next ->
-                    { selectPage(next) }
-                },
-                modifier = Modifier.fillMaxSize(),
+
+            CarouselArrow(
+                onClick = { selectPage(pagerState.currentPage - 1) },
+                enabled = pagerState.currentPage > 0,
+                previous = true,
+                modifier = Modifier.align(Alignment.CenterStart),
+            )
+            CarouselArrow(
+                onClick = { selectPage(pagerState.currentPage + 1) },
+                enabled = pagerState.currentPage < races.lastIndex,
+                previous = false,
+                modifier = Modifier.align(Alignment.CenterEnd),
             )
         }
 
-        RaceCarouselNavigation(
+        RaceCarouselPagination(
             currentPage = pagerState.currentPage,
             pageCount = races.size,
-            onPrevious = { selectPage(pagerState.currentPage - 1) },
-            onNext = { selectPage(pagerState.currentPage + 1) },
-            modifier = Modifier.align(Alignment.BottomCenter),
         )
     }
 
@@ -172,55 +209,63 @@ internal fun RaceCarousel(
 }
 
 @Composable
-private fun RaceCarouselNavigation(
+private fun RaceCarouselPagination(
     currentPage: Int,
     pageCount: Int,
-    onPrevious: () -> Unit,
-    onNext: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Row(
         modifier = modifier
             .fillMaxWidth()
-            .padding(horizontal = 20.dp, vertical = 4.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.SpaceBetween,
-    ) {
-        IconButton(
-            onClick = onPrevious,
-            enabled = currentPage > 0,
-        ) {
-            Icon(
-                imageVector = Icons.AutoMirrored.Outlined.ArrowBack,
-                contentDescription = "Previous race",
-            )
-        }
-        Row(
-            modifier = Modifier.semantics {
+            .padding(vertical = 4.dp)
+            .semantics {
                 contentDescription = "Race ${currentPage + 1} of $pageCount"
             },
-            horizontalArrangement = Arrangement.spacedBy(5.dp),
-        ) {
-            repeat(pageCount) { index ->
-                Text(
-                    text = if (index == currentPage) "●" else "○",
-                    style = MaterialTheme.typography.labelSmall,
-                    color = if (index == currentPage) {
-                        MaterialTheme.colorScheme.primary
-                    } else {
-                        MaterialTheme.colorScheme.outline
-                    },
-                )
-            }
-        }
-        IconButton(
-            onClick = onNext,
-            enabled = currentPage < pageCount - 1,
-        ) {
-            Icon(
-                imageVector = Icons.AutoMirrored.Outlined.ArrowForward,
-                contentDescription = "Next race",
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(5.dp, Alignment.CenterHorizontally),
+    ) {
+        repeat(pageCount) { index ->
+            Text(
+                text = if (index == currentPage) "●" else "○",
+                style = MaterialTheme.typography.labelSmall,
+                color = if (index == currentPage) {
+                    MaterialTheme.colorScheme.primary
+                } else {
+                    MaterialTheme.colorScheme.outline
+                },
             )
         }
+    }
+}
+
+@Composable
+private fun CarouselArrow(
+    onClick: () -> Unit,
+    enabled: Boolean,
+    previous: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    val contentColor = if (MaterialTheme.colorScheme.surface.luminance() > 0.5f) {
+        MaterialTheme.colorScheme.onPrimary
+    } else {
+        MaterialTheme.colorScheme.onSurface
+    }
+    IconButton(
+        onClick = onClick,
+        enabled = enabled,
+        modifier = modifier.background(
+            color = MaterialTheme.colorScheme.scrim.copy(alpha = if (enabled) 0.48f else 0.24f),
+            shape = CircleShape,
+        ),
+    ) {
+        Icon(
+            imageVector = if (previous) {
+                Icons.AutoMirrored.Outlined.ArrowBack
+            } else {
+                Icons.AutoMirrored.Outlined.ArrowForward
+            },
+            contentDescription = if (previous) "Previous race" else "Next race",
+            tint = contentColor.copy(alpha = if (enabled) 1f else 0.38f),
+        )
     }
 }

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/guided/components/race/RaceCarouselPage.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/guided/components/race/RaceCarouselPage.kt
@@ -1,21 +1,16 @@
 package com.github.arhor.spellbindr.ui.feature.character.guided.components.race
 
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.selection.selectable
-import androidx.compose.material3.Card
-import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.draw.drawWithCache
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.semantics.CustomAccessibilityAction
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
@@ -40,23 +35,22 @@ internal fun RaceCarouselPage(
     onNext: (() -> Unit)?,
     modifier: Modifier = Modifier,
 ) {
-    val artworkWeight = if (LocalDensity.current.fontScale >= LARGE_FONT_SCALE) 0.22f else 0.30f
+    val scrim = MaterialTheme.colorScheme.scrim
     val accessibilityActions = buildList {
         onPrevious?.let { previous ->
-            add(CustomAccessibilityAction(label = "Previous race") {
+            add(CustomAccessibilityAction("Previous race") {
                 previous()
                 true
             })
         }
         onNext?.let { next ->
-            add(CustomAccessibilityAction(label = "Next race") {
+            add(CustomAccessibilityAction("Next race") {
                 next()
                 true
             })
-        }
     }
 
-    Card(
+    Box(
         modifier = modifier
             .fillMaxSize()
             .semantics {
@@ -66,71 +60,38 @@ internal fun RaceCarouselPage(
                     append(position)
                     append(" of ")
                     append(totalCount)
-                    val conciseSummary = summary.conciseDescription()
-                    if (conciseSummary.isNotBlank()) {
+                    summary.conciseDescription().takeIf { it.isNotBlank() }?.let {
                         append(". ")
-                        append(conciseSummary)
+                        append(it)
                     }
                 }
                 stateDescription = if (selected) "Selected" else "Not selected"
                 customActions = accessibilityActions
             }
-            .selectable(
-                selected = selected,
-                role = Role.RadioButton,
-                onClick = onSelect,
-            ),
-        border = BorderStroke(
-            width = if (selected) 2.dp else 1.dp,
-            color = if (selected) {
-                MaterialTheme.colorScheme.primary
-            } else {
-                MaterialTheme.colorScheme.outlineVariant
-            },
-        ),
-        colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surfaceContainer,
-        ),
+            .selectable(selected = selected, role = Role.RadioButton, onClick = onSelect),
     ) {
-        Column(Modifier.fillMaxSize()) {
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .weight(artworkWeight),
-            ) {
-                RaceArtwork(
-                    raceId = race.id,
-                    modifier = Modifier.fillMaxSize(),
-                )
-                if (selected) {
-                    Surface(
-                        modifier = Modifier
-                            .align(Alignment.TopEnd)
-                            .padding(10.dp),
-                        color = MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.94f),
-                        shape = MaterialTheme.shapes.small,
-                    ) {
-                        Text(
-                            text = "Selected",
-                            style = MaterialTheme.typography.labelMedium,
-                            color = MaterialTheme.colorScheme.onPrimaryContainer,
-                            modifier = Modifier.padding(horizontal = 9.dp, vertical = 5.dp),
+        RaceArtwork(raceId = race.id, modifier = Modifier.fillMaxSize())
+        RaceSummaryPanel(
+            summary = summary,
+            subraces = race.subraces,
+            selectedSubraceId = selectedSubraceId,
+            onSubraceSelected = onSubraceSelected,
+            onViewDetails = onViewDetails,
+            modifier = Modifier
+                .fillMaxWidth()
+                .align(Alignment.BottomCenter)
+                .drawWithCache {
+                    onDrawBehind {
+                        drawRect(
+                            Brush.verticalGradient(
+                                0f to scrim.copy(alpha = 0f),
+                                0.30f to scrim.copy(alpha = 0.72f),
+                                1f to scrim.copy(alpha = 0.94f),
+                            ),
                         )
                     }
                 }
-            }
-            RaceSummaryPanel(
-                summary = summary,
-                subraces = race.subraces,
-                selectedSubraceId = selectedSubraceId,
-                onSubraceSelected = onSubraceSelected,
-                onViewDetails = onViewDetails,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .weight(1f - artworkWeight),
-            )
-        }
+                .padding(top = 38.dp),
+        )
     }
 }
-
-private const val LARGE_FONT_SCALE = 1.2f

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/guided/components/race/RaceCarouselPage.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/guided/components/race/RaceCarouselPage.kt
@@ -27,6 +27,7 @@ internal fun RaceCarouselPage(
     position: Int,
     totalCount: Int,
     selected: Boolean,
+    focused: Boolean,
     selectedSubraceId: String?,
     onSelect: () -> Unit,
     onSubraceSelected: (String) -> Unit,
@@ -36,6 +37,7 @@ internal fun RaceCarouselPage(
     modifier: Modifier = Modifier,
 ) {
     val scrim = MaterialTheme.colorScheme.scrim
+    val conciseSummary = summary.conciseDescription()
     val accessibilityActions = buildList {
         onPrevious?.let { previous ->
             add(CustomAccessibilityAction("Previous race") {
@@ -54,45 +56,58 @@ internal fun RaceCarouselPage(
     Box(
         modifier = modifier
             .fillMaxSize()
-            .semantics {
-                contentDescription = buildString {
-                    append(summary.name)
-                    append(", ")
-                    append(position)
-                    append(" of ")
-                    append(totalCount)
-                    summary.conciseDescription().takeIf { it.isNotBlank() }?.let {
-                        append(". ")
-                        append(it)
-                    }
-                }
-                stateDescription = if (selected) "Selected" else "Not selected"
-                customActions = accessibilityActions
-            }
-            .selectable(selected = selected, role = Role.RadioButton, onClick = onSelect),
+            .then(
+                if (focused) {
+                    Modifier
+                        .semantics {
+                            contentDescription = buildString {
+                                append(summary.name)
+                                append(", ")
+                                append(position)
+                                append(" of ")
+                                append(totalCount)
+                                conciseSummary.takeIf { it.isNotBlank() }?.let {
+                                    append(". ")
+                                    append(it)
+                                }
+                            }
+                            stateDescription = if (selected) "Selected" else "Not selected"
+                            customActions = accessibilityActions
+                        }
+                        .selectable(
+                            selected = selected,
+                            role = Role.RadioButton,
+                            onClick = onSelect,
+                        )
+                } else {
+                    Modifier
+                },
+            ),
     ) {
         RaceArtwork(raceId = race.id, modifier = Modifier.fillMaxSize())
-        RaceSummaryPanel(
-            summary = summary,
-            subraces = race.subraces,
-            selectedSubraceId = selectedSubraceId,
-            onSubraceSelected = onSubraceSelected,
-            onViewDetails = onViewDetails,
-            modifier = Modifier
-                .fillMaxWidth()
-                .align(Alignment.BottomCenter)
-                .drawWithCache {
-                    onDrawBehind {
-                        drawRect(
-                            Brush.verticalGradient(
-                                0f to scrim.copy(alpha = 0f),
-                                0.30f to scrim.copy(alpha = 0.72f),
-                                1f to scrim.copy(alpha = 0.94f),
-                            ),
-                        )
+        if (focused) {
+            RaceSummaryPanel(
+                summary = summary,
+                subraces = race.subraces,
+                selectedSubraceId = selectedSubraceId,
+                onSubraceSelected = onSubraceSelected,
+                onViewDetails = onViewDetails,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .align(Alignment.BottomCenter)
+                    .drawWithCache {
+                        onDrawBehind {
+                            drawRect(
+                                Brush.verticalGradient(
+                                    0f to scrim.copy(alpha = 0f),
+                                    0.30f to scrim.copy(alpha = 0.72f),
+                                    1f to scrim.copy(alpha = 0.94f),
+                                ),
+                            )
+                        }
                     }
-                }
-                .padding(top = 38.dp),
-        )
+                    .padding(top = 38.dp),
+            )
+        }
     }
 }

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/guided/components/race/RaceCarouselPage.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/guided/components/race/RaceCarouselPage.kt
@@ -48,6 +48,7 @@ internal fun RaceCarouselPage(
                 next()
                 true
             })
+        }
     }
 
     Box(

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/guided/components/race/RaceSummaryPanel.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/guided/components/race/RaceSummaryPanel.kt
@@ -14,6 +14,7 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -28,6 +29,11 @@ internal fun RaceSummaryPanel(
     onViewDetails: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val contentColor = if (MaterialTheme.colorScheme.surface.luminance() > 0.5f) {
+        MaterialTheme.colorScheme.onPrimary
+    } else {
+        MaterialTheme.colorScheme.onSurface
+    }
     Column(
         modifier = modifier.padding(horizontal = 14.dp, vertical = 10.dp),
         verticalArrangement = Arrangement.spacedBy(5.dp),
@@ -41,6 +47,7 @@ internal fun RaceSummaryPanel(
                 text = summary.name,
                 style = MaterialTheme.typography.titleLarge,
                 fontWeight = FontWeight.SemiBold,
+                color = contentColor,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
                 modifier = Modifier.weight(1f),
@@ -51,19 +58,6 @@ internal fun RaceSummaryPanel(
             }
         }
 
-        if (subraces.isNotEmpty()) {
-            Text(
-                text = "Choose a subrace",
-                style = MaterialTheme.typography.labelMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-            SubraceSelector(
-                subraces = subraces,
-                selectedSubraceId = selectedSubraceId,
-                onSubraceSelected = onSubraceSelected,
-            )
-        }
-
         val mechanics = buildList {
             summary.size?.let { add("Size $it") }
             summary.speedFeet?.let { add("Speed $it ft") }
@@ -72,6 +66,7 @@ internal fun RaceSummaryPanel(
             Text(
                 text = mechanics,
                 style = MaterialTheme.typography.bodyMedium,
+                color = contentColor,
                 maxLines = 1,
             )
         }
@@ -79,15 +74,28 @@ internal fun RaceSummaryPanel(
             Text(
                 text = summary.abilityBonuses.joinToString("  •  "),
                 style = MaterialTheme.typography.bodyMedium,
+                color = contentColor,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
+            )
+        }
+        if (subraces.isNotEmpty()) {
+            Text(
+                text = "Choose a subrace",
+                style = MaterialTheme.typography.labelMedium,
+                color = contentColor,
+            )
+            SubraceSelector(
+                subraces = subraces,
+                selectedSubraceId = selectedSubraceId,
+                onSubraceSelected = onSubraceSelected,
             )
         }
         if (summary.definingTraits.isNotEmpty()) {
             Text(
                 text = summary.definingTraits.joinToString("  •  "),
                 style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                color = contentColor.copy(alpha = 0.82f),
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
             )

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/guided/steps/RaceStep.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/guided/steps/RaceStep.kt
@@ -1,14 +1,8 @@
 package com.github.arhor.spellbindr.ui.feature.character.guided
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 import com.github.arhor.spellbindr.ui.feature.character.guided.components.race.RaceCarousel
 
 @Composable
@@ -17,34 +11,16 @@ internal fun RaceStep(
     onRaceSelected: (String) -> Unit,
     onSubraceSelected: (String) -> Unit,
 ) {
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(vertical = 10.dp),
-        verticalArrangement = Arrangement.spacedBy(8.dp),
-    ) {
-        Text(
-            text = "Choose a race",
-            style = MaterialTheme.typography.titleMedium,
-            modifier = Modifier.padding(horizontal = 16.dp),
-        )
-        Text(
-            text = "Swipe to explore, then select a race. You can review every trait in Details.",
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = Modifier.padding(horizontal = 16.dp),
-        )
-        RaceCarousel(
-            races = state.races,
-            traitsById = state.traitsById,
-            selectedRaceId = state.selection.raceId,
-            selectedSubraceId = state.selection.subraceId,
-            onRaceSelected = onRaceSelected,
-            onSubraceSelected = { raceId, subraceId ->
-                if (state.selection.raceId != raceId) onRaceSelected(raceId)
-                onSubraceSelected(subraceId)
-            },
-            modifier = Modifier.weight(1f),
-        )
-    }
+    RaceCarousel(
+        races = state.races,
+        traitsById = state.traitsById,
+        selectedRaceId = state.selection.raceId,
+        selectedSubraceId = state.selection.subraceId,
+        onRaceSelected = onRaceSelected,
+        onSubraceSelected = { raceId, subraceId ->
+            if (state.selection.raceId != raceId) onRaceSelected(raceId)
+            onSubraceSelected(subraceId)
+        },
+        modifier = Modifier.fillMaxSize(),
+    )
 }

--- a/app/src/screenshotTest/kotlin/com/github/arhor/spellbindr/ui/screenshot/GuidedRaceStepScreenshotPreviews.kt
+++ b/app/src/screenshotTest/kotlin/com/github/arhor/spellbindr/ui/screenshot/GuidedRaceStepScreenshotPreviews.kt
@@ -1,0 +1,134 @@
+package com.github.arhor.spellbindr.ui.screenshot
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import com.android.tools.screenshot.PreviewTest
+import com.github.arhor.spellbindr.domain.model.AbilityScores
+import com.github.arhor.spellbindr.domain.model.Choice
+import com.github.arhor.spellbindr.domain.model.Effect
+import com.github.arhor.spellbindr.domain.model.EntityRef
+import com.github.arhor.spellbindr.domain.model.Race
+import com.github.arhor.spellbindr.domain.model.Trait
+import com.github.arhor.spellbindr.ui.feature.character.guided.GuidedCharacterSetupScreen
+import com.github.arhor.spellbindr.ui.feature.character.guided.GuidedCharacterSetupUiState
+import com.github.arhor.spellbindr.ui.feature.character.guided.GuidedSelection
+import com.github.arhor.spellbindr.ui.feature.character.guided.model.GuidedCharacterPreview
+import com.github.arhor.spellbindr.ui.feature.character.guided.model.GuidedStep
+
+@PreviewTest
+@Preview(widthDp = 360, heightDp = 640)
+@Composable
+fun GuidedRaceStep_RequiredSubraceDisabled_Screenshot() {
+    ScreenshotHarness {
+        GuidedCharacterSetupScreen(state = guidedRacePreviewState(halfling, raceId = "halfling"))
+    }
+}
+
+@PreviewTest
+@Preview(widthDp = 360, heightDp = 640)
+@Composable
+fun GuidedRaceStep_DragonbornEnabled_Screenshot() {
+    ScreenshotHarness {
+        GuidedCharacterSetupScreen(state = guidedRacePreviewState(dragonborn, raceId = "dragonborn"))
+    }
+}
+
+@PreviewTest
+@Preview(widthDp = 280, heightDp = 500)
+@Composable
+fun GuidedRaceStep_LongTraitsNarrow_Screenshot() {
+    ScreenshotHarness {
+        GuidedCharacterSetupScreen(state = guidedRacePreviewState(dragonborn, raceId = "dragonborn"))
+    }
+}
+
+private fun guidedRacePreviewState(
+    race: Race,
+    raceId: String,
+): GuidedCharacterSetupUiState.Content = GuidedCharacterSetupUiState.Content(
+    step = GuidedStep.RACE,
+    steps = GuidedStep.entries.toList(),
+    currentStepIndex = GuidedStep.entries.indexOf(GuidedStep.RACE),
+    totalSteps = GuidedStep.entries.size,
+    name = "Preview hero",
+    classes = emptyList(),
+    races = listOf(race),
+    backgrounds = emptyList(),
+    languages = emptyList(),
+    equipment = emptyList(),
+    traitsById = previewRaceTraits.associateBy(Trait::id),
+    featuresById = emptyMap(),
+    languagesById = emptyMap(),
+    equipmentById = emptyMap(),
+    spells = emptyList(),
+    spellsById = emptyMap(),
+    referenceDataVersion = 1,
+    selection = GuidedSelection(
+        classId = null,
+        subclassId = null,
+        raceId = raceId,
+        subraceId = null,
+        backgroundId = null,
+        abilityMethod = null,
+        standardArrayAssignments = emptyMap(),
+        pointBuyScores = emptyMap(),
+        choiceSelections = emptyMap(),
+    ),
+    preview = GuidedCharacterPreview(
+        abilityScores = AbilityScores(),
+        maxHitPoints = 1,
+        armorClass = 10,
+        speed = 30,
+        languagesCount = 0,
+        proficienciesCount = 0,
+    ),
+    isSaving = false,
+)
+
+private val halfling = Race(
+    id = "halfling",
+    name = "Halfling",
+    traits = listOf(EntityRef("halfling-size"), EntityRef("halfling-speed"), EntityRef("lucky")),
+    subraces = listOf(
+        Race.Subrace("lightfoot", "Lightfoot", "Naturally stealthy and sociable.", emptyList()),
+        Race.Subrace("stout", "Stout", "Hardy and resilient.", emptyList()),
+    ),
+)
+
+private val dragonborn = Race(
+    id = "dragonborn",
+    name = "Dragonborn",
+    traits = listOf(
+        EntityRef("dragonborn-ability"),
+        EntityRef("dragonborn-size"),
+        EntityRef("dragonborn-speed"),
+        EntityRef("draconic-ancestry"),
+        EntityRef("breath-weapon"),
+        EntityRef("damage-resistance"),
+        EntityRef("long-trait"),
+    ),
+    subraces = emptyList(),
+)
+
+private val previewRaceTraits = listOf(
+    Trait("halfling-size", "Size", listOf("Your size is Small."), listOf(Effect.ModifySizeEffect("small"))),
+    Trait("halfling-speed", "Speed", listOf("Your speed is 25 feet."), listOf(Effect.ModifySpeedEffect(25))),
+    Trait("lucky", "Lucky", listOf("You can reroll a natural 1.")),
+    Trait(
+        "dragonborn-ability",
+        "Ability Score Increase",
+        listOf("Your Strength increases by 2 and Charisma by 1."),
+        listOf(Effect.ModifyAbilityEffect(mapOf("str" to 2, "cha" to 1))),
+    ),
+    Trait("dragonborn-size", "Size", listOf("Your size is Medium."), listOf(Effect.ModifySizeEffect("medium"))),
+    Trait("dragonborn-speed", "Speed", listOf("Your speed is 30 feet."), listOf(Effect.ModifySpeedEffect(30))),
+    Trait(
+        "draconic-ancestry",
+        "Draconic Ancestry",
+        listOf("Choose your draconic ancestry later."),
+        draconicAncestryChoice = Choice.OptionsArrayChoice(choose = 1, from = listOf("black", "blue")),
+    ),
+    Trait("breath-weapon", "Breath Weapon", listOf("Exhale destructive energy.")),
+    Trait("damage-resistance", "Damage Resistance", listOf("Resist your ancestry's damage type.")),
+    Trait("long-trait", "Ancient Draconic Heritage", listOf("A deliberately long summary for truncation coverage.")),
+)


### PR DESCRIPTION
## Summary

- make the guided Race step artwork-led with a compact gradient information overlay
- remove redundant race-step status and instructional UI, and hide app navigation during guided setup
- add screenshot previews for subrace-required, enabled, narrow, and long-summary race states

## Validation

- `git diff --check`
- `./gradlew :app:updateDebugScreenshotTest --tests '*GuidedRaceStep*' --stacktrace` *(blocked: configured Android SDK is missing accepted licenses for Platform 37 and Build Tools 36)*