### PR TITLE
feat: add multiclass level up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ google-services.json
 .DS_Store
 /build
 /captures
+/.worktrees/
 .externalNativeBuild
 .cxx
 android-commandlinetools.zip

--- a/app/src/main/assets/data/feats.json
+++ b/app/src/main/assets/data/feats.json
@@ -177,10 +177,11 @@
     "name": "Grappler",
     "prerequisites": [
       {
-        "abilityScore": {
-          "id": "str"
-        },
-        "minimumScore": 13
+        "type": "ability-score",
+        "abilityScore": [
+          "str"
+        ],
+        "minimumValue": 13
       }
     ],
     "desc": [

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/data/local/assets/FeatsAssetDataStore.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/data/local/assets/FeatsAssetDataStore.kt
@@ -1,0 +1,22 @@
+package com.github.arhor.spellbindr.data.local.assets
+
+import android.content.Context
+import com.github.arhor.spellbindr.domain.model.Feat
+import com.github.arhor.spellbindr.logging.LoggerFactory
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.serialization.json.Json
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class FeatsAssetDataStore @Inject constructor(
+    @ApplicationContext context: Context,
+    json: Json,
+    loggerFactory: LoggerFactory,
+) : AssetDataStoreBase<Feat>(
+    json = json,
+    path = "data/feats.json",
+    context = context,
+    serializer = Feat.serializer(),
+    loggerFactory = loggerFactory,
+)

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/data/local/database/dao/CharacterDao.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/data/local/database/dao/CharacterDao.kt
@@ -32,6 +32,11 @@ interface CharacterDao {
     @Query("SELECT * FROM characters WHERE id = :id")
     fun observeCharacterWithProgression(id: String): Flow<CharacterWithProgressionEntity?>
 
+    /** One-shot relation read used inside the repository's Room transaction. */
+    @Transaction
+    @Query("SELECT * FROM characters WHERE id = :id")
+    suspend fun getCharacterWithProgression(id: String): CharacterWithProgressionEntity?
+
     /**
      * Inserts a new character or updates the existing row without deleting it.
      *

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/data/local/database/entity/CharacterSheetSnapshot.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/data/local/database/entity/CharacterSheetSnapshot.kt
@@ -8,6 +8,7 @@ import com.github.arhor.spellbindr.domain.model.SavingThrowEntry
 import com.github.arhor.spellbindr.domain.model.SkillEntry
 import com.github.arhor.spellbindr.domain.model.SpellSlotState
 import com.github.arhor.spellbindr.domain.model.Weapon
+import com.github.arhor.spellbindr.domain.model.ManagedProgressionSheetState
 import com.github.arhor.spellbindr.domain.model.defaultSavingThrows
 import com.github.arhor.spellbindr.domain.model.defaultSkills
 import com.github.arhor.spellbindr.domain.model.defaultSpellSlots
@@ -54,4 +55,7 @@ data class CharacterSheetSnapshot(
     val notes: String = "",
     val characterSpells: List<CharacterSpell> = emptyList(),
     val weapons: List<Weapon> = emptyList(),
+    /** Added with a default so snapshots written before level-up support remain decodable. */
+    val manualProficiencyIds: Set<String> = emptySet(),
+    val managedProgression: ManagedProgressionSheetState? = null,
 )

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/data/mapper/CharacterSheetMapper.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/data/mapper/CharacterSheetMapper.kt
@@ -3,7 +3,10 @@ package com.github.arhor.spellbindr.data.mapper
 import com.github.arhor.spellbindr.data.local.database.entity.CharacterSheetSnapshot
 import com.github.arhor.spellbindr.domain.model.CharacterSheet
 
-fun CharacterSheetSnapshot.toDomain(id: String): CharacterSheet = CharacterSheet(
+fun CharacterSheetSnapshot.toDomain(
+    id: String,
+    legacyProficiencyIds: Set<String> = emptySet(),
+): CharacterSheet = CharacterSheet(
     id = id,
     name = name,
     level = level,
@@ -41,6 +44,10 @@ fun CharacterSheetSnapshot.toDomain(id: String): CharacterSheet = CharacterSheet
     notes = notes,
     characterSpells = characterSpells,
     weapons = weapons,
+    manualProficiencyIds = manualProficiencyIds.ifEmpty {
+        legacyProficiencyIds - managedProgression?.proficiencyIds.orEmpty()
+    },
+    managedProgression = managedProgression,
 )
 
 fun CharacterSheet.toSnapshot(): CharacterSheetSnapshot = CharacterSheetSnapshot(
@@ -80,4 +87,6 @@ fun CharacterSheet.toSnapshot(): CharacterSheetSnapshot = CharacterSheetSnapshot
     notes = notes,
     characterSpells = characterSpells,
     weapons = weapons,
+    manualProficiencyIds = manualProficiencyIds,
+    managedProgression = managedProgression,
 )

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/data/repository/CharacterRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/data/repository/CharacterRepositoryImpl.kt
@@ -1,20 +1,33 @@
 package com.github.arhor.spellbindr.data.repository
 
+import androidx.room.withTransaction
 import com.github.arhor.spellbindr.data.local.database.CharacterProgressionJsonCodec
+import com.github.arhor.spellbindr.data.local.database.SpellbindrDatabase
 import com.github.arhor.spellbindr.data.local.database.dao.CharacterDao
 import com.github.arhor.spellbindr.data.local.database.entity.CharacterEntity
 import com.github.arhor.spellbindr.data.mapper.toDomain
 import com.github.arhor.spellbindr.data.mapper.toEntity
 import com.github.arhor.spellbindr.data.mapper.toSnapshot
 import com.github.arhor.spellbindr.domain.model.AbilityIds
+import com.github.arhor.spellbindr.domain.model.ApplyLevelUpResult
 import com.github.arhor.spellbindr.domain.model.Character
 import com.github.arhor.spellbindr.domain.model.CharacterCreationResult
 import com.github.arhor.spellbindr.domain.model.CharacterSheet
 import com.github.arhor.spellbindr.domain.model.CharacterWithProgression
 import com.github.arhor.spellbindr.domain.model.EntityRef
+import com.github.arhor.spellbindr.domain.model.HitDicePoolState
+import com.github.arhor.spellbindr.domain.model.LevelUpPlan
+import com.github.arhor.spellbindr.domain.model.LevelUpReferenceData
+import com.github.arhor.spellbindr.domain.model.LevelUpReferenceRules
+import com.github.arhor.spellbindr.domain.model.LevelUpValidationCode
+import com.github.arhor.spellbindr.domain.model.LevelUpValidationIssue
+import com.github.arhor.spellbindr.domain.model.LevelUpValidationSeverity
+import com.github.arhor.spellbindr.domain.model.ManagedProgressionSheetState
 import com.github.arhor.spellbindr.domain.model.Loadable
 import com.github.arhor.spellbindr.domain.model.ProgressionState
+import com.github.arhor.spellbindr.domain.model.SpellLearningPolicy
 import com.github.arhor.spellbindr.domain.repository.CharacterRepository
+import com.github.arhor.spellbindr.domain.usecase.LevelUpProgressionEngine
 import com.github.arhor.spellbindr.utils.asLoadableFlow
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.firstOrNull
@@ -34,6 +47,7 @@ import javax.inject.Singleton
 class CharacterRepositoryImpl @Inject constructor(
     private val characterDao: CharacterDao,
     private val progressionJsonCodec: CharacterProgressionJsonCodec,
+    private val database: SpellbindrDatabase,
 ) : CharacterRepository {
 
     override fun observeCharacterSheets(): Flow<Loadable<List<CharacterSheet>>> =
@@ -43,13 +57,16 @@ class CharacterRepositoryImpl @Inject constructor(
 
     override fun observeCharacterSheet(id: String): Flow<CharacterSheet?> =
         characterDao.getCharacterById(id).map {
-            it?.manualSheet?.toDomain(it.id)
+            it?.manualSheet?.toDomain(it.id, it.proficiencies.mapTo(linkedSetOf()) { ref -> ref.id })
         }
 
     override fun observeCharacterWithProgression(id: String): Flow<CharacterWithProgression?> =
         characterDao.observeCharacterWithProgression(id).map { relation ->
             relation?.let {
-                val sheet = it.character.manualSheet?.toDomain(it.character.id) ?: return@map null
+                val sheet = it.character.manualSheet?.toDomain(
+                    it.character.id,
+                    it.character.proficiencies.mapTo(linkedSetOf()) { ref -> ref.id },
+                ) ?: return@map null
                 CharacterWithProgression(
                     sheet = sheet,
                     progressionState = it.progression.toDomain(progressionJsonCodec),
@@ -83,6 +100,69 @@ class CharacterRepositoryImpl @Inject constructor(
         )
     }
 
+    override suspend fun applyLevelUp(
+        characterId: String,
+        expectedTotalLevel: Int,
+        plan: LevelUpPlan,
+        referenceData: LevelUpReferenceData,
+    ): ApplyLevelUpResult = try {
+        database.withTransaction {
+            val relation = characterDao.getCharacterWithProgression(characterId)
+                ?: return@withTransaction ApplyLevelUpResult.MissingCharacter
+            val sheet = relation.character.manualSheet?.toDomain(
+                characterId,
+                relation.character.proficiencies.mapTo(linkedSetOf()) { ref -> ref.id },
+            )
+                ?: return@withTransaction ApplyLevelUpResult.MissingCharacter
+            val state = runCatching { relation.progression.toDomain(progressionJsonCodec) }.getOrElse {
+                return@withTransaction ApplyLevelUpResult.ValidationFailure(
+                    listOf(LevelUpValidationIssue(
+                        code = LevelUpValidationCode.CorruptProgression,
+                        message = "Stored progression data is corrupt and cannot be leveled up.",
+                        severity = LevelUpValidationSeverity.Blocking,
+                    ))
+                )
+            }
+            val progression = when (state) {
+                ProgressionState.Unmanaged -> return@withTransaction ApplyLevelUpResult.UnmanagedCharacter
+                is ProgressionState.Managed -> state.progression
+            }
+            if (progression.totalLevel != expectedTotalLevel || plan.expectedTotalLevel != expectedTotalLevel) {
+                return@withTransaction ApplyLevelUpResult.StaleState
+            }
+
+            val preview = LevelUpProgressionEngine.rebuild(sheet, progression, plan, referenceData)
+            if (!preview.canConfirm) return@withTransaction ApplyLevelUpResult.ValidationFailure(preview.validations)
+            val clazz = plan.selectedClassId?.let(referenceData.classesById::get)
+                ?: return@withTransaction ApplyLevelUpResult.ValidationFailure(preview.validations)
+            val nextClassLevel = progression.classLevels.getOrDefault(clazz.id, 0) + 1
+            val record = LevelUpProgressionEngine.recordFor(
+                plan = plan,
+                clazz = clazz,
+                classLevel = nextClassLevel,
+                progression = progression,
+                referenceData = referenceData,
+                validations = preview.validations,
+            )
+            val updatedProgression = progression.copy(levels = progression.levels + record)
+            val updatedSheet = sheet.materializeManagedLevel(preview.after, record, referenceData)
+            val updatedEntity = updatedSheet.toCharacterEntity(relation.character).copy(
+                classes = preview.after.classLevels.mapKeys { EntityRef(it.key) },
+                abilityScores = updatedSheet.toAbilityScoreMap(),
+                // Structured entity fields can also contain user-authored values. Never replace them.
+                proficiencies = updatedSheet.allProficiencyIds.mapTo(linkedSetOf(), ::EntityRef),
+                spells = relation.character.spells + updatedSheet.characterSpells.map { EntityRef(it.spellId) },
+            )
+            characterDao.saveCharacterWithProgression(
+                character = updatedEntity,
+                progression = ProgressionState.Managed(updatedProgression).toEntity(characterId, progressionJsonCodec),
+            )
+            ApplyLevelUpResult.Success(updatedSheet, updatedProgression)
+        }
+    } catch (failure: Throwable) {
+        ApplyLevelUpResult.PersistenceFailure(failure.message ?: "Unable to save level-up changes.")
+    }
+
     override fun getCharacters(): Flow<List<Character>> {
         return characterDao.getAllCharacters().map { entities ->
             entities.map { it.toDomain() }
@@ -102,7 +182,7 @@ class CharacterRepositoryImpl @Inject constructor(
     }
 
     private fun entityToCharacterSheet(entity: CharacterEntity?): CharacterSheet? =
-        entity?.manualSheet?.toDomain(entity.id)
+        entity?.manualSheet?.toDomain(entity.id, entity.proficiencies.mapTo(linkedSetOf()) { ref -> ref.id })
 
     private fun CharacterSheet.toCharacterEntity(base: CharacterEntity): CharacterEntity = base.copy(
         id = id,
@@ -111,6 +191,7 @@ class CharacterRepositoryImpl @Inject constructor(
         background = background.asEntityRef("background", id),
         classes = toClassLevels(),
         abilityScores = toAbilityScoreMap(),
+        proficiencies = allProficiencyIds.mapTo(linkedSetOf(), ::EntityRef),
         manualSheet = toSnapshot(),
     )
 
@@ -130,4 +211,104 @@ class CharacterRepositoryImpl @Inject constructor(
         put(EntityRef(AbilityIds.WIS), abilityScores.wisdom)
         put(EntityRef(AbilityIds.CHA), abilityScores.charisma)
     }
+
+    private fun CharacterSheet.materializeManagedLevel(
+        after: com.github.arhor.spellbindr.domain.model.LevelUpSnapshot,
+        record: com.github.arhor.spellbindr.domain.model.CharacterLevelRecord,
+        referenceData: LevelUpReferenceData,
+    ): CharacterSheet {
+        val existingPools = managedProgression?.hitDicePools.orEmpty().associateBy(HitDicePoolState::dieSize)
+        val pools = after.hitDicePools.map { pool ->
+            HitDicePoolState(
+                dieSize = pool.dieSize,
+                total = pool.total,
+                expended = existingPools[pool.dieSize]?.expended.orZero().coerceIn(0, pool.total),
+            )
+        }
+        val existingSlots = spellSlots.associateBy { it.level }
+        val slots = (1..9).map { level ->
+            val total = after.sharedSpellSlots[level].orZero()
+            com.github.arhor.spellbindr.domain.model.SpellSlotState(
+                level = level,
+                total = total,
+                expended = existingSlots[level]?.expended.orZero().coerceIn(0, total),
+            )
+        }
+        val pact = after.pactMagic?.let { capacity ->
+            com.github.arhor.spellbindr.domain.model.PactSlotState(
+                slotLevel = capacity.slotLevel,
+                total = capacity.slots,
+                expended = pactSlots?.expended.orZero().coerceIn(0, capacity.slots),
+            )
+        }
+        val selectedClass = referenceData.classesById[record.classId]
+        val changedSpells = characterSpells
+            .filterNot { spell -> record.spellChanges.replaced.any { replacement ->
+                val sourceMatches = spell.sourceClass.equals(replacement.classId, ignoreCase = true) ||
+                    spell.sourceClass.equals(selectedClass?.name, ignoreCase = true)
+                sourceMatches && replacement.removedSpellId == spell.spellId
+            } }
+            .toMutableSet()
+        (record.spellChanges.learned + record.spellChanges.addedToSpellbook +
+            record.spellChanges.replaced.map { replacement ->
+                com.github.arhor.spellbindr.domain.model.ClassSpellRef(
+                    replacement.classId,
+                    replacement.learnedSpellId,
+                )
+            }).forEach { spell ->
+            changedSpells += com.github.arhor.spellbindr.domain.model.CharacterSpell(spell.spellId, spell.classId)
+        }
+        val spellPolicy = LevelUpReferenceRules.policyFor(record.classId)?.spells
+        if (selectedClass != null && spellPolicy is SpellLearningPolicy.Prepared) {
+            val maxSpellLevel = selectedClass.levels.firstOrNull { it.level == record.classLevel }
+                ?.spellcasting?.spellSlots.orEmpty().keys.mapNotNull(String::toIntOrNull).maxOrNull().orZero()
+            val capacity = (record.classLevel / spellPolicy.preparation.levelDivisor +
+                after.abilityScores.modifierFor(spellPolicy.preparation.abilityId))
+                .coerceAtLeast(spellPolicy.preparation.minimumPreparedSpells)
+            var retainedPrepared = 0
+            changedSpells.removeAll { stored ->
+                val belongsToClass = stored.sourceClass.equals(selectedClass.id, ignoreCase = true) ||
+                    stored.sourceClass.equals(selectedClass.name, ignoreCase = true)
+                val spell = referenceData.spellsById[stored.spellId]
+                when {
+                    !belongsToClass -> false
+                    spell == null -> true
+                    spell.level == 0 -> false
+                    else -> {
+                        val eligible = selectedClass.id in spell.classes.map { it.id } && spell.level <= maxSpellLevel
+                        val preserve = eligible && retainedPrepared < capacity
+                        if (preserve) retainedPrepared++
+                        !preserve
+                    }
+                }
+            }
+        }
+        return copy(
+            level = after.totalLevel,
+            className = after.classDisplayName,
+            abilityScores = after.abilityScores,
+            proficiencyBonus = after.proficiencyBonus,
+            maxHitPoints = after.maximumHitPoints,
+            // Managed pools replace the old free-text hit-dice field; manual sheets remain untouched.
+            hitDice = "",
+            spellSlots = slots,
+            pactSlots = pact,
+            savingThrows = savingThrows.map { save ->
+                save.copy(proficient = save.proficient || save.abilityId in after.savingThrowAbilityIds)
+            },
+            skills = skills.map { skill ->
+                val skillId = "skill-${skill.skill.name.lowercase().replace('_', '-')}"
+                skill.copy(proficient = skill.proficient || skillId in after.proficiencyIds)
+            },
+            characterSpells = changedSpells.sortedWith(compareBy({ it.sourceClass }, { it.spellId })),
+            managedProgression = ManagedProgressionSheetState(
+                hitDicePools = pools,
+                proficiencyIds = after.proficiencyIds,
+                savingThrowAbilityIds = after.savingThrowAbilityIds,
+                featureIds = after.featureIds,
+            ),
+        )
+    }
+
+    private fun Int?.orZero(): Int = this ?: 0
 }

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/data/repository/FeatsRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/data/repository/FeatsRepositoryImpl.kt
@@ -1,0 +1,18 @@
+package com.github.arhor.spellbindr.data.repository
+
+import com.github.arhor.spellbindr.data.local.assets.FeatsAssetDataStore
+import com.github.arhor.spellbindr.domain.model.Feat
+import com.github.arhor.spellbindr.domain.model.Loadable
+import com.github.arhor.spellbindr.domain.repository.FeatsRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class FeatsRepositoryImpl @Inject constructor(
+    private val featsDataStore: FeatsAssetDataStore,
+) : FeatsRepository {
+
+    override val allFeatsState: Flow<Loadable<List<Feat>>>
+        get() = featsDataStore.data
+}

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/di/AssetDataStoreModule.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/di/AssetDataStoreModule.kt
@@ -10,6 +10,7 @@ import com.github.arhor.spellbindr.data.local.assets.ConditionsDataStore
 import com.github.arhor.spellbindr.data.local.assets.DefaultAssetBootstrapper
 import com.github.arhor.spellbindr.data.local.assets.EquipmentAssetDataStore
 import com.github.arhor.spellbindr.data.local.assets.FeaturesAssetDataStore
+import com.github.arhor.spellbindr.data.local.assets.FeatsAssetDataStore
 import com.github.arhor.spellbindr.data.local.assets.LanguagesAssetDataStore
 import com.github.arhor.spellbindr.data.local.assets.SpellAssetDataStore
 import com.github.arhor.spellbindr.data.local.assets.TraitsAssetDataStore
@@ -65,6 +66,11 @@ abstract class AssetDataStoreModule {
     @Binds
     @IntoSet
     abstract fun bindFeaturesAssetDataStore(dataStore: FeaturesAssetDataStore)
+        : AssetDataStore<*>
+
+    @Binds
+    @IntoSet
+    abstract fun bindFeatsAssetDataStore(dataStore: FeatsAssetDataStore)
         : AssetDataStore<*>
 
     @Binds

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/di/CommonDomainModule.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/di/CommonDomainModule.kt
@@ -7,6 +7,7 @@ import com.github.arhor.spellbindr.data.repository.CharacterClassRepositoryImpl
 import com.github.arhor.spellbindr.data.repository.ConditionsRepositoryImpl
 import com.github.arhor.spellbindr.data.repository.EquipmentRepositoryImpl
 import com.github.arhor.spellbindr.data.repository.FeaturesRepositoryImpl
+import com.github.arhor.spellbindr.data.repository.FeatsRepositoryImpl
 import com.github.arhor.spellbindr.data.repository.LanguagesRepositoryImpl
 import com.github.arhor.spellbindr.data.repository.RacesRepositoryImpl
 import com.github.arhor.spellbindr.data.repository.SpellsRepositoryImpl
@@ -18,6 +19,7 @@ import com.github.arhor.spellbindr.domain.repository.CharacterClassRepository
 import com.github.arhor.spellbindr.domain.repository.ConditionsRepository
 import com.github.arhor.spellbindr.domain.repository.EquipmentRepository
 import com.github.arhor.spellbindr.domain.repository.FeaturesRepository
+import com.github.arhor.spellbindr.domain.repository.FeatsRepository
 import com.github.arhor.spellbindr.domain.repository.LanguagesRepository
 import com.github.arhor.spellbindr.domain.repository.RacesRepository
 import com.github.arhor.spellbindr.domain.repository.SpellsRepository
@@ -38,6 +40,9 @@ abstract class CommonDomainModule {
 
     @Binds
     abstract fun bindFeaturesRepository(impl: FeaturesRepositoryImpl): FeaturesRepository
+
+    @Binds
+    abstract fun bindFeatsRepository(impl: FeatsRepositoryImpl): FeatsRepository
 
     @Binds
     abstract fun bindLanguagesRepository(impl: LanguagesRepositoryImpl): LanguagesRepository

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/domain/model/ApplyLevelUpResult.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/domain/model/ApplyLevelUpResult.kt
@@ -1,0 +1,15 @@
+package com.github.arhor.spellbindr.domain.model
+
+/** Result of a stale-safe one-level persistence attempt. */
+sealed interface ApplyLevelUpResult {
+    data class Success(
+        val sheet: CharacterSheet,
+        val progression: CharacterProgression,
+    ) : ApplyLevelUpResult
+
+    data object MissingCharacter : ApplyLevelUpResult
+    data object UnmanagedCharacter : ApplyLevelUpResult
+    data object StaleState : ApplyLevelUpResult
+    data class ValidationFailure(val issues: List<LevelUpValidationIssue>) : ApplyLevelUpResult
+    data class PersistenceFailure(val message: String) : ApplyLevelUpResult
+}

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/domain/model/CharacterClass.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/domain/model/CharacterClass.kt
@@ -6,7 +6,7 @@ import kotlinx.serialization.Serializable
 data class CharacterClass(
     val id: String,
     val name: String,
-//    val multiClassing: MultiClassing,
+    val multiClassing: MultiClassing? = null,
     val hitDie: Int,
     val proficiencies: List<String>,
     val proficiencyChoices: List<Choice>,

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/domain/model/CharacterProgression.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/domain/model/CharacterProgression.kt
@@ -51,7 +51,13 @@ data class CharacterLevelRecord(
     val featureChoices: Map<String, Set<String>> = emptyMap(),
     val proficiencyChoices: List<ProficiencyChoiceSelection> = emptyList(),
     val abilityScoreDecision: AbilityScoreDecision? = null,
+    /** Selections owned by a feat, keyed by the feat's stable choice id. */
+    val featChoices: Map<String, Set<String>> = emptyMap(),
     val spellChanges: SpellChanges = SpellChanges(),
+    /** Overrideable rules explicitly acknowledged while this level was taken. */
+    val ruleAcknowledgements: Set<String> = emptySet(),
+    /** Optional player-facing context for an acknowledgement or manual HP result. */
+    val notes: String? = null,
 )
 
 @Serializable

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/domain/model/CharacterSheet.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/domain/model/CharacterSheet.kt
@@ -85,6 +85,33 @@ data class CharacterSheet(
     val notes: String = "",
     val characterSpells: List<CharacterSpell> = emptyList(),
     val weapons: List<Weapon> = emptyList(),
+    /** User-authored structured proficiencies; progression recalculation never replaces these ids. */
+    val manualProficiencyIds: Set<String> = emptySet(),
+    /**
+     * Derived, progression-owned state for managed characters.  It is intentionally separate from
+     * the free-text sheet fields so recalculating a level never rewrites player-authored notes.
+     */
+    val managedProgression: ManagedProgressionSheetState? = null,
+) {
+    /** The effective structured proficiency set used by persistence and rules checks. */
+    val allProficiencyIds: Set<String>
+        get() = manualProficiencyIds + managedProgression?.proficiencyIds.orEmpty()
+}
+
+@Serializable
+data class ManagedProgressionSheetState(
+    val hitDicePools: List<HitDicePoolState> = emptyList(),
+    val proficiencyIds: Set<String> = emptySet(),
+    val savingThrowAbilityIds: Set<AbilityId> = emptySet(),
+    val featureIds: Set<String> = emptySet(),
+)
+
+/** A managed hit-die pool; legacy [CharacterSheet.hitDice] stays available to unmanaged sheets. */
+@Serializable
+data class HitDicePoolState(
+    val dieSize: Int,
+    val total: Int,
+    val expended: Int = 0,
 )
 
 /**

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/domain/model/Feat.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/domain/model/Feat.kt
@@ -1,0 +1,23 @@
+package com.github.arhor.spellbindr.domain.model
+
+import kotlinx.serialization.Serializable
+
+/**
+ * A selectable feat from the bundled rules data.
+ *
+ * Only [effects] are intentionally machine-readable. Descriptive rules remain in [desc] and are
+ * shown to the player without being inferred by progression calculation.
+ */
+@Serializable
+data class Feat(
+    val id: String,
+    val name: String,
+    val desc: List<String>,
+    val prerequisites: List<Prerequisite> = emptyList(),
+    val effects: List<Effect> = emptyList(),
+    val abilityBonusChoice: Choice.AbilityBonusChoice? = null,
+) {
+    /** Stable persisted key for the feat-owned ability choice, when the feat has one. */
+    val abilityBonusChoiceId: String?
+        get() = abilityBonusChoice?.let { "$id:ability-bonus" }
+}

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/domain/model/LevelUpPlan.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/domain/model/LevelUpPlan.kt
@@ -1,0 +1,222 @@
+package com.github.arhor.spellbindr.domain.model
+
+import kotlinx.serialization.Serializable
+
+/**
+ * A serializable, one-level draft. The expected level protects confirmation from applying a stale draft.
+ *
+ * It intentionally stores ids rather than asset objects so it can be retained by a SavedStateHandle and rebuilt
+ * against a newer reference-data snapshot.
+ */
+@Serializable
+data class LevelUpPlan(
+    val expectedTotalLevel: Int,
+    val rulesetId: String,
+    val referenceDataVersion: String,
+    val selectedClassId: String? = null,
+    val selections: LevelUpSelections = LevelUpSelections(),
+)
+
+@Serializable
+data class LevelUpSelections(
+    val subclassId: String? = null,
+    val featureChoices: Map<String, Set<String>> = emptyMap(),
+    val proficiencyChoices: Map<String, Set<String>> = emptyMap(),
+    val hitPointGain: HitPointGain? = null,
+    val abilityScoreDecision: AbilityScoreDecision? = null,
+    val featChoices: Map<String, Set<String>> = emptyMap(),
+    val spellChanges: SpellChanges = SpellChanges(),
+    val acknowledgedIssueCodes: Set<String> = emptySet(),
+    val note: String? = null,
+)
+
+@Serializable
+enum class LevelUpValidationSeverity {
+    Blocking,
+    Overrideable,
+}
+
+@Serializable
+enum class LevelUpValidationCode {
+    UnmanagedCharacter,
+    StaleProgression,
+    UnsupportedRuleset,
+    ReferenceDataVersionMismatch,
+    CorruptProgression,
+    MissingClass,
+    MissingClassLevel,
+    MissingSubclass,
+    MissingFeature,
+    MaximumCharacterLevel,
+    MaximumClassLevel,
+    MulticlassPrerequisite,
+    ExperienceThreshold,
+    SubclassRequired,
+    StickySubclass,
+    ChoiceRequired,
+    InvalidChoice,
+    HitPointGainRequired,
+    InvalidHitPointGain,
+    AbilityScoreDecisionRequired,
+    InvalidAbilityScoreIncrease,
+    FeatRequired,
+    FeatPrerequisite,
+    MissingFeat,
+    SpellPolicy,
+}
+
+@Serializable
+data class LevelUpValidationIssue(
+    val code: LevelUpValidationCode,
+    val message: String,
+    val severity: LevelUpValidationSeverity,
+) {
+    val acknowledgementId: String
+        get() = code.name
+}
+
+@Serializable
+sealed interface LevelUpRequirement {
+    val id: String
+
+    @Serializable
+    data class ClassSelection(
+        override val id: String = "class-selection",
+        val eligibleClassIds: List<String>,
+        val selectedClassId: String?,
+        /** Per-class rule status; ineligible prerequisite entries remain selectable through acknowledgement. */
+        val eligibility: List<LevelUpClassEligibility> = emptyList(),
+    ) : LevelUpRequirement
+
+    @Serializable
+    data class SubclassSelection(
+        override val id: String,
+        val classId: String,
+        val options: List<LevelUpChoiceOption>,
+        val selectedSubclassId: String?,
+    ) : LevelUpRequirement
+
+    @Serializable
+    data class ChoiceSelection(
+        override val id: String,
+        val sourceId: String,
+        val label: String,
+        val choice: Choice,
+        val selectedOptionIds: Set<String>,
+        val category: LevelUpChoiceCategory,
+    ) : LevelUpRequirement
+
+    @Serializable
+    data class HitPoints(
+        override val id: String = "hit-points",
+        val hitDie: Int,
+        val selectedGain: HitPointGain?,
+    ) : LevelUpRequirement
+
+    @Serializable
+    data class AbilityScoreImprovement(
+        override val id: String,
+        val classId: String,
+        val abilityPoints: Int,
+        val maximumAbilityScore: Int,
+        val allowsFeat: Boolean,
+        val selectedDecision: AbilityScoreDecision?,
+    ) : LevelUpRequirement
+
+    /** The spell subsystem owns exact spell selection counts and legality. */
+    @Serializable
+    data class SpellDecisions(
+        override val id: String,
+        val classId: String,
+        val classLevel: Int,
+        val policyId: String,
+        val changes: SpellChanges,
+        /** A mutable prepared list may contain at most this many spells, when applicable. */
+        val preparationCapacity: Int? = null,
+    ) : LevelUpRequirement
+
+    @Serializable
+    data class Acknowledgement(
+        override val id: String,
+        val issue: LevelUpValidationIssue,
+        val acknowledged: Boolean,
+    ) : LevelUpRequirement
+}
+
+@Serializable
+data class LevelUpClassEligibility(
+    val classId: String,
+    val eligible: Boolean,
+    val reasons: List<String> = emptyList(),
+)
+
+@Serializable
+enum class LevelUpChoiceCategory {
+    Feature,
+    Proficiency,
+    Feat,
+}
+
+@Serializable
+data class LevelUpChoiceOption(
+    val id: String,
+    val label: String = id,
+)
+
+@Serializable
+data class LevelUpHitDicePool(
+    val dieSize: Int,
+    val total: Int,
+)
+
+@Serializable
+data class LevelUpSnapshot(
+    val totalLevel: Int,
+    val classLevels: Map<String, Int>,
+    val classDisplayName: String,
+    val proficiencyBonus: Int,
+    val abilityScores: AbilityScores,
+    val maximumHitPoints: Int,
+    val hitDicePools: List<LevelUpHitDicePool>,
+    val proficiencyIds: Set<String>,
+    val savingThrowAbilityIds: Set<AbilityId>,
+    val featureIds: Set<String>,
+    val sharedCasterLevel: Int,
+    val sharedSpellSlots: Map<Int, Int>,
+    /** Pact Magic never contributes to the shared multiclass slot table. */
+    val pactMagic: LevelUpPactMagicCapacity? = null,
+)
+
+@Serializable
+data class LevelUpPactMagicCapacity(
+    val slotLevel: Int,
+    val slots: Int,
+)
+
+@Serializable
+data class LevelUpPreview(
+    val before: LevelUpSnapshot,
+    val after: LevelUpSnapshot,
+    val requirements: List<LevelUpRequirement>,
+    val validations: List<LevelUpValidationIssue>,
+) {
+    val canConfirm: Boolean
+        get() = validations.none { it.severity == LevelUpValidationSeverity.Blocking } &&
+            validations.filter { it.severity == LevelUpValidationSeverity.Overrideable }
+                .all { issue -> requirements.filterIsInstance<LevelUpRequirement.Acknowledgement>()
+                    .any { it.id == issue.acknowledgementId && it.acknowledged } }
+}
+
+/** Reference data used by the pure engine; repositories adapt their loaded assets into this value. */
+data class LevelUpReferenceData(
+    val classes: List<CharacterClass>,
+    val features: List<Feature>,
+    val feats: List<Feat> = emptyList(),
+    val referenceDataVersion: String = LevelUpReferenceRules.referenceDataVersion,
+    val spells: List<Spell> = emptyList(),
+) {
+    val classesById: Map<String, CharacterClass> = classes.associateBy(CharacterClass::id)
+    val featuresById: Map<String, Feature> = features.associateBy(Feature::id)
+    val featsById: Map<String, Feat> = feats.associateBy(Feat::id)
+    val spellsById: Map<String, Spell> = spells.associateBy(Spell::id)
+}

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/domain/model/LevelUpReferenceRules.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/domain/model/LevelUpReferenceRules.kt
@@ -1,0 +1,217 @@
+package com.github.arhor.spellbindr.domain.model
+
+/** Versioned, structured rules consumed by level-up planning and materialization. */
+object LevelUpReferenceRules {
+
+    const val rulesetId: String = CharacterProgression.SUPPORTED_RULESET_ID
+    const val referenceDataVersion: String = CharacterProgression.BUNDLED_REFERENCE_DATA_VERSION
+    const val maximumCharacterLevel: Int = 20
+
+    val experienceThresholds: Map<Int, Int> = mapOf(
+        1 to 0,
+        2 to 300,
+        3 to 900,
+        4 to 2_700,
+        5 to 6_500,
+        6 to 14_000,
+        7 to 23_000,
+        8 to 34_000,
+        9 to 48_000,
+        10 to 64_000,
+        11 to 85_000,
+        12 to 100_000,
+        13 to 120_000,
+        14 to 140_000,
+        15 to 165_000,
+        16 to 195_000,
+        17 to 225_000,
+        18 to 265_000,
+        19 to 305_000,
+        20 to 355_000,
+    )
+
+    /** The multiclass spell-slot table; Pact Magic slots are deliberately excluded. */
+    val sharedSpellSlots: Map<Int, Map<Int, Int>> = mapOf(
+        1 to mapOf(1 to 2),
+        2 to mapOf(1 to 3),
+        3 to mapOf(1 to 4, 2 to 2),
+        4 to mapOf(1 to 4, 2 to 3),
+        5 to mapOf(1 to 4, 2 to 3, 3 to 2),
+        6 to mapOf(1 to 4, 2 to 3, 3 to 3),
+        7 to mapOf(1 to 4, 2 to 3, 3 to 3, 4 to 1),
+        8 to mapOf(1 to 4, 2 to 3, 3 to 3, 4 to 2),
+        9 to mapOf(1 to 4, 2 to 3, 3 to 3, 4 to 3, 5 to 1),
+        10 to mapOf(1 to 4, 2 to 3, 3 to 3, 4 to 3, 5 to 2),
+        11 to mapOf(1 to 4, 2 to 3, 3 to 3, 4 to 3, 5 to 2, 6 to 1),
+        12 to mapOf(1 to 4, 2 to 3, 3 to 3, 4 to 3, 5 to 2, 6 to 1),
+        13 to mapOf(1 to 4, 2 to 3, 3 to 3, 4 to 3, 5 to 2, 6 to 1, 7 to 1),
+        14 to mapOf(1 to 4, 2 to 3, 3 to 3, 4 to 3, 5 to 2, 6 to 1, 7 to 1),
+        15 to mapOf(1 to 4, 2 to 3, 3 to 3, 4 to 3, 5 to 2, 6 to 1, 7 to 1, 8 to 1),
+        16 to mapOf(1 to 4, 2 to 3, 3 to 3, 4 to 3, 5 to 2, 6 to 1, 7 to 1, 8 to 1),
+        17 to mapOf(1 to 4, 2 to 3, 3 to 3, 4 to 3, 5 to 2, 6 to 1, 7 to 1, 8 to 1, 9 to 1),
+        18 to mapOf(1 to 4, 2 to 3, 3 to 3, 4 to 3, 5 to 3, 6 to 1, 7 to 1, 8 to 1, 9 to 1),
+        19 to mapOf(1 to 4, 2 to 3, 3 to 3, 4 to 3, 5 to 3, 6 to 2, 7 to 1, 8 to 1, 9 to 1),
+        20 to mapOf(1 to 4, 2 to 3, 3 to 3, 4 to 3, 5 to 3, 6 to 2, 7 to 2, 8 to 1, 9 to 1),
+    )
+
+    val pactMagic: PactMagicPolicy = PactMagicPolicy(classId = "warlock")
+
+    private val standardAsiLevels: Set<Int> = setOf(4, 8, 12, 16, 19)
+    private val fighterAsiLevels: Set<Int> = setOf(4, 6, 8, 12, 14, 16, 19)
+    private val rogueAsiLevels: Set<Int> = setOf(4, 8, 10, 12, 16, 19)
+
+    val classPolicies: Map<String, CharacterClassLevelUpPolicy> = mapOf(
+        "barbarian" to nonCasterPolicy(subclassLevel = 3, abilityScoreImprovementLevels = standardAsiLevels),
+        "bard" to knownCasterPolicy(subclassLevel = 3),
+        "cleric" to preparedCasterPolicy(subclassLevel = 1, abilityId = AbilityIds.WIS),
+        "druid" to preparedCasterPolicy(subclassLevel = 2, abilityId = AbilityIds.WIS),
+        "fighter" to nonCasterPolicy(subclassLevel = 3, abilityScoreImprovementLevels = fighterAsiLevels).copy(
+            subclassCasterContributions = mapOf("eldritch-knight" to CasterContribution.Third),
+        ),
+        "monk" to nonCasterPolicy(subclassLevel = 3, abilityScoreImprovementLevels = standardAsiLevels),
+        "paladin" to preparedCasterPolicy(
+            subclassLevel = 3,
+            abilityId = AbilityIds.CHA,
+            contribution = CasterContribution.Half,
+            preparationLevelDivisor = 2,
+        ),
+        "ranger" to knownCasterPolicy(subclassLevel = 3, contribution = CasterContribution.Half),
+        "rogue" to nonCasterPolicy(subclassLevel = 3, abilityScoreImprovementLevels = rogueAsiLevels).copy(
+            subclassCasterContributions = mapOf("arcane-trickster" to CasterContribution.Third),
+        ),
+        "sorcerer" to knownCasterPolicy(subclassLevel = 1),
+        "warlock" to CharacterClassLevelUpPolicy(
+            subclass = SubclassAcquisitionPolicy(level = 1),
+            abilityScoreImprovement = AbilityScoreImprovementPolicy(standardAsiLevels),
+            casterContribution = CasterContribution.Pact,
+            spells = SpellLearningPolicy.Known(replacementStartsAtLevel = 2),
+        ),
+        "wizard" to CharacterClassLevelUpPolicy(
+            subclass = SubclassAcquisitionPolicy(level = 2),
+            abilityScoreImprovement = AbilityScoreImprovementPolicy(standardAsiLevels),
+            casterContribution = CasterContribution.Full,
+            spells = SpellLearningPolicy.Spellbook(
+                spellsAtFirstLevel = 6,
+                spellsAddedPerLevel = 2,
+                preparation = SpellPreparationPolicy(abilityId = AbilityIds.INT, levelDivisor = 1),
+            ),
+        ),
+    )
+
+    fun policyFor(classId: String): CharacterClassLevelUpPolicy? = classPolicies[classId]
+
+    private fun nonCasterPolicy(
+        subclassLevel: Int,
+        abilityScoreImprovementLevels: Set<Int>,
+    ) = CharacterClassLevelUpPolicy(
+        subclass = SubclassAcquisitionPolicy(level = subclassLevel),
+        abilityScoreImprovement = AbilityScoreImprovementPolicy(abilityScoreImprovementLevels),
+    )
+
+    private fun knownCasterPolicy(
+        subclassLevel: Int,
+        contribution: CasterContribution = CasterContribution.Full,
+    ) = CharacterClassLevelUpPolicy(
+        subclass = SubclassAcquisitionPolicy(level = subclassLevel),
+        abilityScoreImprovement = AbilityScoreImprovementPolicy(standardAsiLevels),
+        casterContribution = contribution,
+        spells = SpellLearningPolicy.Known(replacementStartsAtLevel = 2),
+    )
+
+    private fun preparedCasterPolicy(
+        subclassLevel: Int,
+        abilityId: AbilityId,
+        contribution: CasterContribution = CasterContribution.Full,
+        preparationLevelDivisor: Int = 1,
+    ) = CharacterClassLevelUpPolicy(
+        subclass = SubclassAcquisitionPolicy(level = subclassLevel),
+        abilityScoreImprovement = AbilityScoreImprovementPolicy(standardAsiLevels),
+        casterContribution = contribution,
+        spells = SpellLearningPolicy.Prepared(
+            SpellPreparationPolicy(abilityId = abilityId, levelDivisor = preparationLevelDivisor),
+        ),
+    )
+}
+
+data class CharacterClassLevelUpPolicy(
+    val subclass: SubclassAcquisitionPolicy,
+    val abilityScoreImprovement: AbilityScoreImprovementPolicy,
+    val casterContribution: CasterContribution = CasterContribution.None,
+    val spells: SpellLearningPolicy = SpellLearningPolicy.None,
+    /** Subclasses such as Eldritch Knight and Arcane Trickster can opt into multiclass casting. */
+    val subclassCasterContributions: Map<String, CasterContribution> = emptyMap(),
+)
+
+data class SubclassAcquisitionPolicy(
+    val level: Int,
+    val selectionIsSticky: Boolean = true,
+)
+
+data class AbilityScoreImprovementPolicy(
+    val levels: Set<Int>,
+    val abilityPoints: Int = 2,
+    val maximumAbilityScore: Int = 20,
+    val allowsFeat: Boolean = true,
+)
+
+sealed interface CasterContribution {
+    data object None : CasterContribution
+    data object Full : CasterContribution
+    data object Half : CasterContribution
+    data object Third : CasterContribution
+    data object Pact : CasterContribution
+}
+
+sealed interface SpellLearningPolicy {
+    data object None : SpellLearningPolicy
+    data class Known(val replacementStartsAtLevel: Int) : SpellLearningPolicy
+    data class Prepared(val preparation: SpellPreparationPolicy) : SpellLearningPolicy
+    data class Spellbook(
+        val spellsAtFirstLevel: Int,
+        val spellsAddedPerLevel: Int,
+        val preparation: SpellPreparationPolicy,
+    ) : SpellLearningPolicy
+}
+
+data class SpellPreparationPolicy(
+    val abilityId: AbilityId,
+    val levelDivisor: Int,
+    val minimumPreparedSpells: Int = 1,
+)
+
+data class PactMagicPolicy(
+    val classId: String,
+    val slotsRefreshOnShortRest: Boolean = true,
+)
+
+/** Descriptive features never participate in calculations unless they carry a structured [Choice]. */
+sealed interface FeatureCapability {
+    data object Descriptive : FeatureCapability
+    data class Selection(
+        val choiceId: String,
+        val choose: Int,
+        val kind: FeatureChoiceKind,
+    ) : FeatureCapability
+}
+
+enum class FeatureChoiceKind {
+    Options,
+    Nested,
+    Proficiency,
+    AbilityBonus,
+    Other,
+}
+
+fun Feature.levelUpCapability(): FeatureCapability = choice?.let {
+    FeatureCapability.Selection(
+        choiceId = "$id:choice",
+        choose = it.choose,
+        kind = when (it) {
+            is Choice.OptionsArrayChoice -> FeatureChoiceKind.Options
+            is Choice.NestedChoice -> FeatureChoiceKind.Nested
+            is Choice.ProficiencyChoice -> FeatureChoiceKind.Proficiency
+            is Choice.AbilityBonusChoice -> FeatureChoiceKind.AbilityBonus
+            else -> FeatureChoiceKind.Other
+        },
+    )
+} ?: FeatureCapability.Descriptive

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/domain/model/MultiClassing.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/domain/model/MultiClassing.kt
@@ -1,11 +1,16 @@
 package com.github.arhor.spellbindr.domain.model
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-
 
 @Serializable
 data class MultiClassing(
-    val prerequisites: List<MultiClassingPreReq>? = null,
-    val proficiencies: List<EntityRef>? = null,
-    val proficiencyChoices: List<Choice>? = null
-)
+    val prerequisites: List<AbilityScorePrerequisite> = emptyList(),
+    @SerialName("proficiencies")
+    val proficiencyGrants: List<String> = emptyList(),
+    val proficiencyChoices: List<Choice> = emptyList(),
+) {
+    /** A stable key for a multiclass-grant choice persisted in progression records. */
+    fun proficiencyChoiceId(classId: String, index: Int): String =
+        "$classId:multiclass-proficiency:$index"
+}

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/domain/model/MultiClassingPreReq.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/domain/model/MultiClassingPreReq.kt
@@ -1,9 +1,16 @@
 package com.github.arhor.spellbindr.domain.model
 
+import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
+/** A typed ability-score requirement used by class multiclassing rules. */
 @Serializable
-data class MultiClassingPreReq(
-    val abilityScore: EntityRef,
-    val minimumScore: Int
+data class AbilityScorePrerequisite(
+    val abilityScore: List<AbilityId>,
+    @SerialName("minimumValue")
+    val minimumScore: Int,
+    val atLeastOne: Boolean = false,
 )
+
+/** Kept as a source-compatible name for consumers of the original model. */
+typealias MultiClassingPreReq = AbilityScorePrerequisite

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/domain/repository/CharacterRepository.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/domain/repository/CharacterRepository.kt
@@ -5,6 +5,9 @@ import com.github.arhor.spellbindr.domain.model.CharacterCreationResult
 import com.github.arhor.spellbindr.domain.model.CharacterSheet
 import com.github.arhor.spellbindr.domain.model.CharacterWithProgression
 import com.github.arhor.spellbindr.domain.model.Loadable
+import com.github.arhor.spellbindr.domain.model.ApplyLevelUpResult
+import com.github.arhor.spellbindr.domain.model.LevelUpPlan
+import com.github.arhor.spellbindr.domain.model.LevelUpReferenceData
 import kotlinx.coroutines.flow.Flow
 
 /**
@@ -47,6 +50,14 @@ interface CharacterRepository {
      * Saves a character created by the guided flow with managed progression in one transaction.
      */
     suspend fun saveGuidedCharacter(result: CharacterCreationResult)
+
+    /** Atomically validates, materializes, and appends exactly one managed level. */
+    suspend fun applyLevelUp(
+        characterId: String,
+        expectedTotalLevel: Int,
+        plan: LevelUpPlan,
+        referenceData: LevelUpReferenceData,
+    ): ApplyLevelUpResult
 
     /**
      * Observes all characters as fully realized domain models.

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/domain/repository/FeatsRepository.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/domain/repository/FeatsRepository.kt
@@ -1,0 +1,9 @@
+package com.github.arhor.spellbindr.domain.repository
+
+import com.github.arhor.spellbindr.domain.model.Feat
+import com.github.arhor.spellbindr.domain.model.Loadable
+import kotlinx.coroutines.flow.Flow
+
+interface FeatsRepository {
+    val allFeatsState: Flow<Loadable<List<Feat>>>
+}

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/domain/usecase/ApplyLevelUpUseCase.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/domain/usecase/ApplyLevelUpUseCase.kt
@@ -1,0 +1,24 @@
+package com.github.arhor.spellbindr.domain.usecase
+
+import com.github.arhor.spellbindr.domain.model.ApplyLevelUpResult
+import com.github.arhor.spellbindr.domain.model.LevelUpPlan
+import com.github.arhor.spellbindr.domain.model.LevelUpReferenceData
+import com.github.arhor.spellbindr.domain.repository.CharacterRepository
+import javax.inject.Inject
+
+/** Confirms a reviewed plan through the repository's single atomic write boundary. */
+class ApplyLevelUpUseCase @Inject constructor(
+    private val characterRepository: CharacterRepository,
+) {
+    suspend operator fun invoke(
+        characterId: String,
+        expectedTotalLevel: Int,
+        plan: LevelUpPlan,
+        referenceData: LevelUpReferenceData,
+    ): ApplyLevelUpResult = characterRepository.applyLevelUp(
+        characterId = characterId,
+        expectedTotalLevel = expectedTotalLevel,
+        plan = plan,
+        referenceData = referenceData,
+    )
+}

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/domain/usecase/LevelUpProgressionEngine.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/domain/usecase/LevelUpProgressionEngine.kt
@@ -1,0 +1,773 @@
+package com.github.arhor.spellbindr.domain.usecase
+
+import com.github.arhor.spellbindr.domain.model.AbilityId
+import com.github.arhor.spellbindr.domain.model.AbilityIds
+import com.github.arhor.spellbindr.domain.model.AbilityScoreDecision
+import com.github.arhor.spellbindr.domain.model.AbilityScorePrerequisite
+import com.github.arhor.spellbindr.domain.model.AbilityScores
+import com.github.arhor.spellbindr.domain.model.CasterContribution
+import com.github.arhor.spellbindr.domain.model.CharacterClass
+import com.github.arhor.spellbindr.domain.model.CharacterLevelRecord
+import com.github.arhor.spellbindr.domain.model.CharacterProgression
+import com.github.arhor.spellbindr.domain.model.CharacterSheet
+import com.github.arhor.spellbindr.domain.model.Choice
+import com.github.arhor.spellbindr.domain.model.Effect
+import com.github.arhor.spellbindr.domain.model.Feature
+import com.github.arhor.spellbindr.domain.model.HitPointGain
+import com.github.arhor.spellbindr.domain.model.LevelUpChoiceCategory
+import com.github.arhor.spellbindr.domain.model.LevelUpChoiceOption
+import com.github.arhor.spellbindr.domain.model.LevelUpClassEligibility
+import com.github.arhor.spellbindr.domain.model.LevelUpHitDicePool
+import com.github.arhor.spellbindr.domain.model.LevelUpPlan
+import com.github.arhor.spellbindr.domain.model.LevelUpPactMagicCapacity
+import com.github.arhor.spellbindr.domain.model.LevelUpPreview
+import com.github.arhor.spellbindr.domain.model.LevelUpReferenceData
+import com.github.arhor.spellbindr.domain.model.LevelUpReferenceRules
+import com.github.arhor.spellbindr.domain.model.LevelUpRequirement
+import com.github.arhor.spellbindr.domain.model.LevelUpSelections
+import com.github.arhor.spellbindr.domain.model.LevelUpSnapshot
+import com.github.arhor.spellbindr.domain.model.LevelUpValidationCode
+import com.github.arhor.spellbindr.domain.model.LevelUpValidationIssue
+import com.github.arhor.spellbindr.domain.model.LevelUpValidationSeverity
+import com.github.arhor.spellbindr.domain.model.ProficiencyChoiceSelection
+import com.github.arhor.spellbindr.domain.model.SpellLearningPolicy
+import javax.inject.Inject
+
+/** Creates an empty, stale-safe one-level draft without inspecting a UI state. */
+class CreateLevelUpPlanUseCase @Inject constructor() {
+    operator fun invoke(progression: CharacterProgression): LevelUpPlan = LevelUpPlan(
+        expectedTotalLevel = progression.totalLevel,
+        rulesetId = progression.rulesetId,
+        referenceDataVersion = progression.referenceDataVersion,
+    )
+}
+
+/** Rebuilds a draft after every selection. All calculations are deterministic and side-effect free. */
+class RebuildLevelUpPlanUseCase @Inject constructor() {
+    operator fun invoke(
+        sheet: CharacterSheet,
+        progression: CharacterProgression,
+        plan: LevelUpPlan,
+        referenceData: LevelUpReferenceData,
+    ): LevelUpPreview = LevelUpProgressionEngine.rebuild(sheet, progression, plan, referenceData)
+}
+
+/** Exposes validation without making callers duplicate the preview calculation. */
+class ValidateLevelUpPlanUseCase @Inject constructor() {
+    operator fun invoke(
+        sheet: CharacterSheet,
+        progression: CharacterProgression,
+        plan: LevelUpPlan,
+        referenceData: LevelUpReferenceData,
+    ): List<LevelUpValidationIssue> =
+        LevelUpProgressionEngine.rebuild(sheet, progression, plan, referenceData).validations
+}
+
+/**
+ * Pure rules engine shared by the wizard and the eventual transactional materializer.
+ *
+ * Spell legality deliberately remains a contract-only requirement here; the spell subsystem can extend it without
+ * changing level ordering, multiclass checks, or the persisted draft shape.
+ */
+object LevelUpProgressionEngine {
+
+    fun rebuild(
+        sheet: CharacterSheet,
+        progression: CharacterProgression,
+        plan: LevelUpPlan,
+        referenceData: LevelUpReferenceData,
+    ): LevelUpPreview {
+        val validations = validateBaseState(sheet, progression, plan, referenceData).toMutableList()
+        val selectedClass = plan.selectedClassId?.let(referenceData.classesById::get)
+        val nextClassLevel = selectedClass?.let { progression.classLevels[it.id].orZero() + 1 }
+
+        if (plan.selectedClassId == null) {
+            validations += blocking(LevelUpValidationCode.ChoiceRequired, "Choose a class to level up.")
+        } else if (selectedClass == null) {
+            validations += blocking(LevelUpValidationCode.MissingClass, "The selected class no longer exists in reference data.")
+        }
+        if (progression.totalLevel >= LevelUpReferenceRules.maximumCharacterLevel) {
+            validations += blocking(LevelUpValidationCode.MaximumCharacterLevel, "Maximum character level reached.")
+        }
+        if (nextClassLevel != null && nextClassLevel > LevelUpReferenceRules.maximumCharacterLevel) {
+            validations += blocking(LevelUpValidationCode.MaximumClassLevel, "A class cannot exceed level 20.")
+        }
+
+        if (selectedClass != null && nextClassLevel != null) {
+            validateClassSelection(sheet, progression, selectedClass, nextClassLevel, referenceData, validations)
+            validateSelections(sheet, progression, plan, selectedClass, nextClassLevel, referenceData, validations)
+        }
+
+        val requirements = requirementsFor(
+            abilities = sheet.abilityScores,
+            progression = progression,
+            plan = plan,
+            selectedClass = selectedClass,
+            nextClassLevel = nextClassLevel,
+            referenceData = referenceData,
+            validations = validations,
+        )
+        val afterProgression = selectedClass?.let { clazz ->
+            nextClassLevel?.let { classLevel ->
+                progression.copy(levels = progression.levels + recordFor(plan, clazz, classLevel, progression, referenceData, validations))
+            }
+        } ?: progression
+        val before = snapshot(sheet.abilityScores, progression, referenceData)
+        val after = snapshot(applyAbilityDecision(sheet.abilityScores, plan.selections, referenceData), afterProgression, referenceData)
+        return LevelUpPreview(before, after, requirements, validations.distinctBy { it.code to it.message })
+    }
+
+    /** Creates the persisted record only after [rebuild] reports that confirmation is allowed. */
+    fun recordFor(
+        plan: LevelUpPlan,
+        clazz: CharacterClass,
+        classLevel: Int,
+        progression: CharacterProgression,
+        referenceData: LevelUpReferenceData,
+        validations: List<LevelUpValidationIssue> = emptyList(),
+    ): CharacterLevelRecord {
+        val resolvedSubclass = plan.selections.subclassId ?: subclassFor(clazz.id, progression)
+        val featureIds = activeFeatureChoices(clazz, classLevel, resolvedSubclass, referenceData)
+            .mapTo(linkedSetOf()) { "${it.first.id}:choice" }
+        val proficiencyIds = if (clazz.id !in progression.classLevels) {
+            val multiClassing = clazz.multiClassing
+            multiClassing?.proficiencyChoices.orEmpty().indices.mapTo(linkedSetOf()) {
+                multiClassing?.proficiencyChoiceId(clazz.id, it).orEmpty()
+            }
+        } else {
+            emptySet()
+        }
+        val featIds = (plan.selections.abilityScoreDecision as? AbilityScoreDecision.Feat)?.featId
+            ?.let(referenceData.featsById::get)?.abilityBonusChoiceId?.let(::setOf).orEmpty()
+        return plan.toRecord(
+            clazz = clazz,
+            classLevel = classLevel,
+            resolvedSubclassId = resolvedSubclass,
+            activeFeatureChoiceIds = featureIds,
+            activeProficiencyChoiceIds = proficiencyIds,
+            activeFeatChoiceIds = featIds,
+            activeAcknowledgementIds = validations.filter { it.severity == LevelUpValidationSeverity.Overrideable }
+                .mapTo(linkedSetOf(), LevelUpValidationIssue::acknowledgementId),
+        )
+    }
+
+    private fun validateBaseState(
+        sheet: CharacterSheet,
+        progression: CharacterProgression,
+        plan: LevelUpPlan,
+        data: LevelUpReferenceData,
+    ): List<LevelUpValidationIssue> = buildList {
+        if (sheet.level != progression.totalLevel || plan.expectedTotalLevel != progression.totalLevel) {
+            add(blocking(LevelUpValidationCode.StaleProgression, "The character changed; reload the level-up draft."))
+        }
+        if (progression.rulesetId != LevelUpReferenceRules.rulesetId || plan.rulesetId != progression.rulesetId) {
+            add(blocking(LevelUpValidationCode.UnsupportedRuleset, "This progression uses an unsupported ruleset."))
+        }
+        if (progression.referenceDataVersion != data.referenceDataVersion ||
+            plan.referenceDataVersion != progression.referenceDataVersion
+        ) {
+            add(blocking(LevelUpValidationCode.ReferenceDataVersionMismatch, "Reference data changed; reload the draft."))
+        }
+        progressionIntegrityIssue(progression, data)?.let(::add)
+    }
+
+    private fun progressionIntegrityIssue(
+        progression: CharacterProgression,
+        data: LevelUpReferenceData,
+    ): LevelUpValidationIssue? {
+        val counts = mutableMapOf<String, Int>()
+        progression.levels.forEachIndexed { index, record ->
+            val clazz = data.classesById[record.classId]
+                ?: return blocking(LevelUpValidationCode.MissingClass, "Progression references missing class ${record.classId}.")
+            val expectedClassLevel = counts.getOrDefault(record.classId, 0) + 1
+            if (record.characterLevel != index + 1 || record.classLevel != expectedClassLevel) {
+                return blocking(LevelUpValidationCode.CorruptProgression, "Progression level order is corrupt.")
+            }
+            if (clazz.levels.none { it.level == record.classLevel }) {
+                return blocking(LevelUpValidationCode.MissingClassLevel, "Class level data is missing for ${clazz.name}.")
+            }
+            record.subclassId?.let { subclassId ->
+                if (clazz.subclasses.none { it.id == subclassId }) {
+                    return blocking(LevelUpValidationCode.MissingSubclass, "Progression references missing subclass $subclassId.")
+                }
+            }
+            counts[record.classId] = expectedClassLevel
+        }
+        return null
+    }
+
+    private fun validateClassSelection(
+        sheet: CharacterSheet,
+        progression: CharacterProgression,
+        clazz: CharacterClass,
+        nextClassLevel: Int,
+        data: LevelUpReferenceData,
+        validations: MutableList<LevelUpValidationIssue>,
+    ) {
+        if (clazz.levels.none { it.level == nextClassLevel }) {
+            validations += blocking(LevelUpValidationCode.MissingClassLevel, "Class level data is missing for ${clazz.name}.")
+        }
+        val isNewClass = clazz.id !in progression.classLevels
+        if (isNewClass) {
+            (progression.classLevels.keys + clazz.id).sorted().forEach { classId ->
+                val classRule = data.classesById[classId]?.multiClassing
+                if (classRule == null) {
+                    validations += blocking(LevelUpValidationCode.MissingClass, "Multiclass rules are missing for $classId.")
+                } else if (!meetsPrerequisites(sheet.abilityScores, classRule.prerequisites)) {
+                    validations += overrideable(
+                        LevelUpValidationCode.MulticlassPrerequisite,
+                        "Ability prerequisites for ${data.classesById[classId]?.name ?: classId} are not met.",
+                    )
+                }
+            }
+        }
+        val targetLevel = progression.totalLevel + 1
+        val experience = sheet.experiencePoints
+        val threshold = LevelUpReferenceRules.experienceThresholds[targetLevel]
+        if (experience != null && threshold != null && experience < threshold) {
+            validations += overrideable(
+                LevelUpValidationCode.ExperienceThreshold,
+                "${threshold - experience} more XP is normally required for level $targetLevel.",
+            )
+        }
+    }
+
+    private fun validateSelections(
+        sheet: CharacterSheet,
+        progression: CharacterProgression,
+        plan: LevelUpPlan,
+        clazz: CharacterClass,
+        nextClassLevel: Int,
+        data: LevelUpReferenceData,
+        validations: MutableList<LevelUpValidationIssue>,
+    ) {
+        val selections = plan.selections
+        val existingSubclass = subclassFor(clazz.id, progression)
+        val requiresSubclass = LevelUpReferenceRules.policyFor(clazz.id)?.subclass?.level == nextClassLevel &&
+            existingSubclass == null
+        if (requiresSubclass && plan.selections.subclassId == null) {
+            validations += blocking(LevelUpValidationCode.SubclassRequired, "Choose a ${clazz.name} subclass.")
+        }
+        if (selections.subclassId != null && existingSubclass == null && !requiresSubclass) {
+            validations += blocking(LevelUpValidationCode.StickySubclass, "A subclass cannot be selected before its acquisition level.")
+        }
+        val proposedSubclass = selections.subclassId ?: existingSubclass
+        if (selections.subclassId != null && clazz.subclasses.none { it.id == selections.subclassId }) {
+            validations += blocking(LevelUpValidationCode.MissingSubclass, "The selected subclass does not belong to ${clazz.name}.")
+        }
+        if (existingSubclass != null && selections.subclassId != null && existingSubclass != selections.subclassId) {
+            validations += blocking(LevelUpValidationCode.StickySubclass, "A class subclass cannot be changed while leveling up.")
+        }
+
+        activeFeatureChoices(clazz, nextClassLevel, proposedSubclass, data).forEach { (feature, choice) ->
+            validateChoice(
+                id = "${feature.id}:choice",
+                choice = choice,
+                selected = selections.featureChoices["${feature.id}:choice"].orEmpty(),
+                label = feature.name,
+                validations = validations,
+            )
+        }
+        if (clazz.id !in progression.classLevels) {
+            clazz.multiClassing?.let { multiClassing -> multiClassing.proficiencyChoices.forEachIndexed { index, choice ->
+                val id = multiClassing.proficiencyChoiceId(clazz.id, index)
+                validateChoice(id, choice, selections.proficiencyChoices[id].orEmpty(), "${clazz.name} proficiency", validations)
+            } }
+        }
+        validateHitPointGain(selections.hitPointGain, clazz.hitDie, nextClassLevel, validations)
+        val asiPolicy = LevelUpReferenceRules.policyFor(clazz.id)?.abilityScoreImprovement
+        if (asiPolicy?.levels?.contains(nextClassLevel) == true) {
+            validateAbilityDecision(
+                sheet.abilityScores,
+                snapshot(sheet.abilityScores, progression, data).proficiencyIds,
+                selections,
+                asiPolicy.abilityPoints,
+                asiPolicy.maximumAbilityScore,
+                asiPolicy.allowsFeat,
+                data,
+                validations,
+            )
+        }
+        validateSpellChanges(progression, selections.spellChanges, clazz, nextClassLevel, data, validations)
+    }
+
+    private fun validateHitPointGain(
+        gain: HitPointGain?,
+        hitDie: Int,
+        classLevel: Int,
+        validations: MutableList<LevelUpValidationIssue>,
+    ) {
+        if (gain == null) {
+            validations += blocking(LevelUpValidationCode.HitPointGainRequired, "Choose a hit point gain.")
+            return
+        }
+        val expectedFixed = if (classLevel == 1) hitDie else hitDie / 2 + 1
+        val isValid = when (gain) {
+            is HitPointGain.Fixed -> gain.rolledValue == expectedFixed
+            is HitPointGain.Rolled -> gain.rolledValue in 1..hitDie
+            is HitPointGain.Manual -> gain.rolledValue >= 1
+        }
+        if (!isValid) validations += blocking(LevelUpValidationCode.InvalidHitPointGain, "The hit point gain is invalid.")
+    }
+
+    private fun validateAbilityDecision(
+        abilities: AbilityScores,
+        proficiencyIds: Set<String>,
+        selections: LevelUpSelections,
+        points: Int,
+        maximum: Int,
+        allowsFeat: Boolean,
+        data: LevelUpReferenceData,
+        validations: MutableList<LevelUpValidationIssue>,
+    ) {
+        when (val decision = selections.abilityScoreDecision) {
+            null -> validations += blocking(LevelUpValidationCode.AbilityScoreDecisionRequired, "Choose an ability score improvement or feat.")
+            is AbilityScoreDecision.Increase -> {
+                val validIds = decision.increases.keys.all { it in AbilityIds.standardOrder }
+                val validPoints = decision.increases.values.all { it > 0 } && decision.increases.values.sum() == points
+                val withinCap = decision.increases.all { (ability, amount) -> abilityScore(abilities, ability) + amount <= maximum }
+                if (!validIds || !validPoints || !withinCap) {
+                    validations += blocking(LevelUpValidationCode.InvalidAbilityScoreIncrease, "Ability score increases must use $points point(s) without exceeding $maximum.")
+                }
+            }
+            is AbilityScoreDecision.Feat -> {
+                if (!allowsFeat) {
+                    validations += blocking(LevelUpValidationCode.FeatRequired, "This class level does not allow a feat.")
+                }
+                val feat = data.featsById[decision.featId]
+                if (feat == null) {
+                    validations += blocking(LevelUpValidationCode.MissingFeat, "The selected feat no longer exists in reference data.")
+                } else {
+                    if (!meetsFeatPrerequisites(abilities, proficiencyIds, feat.prerequisites)) {
+                        validations += blocking(LevelUpValidationCode.FeatPrerequisite, "Prerequisites for ${feat.name} are not met.")
+                    }
+                    feat.abilityBonusChoice?.let { choice -> validateFeatChoice(feat.abilityBonusChoiceId.orEmpty(), choice,
+                        selections.featChoices[feat.abilityBonusChoiceId].orEmpty(), abilities, feat.name, validations) }
+                    val afterFeat = applyAbilityDecision(abilities, selections, data)
+                    if (AbilityIds.standardOrder.any { abilityScore(afterFeat, it) > 20 }) {
+                        validations += blocking(LevelUpValidationCode.InvalidAbilityScoreIncrease, "A feat cannot increase an ability score above 20.")
+                    }
+                }
+            }
+        }
+    }
+
+    /** Validates selections against the selected class's own spell progression, never multiclass slot level. */
+    private fun validateSpellChanges(
+        progression: CharacterProgression,
+        changes: com.github.arhor.spellbindr.domain.model.SpellChanges,
+        clazz: CharacterClass,
+        classLevel: Int,
+        data: LevelUpReferenceData,
+        validations: MutableList<LevelUpValidationIssue>,
+    ) {
+        val policy = LevelUpReferenceRules.policyFor(clazz.id)?.spells ?: return
+        if (policy == SpellLearningPolicy.None) return
+        val allRefs = changes.learned + changes.addedToSpellbook + changes.replaced.flatMapTo(linkedSetOf()) {
+            setOf(com.github.arhor.spellbindr.domain.model.ClassSpellRef(it.classId, it.removedSpellId),
+                com.github.arhor.spellbindr.domain.model.ClassSpellRef(it.classId, it.learnedSpellId))
+        }
+        if (allRefs.any { it.classId != clazz.id }) {
+            validations += blocking(LevelUpValidationCode.SpellPolicy, "Spell decisions must belong to ${clazz.name}.")
+            return
+        }
+        val classSpellcasting = clazz.levels.firstOrNull { it.level == classLevel }?.spellcasting
+        val previousSpellcasting = clazz.levels.firstOrNull { it.level == classLevel - 1 }?.spellcasting
+        fun spell(ref: com.github.arhor.spellbindr.domain.model.ClassSpellRef) = data.spellsById[ref.spellId]
+        val invalid = allRefs.any { ref ->
+            val value = spell(ref)
+            value == null || clazz.id !in value.classes.map { it.id } ||
+                value.level > classSpellcasting?.spellSlots.orEmpty().keys.maxOfOrNull { it.toInt() }.orZero()
+        }
+        if (invalid) validations += blocking(LevelUpValidationCode.SpellPolicy, "A selected spell is not legal for this class level.")
+        val selectedCantrips = changes.learned.count { spell(it)?.level == 0 }
+        val selectedKnown = changes.learned.count { spell(it)?.level?.let { level -> level > 0 } == true }
+        val expectedCantrips = (classSpellcasting?.cantrips.orZero() - previousSpellcasting?.cantrips.orZero()).coerceAtLeast(0)
+        when (policy) {
+            is SpellLearningPolicy.Known -> {
+                val expectedKnown = (classSpellcasting?.spells.orZero() - previousSpellcasting?.spells.orZero()).coerceAtLeast(0)
+                if (selectedCantrips != expectedCantrips || selectedKnown != expectedKnown) {
+                    validations += blocking(LevelUpValidationCode.SpellPolicy, "Choose the required known spells and cantrips for this class level.")
+                }
+                if (changes.addedToSpellbook.isNotEmpty() || changes.replaced.size > 1 ||
+                    (changes.replaced.isNotEmpty() && classLevel < policy.replacementStartsAtLevel)
+                ) validations += blocking(LevelUpValidationCode.SpellPolicy, "The selected spell replacement is not allowed at this class level.")
+                val currentlyKnown = classOwnedSpellIds(progression, clazz.id)
+                val removed = changes.replaced.map { it.removedSpellId }
+                val replacements = changes.replaced.map { it.learnedSpellId }
+                val learned = changes.learned.map { it.spellId }
+                if (removed.distinct().size != removed.size || replacements.distinct().size != replacements.size ||
+                    removed.any { it !in currentlyKnown } || changes.replaced.any { it.removedSpellId == it.learnedSpellId } ||
+                    replacements.any { it in currentlyKnown && it !in removed } ||
+                    (replacements + learned).distinct().size != replacements.size + learned.size ||
+                    learned.any { it in currentlyKnown && it !in removed }
+                ) {
+                    validations += blocking(
+                        LevelUpValidationCode.SpellPolicy,
+                        "Replacements must remove a currently known class spell and learn a distinct, non-duplicate spell.",
+                    )
+                }
+            }
+            is SpellLearningPolicy.Prepared -> {
+                if (selectedCantrips != expectedCantrips || selectedKnown != 0 || changes.addedToSpellbook.isNotEmpty() || changes.replaced.isNotEmpty()) {
+                    validations += blocking(LevelUpValidationCode.SpellPolicy, "Prepared casters only choose newly gained cantrips here.")
+                }
+            }
+            is SpellLearningPolicy.Spellbook -> {
+                val expectedBook = if (classLevel == 1) policy.spellsAtFirstLevel else policy.spellsAddedPerLevel
+                if (selectedCantrips != expectedCantrips || selectedKnown != 0 || changes.addedToSpellbook.size != expectedBook || changes.replaced.isNotEmpty()) {
+                    validations += blocking(LevelUpValidationCode.SpellPolicy, "Choose the required spellbook additions and cantrips for this class level.")
+                }
+                if (changes.addedToSpellbook.any { spell(it)?.level == 0 }) {
+                    validations += blocking(LevelUpValidationCode.SpellPolicy, "Cantrips are not spellbook additions.")
+                }
+            }
+            SpellLearningPolicy.None -> Unit
+        }
+    }
+
+    private fun requirementsFor(
+        abilities: AbilityScores,
+        progression: CharacterProgression,
+        plan: LevelUpPlan,
+        selectedClass: CharacterClass?,
+        nextClassLevel: Int?,
+        referenceData: LevelUpReferenceData,
+        validations: List<LevelUpValidationIssue>,
+    ): List<LevelUpRequirement> = buildList {
+        val eligibility = referenceData.classes.sortedBy { it.id }.map { candidate ->
+            classEligibility(abilities, progression, candidate, referenceData)
+        }
+        add(LevelUpRequirement.ClassSelection(
+            eligibleClassIds = eligibility.filter(LevelUpClassEligibility::eligible).map(LevelUpClassEligibility::classId),
+            selectedClassId = plan.selectedClassId,
+            eligibility = eligibility,
+        ))
+        if (selectedClass == null || nextClassLevel == null) return@buildList
+        val existingSubclass = subclassFor(selectedClass.id, progression)
+        if (LevelUpReferenceRules.policyFor(selectedClass.id)?.subclass?.level == nextClassLevel && existingSubclass == null) {
+            add(LevelUpRequirement.SubclassSelection(
+                id = "${selectedClass.id}:subclass",
+                classId = selectedClass.id,
+                options = selectedClass.subclasses.map { LevelUpChoiceOption(it.id, it.name) }.sortedBy { it.id },
+                selectedSubclassId = plan.selections.subclassId,
+            ))
+        }
+        val subclass = plan.selections.subclassId ?: existingSubclass
+        activeFeatureChoices(selectedClass, nextClassLevel, subclass, referenceData).forEach { (feature, choice) ->
+            val id = "${feature.id}:choice"
+            add(LevelUpRequirement.ChoiceSelection(id, feature.id, feature.name, choice,
+                plan.selections.featureChoices[id].orEmpty(), LevelUpChoiceCategory.Feature))
+        }
+        if (selectedClass.id !in progression.classLevels) selectedClass.multiClassing?.let { multiClassing -> multiClassing.proficiencyChoices
+            .forEachIndexed { index, choice ->
+                val id = multiClassing.proficiencyChoiceId(selectedClass.id, index)
+                add(LevelUpRequirement.ChoiceSelection(id, selectedClass.id, "${selectedClass.name} proficiency", choice,
+                    plan.selections.proficiencyChoices[id].orEmpty(), LevelUpChoiceCategory.Proficiency))
+            } }
+        add(LevelUpRequirement.HitPoints(hitDie = selectedClass.hitDie, selectedGain = plan.selections.hitPointGain))
+        LevelUpReferenceRules.policyFor(selectedClass.id)?.let { policy ->
+            if (nextClassLevel in policy.abilityScoreImprovement.levels) add(LevelUpRequirement.AbilityScoreImprovement(
+                id = "${selectedClass.id}:$nextClassLevel:asi", classId = selectedClass.id,
+                abilityPoints = policy.abilityScoreImprovement.abilityPoints,
+                maximumAbilityScore = policy.abilityScoreImprovement.maximumAbilityScore,
+                allowsFeat = policy.abilityScoreImprovement.allowsFeat,
+                selectedDecision = plan.selections.abilityScoreDecision,
+            ))
+            if (policy.spells != SpellLearningPolicy.None) add(LevelUpRequirement.SpellDecisions(
+                id = "${selectedClass.id}:$nextClassLevel:spells", classId = selectedClass.id,
+                classLevel = nextClassLevel, policyId = spellPolicyId(policy.spells), changes = plan.selections.spellChanges,
+                preparationCapacity = preparationCapacity(policy.spells, nextClassLevel, abilities, plan, referenceData),
+            ))
+        }
+        validations.filter { it.severity == LevelUpValidationSeverity.Overrideable }.forEach { issue ->
+            add(LevelUpRequirement.Acknowledgement(issue.acknowledgementId, issue,
+                issue.acknowledgementId in plan.selections.acknowledgedIssueCodes))
+        }
+    }
+
+    private fun snapshot(
+        abilities: AbilityScores,
+        progression: CharacterProgression,
+        data: LevelUpReferenceData,
+    ): LevelUpSnapshot {
+        val classesById = data.classesById
+        val classLevels = progression.classLevels
+        val pools = progression.levels.groupBy { record -> classesById[record.classId]?.hitDie ?: 0 }
+            .filterKeys { it > 0 }.map { (die, records) -> LevelUpHitDicePool(die, records.size) }.sortedBy { it.dieSize }
+        val firstClass = progression.levels.firstOrNull()?.classId
+        val proficiencyIds = linkedSetOf<String>()
+        val savingThrows = linkedSetOf<AbilityId>()
+        val featureIds = linkedSetOf<String>()
+        progression.levels.forEachIndexed { index, record ->
+            val clazz = classesById[record.classId] ?: return@forEachIndexed
+            if (index == 0) {
+                proficiencyIds += clazz.proficiencies
+                savingThrows += clazz.savingThrows
+            } else if (record.classLevel == 1) {
+                proficiencyIds += clazz.multiClassing?.proficiencyGrants.orEmpty()
+            }
+            proficiencyIds += record.proficiencyChoices.flatMap { it.selectedProficiencyIds }
+            clazz.levels.firstOrNull { it.level == record.classLevel }?.features?.let(featureIds::addAll)
+            record.subclassId?.let { subclassId -> clazz.subclasses.firstOrNull { it.id == subclassId }
+                ?.levels?.firstOrNull { it.level == record.classLevel }?.features?.let(featureIds::addAll) }
+        }
+        val sharedCasterLevel = classLevels.entries.sumOf { (classId, level) -> when (casterContributionFor(classId, progression)) {
+            CasterContribution.Full -> level
+            CasterContribution.Half -> level / 2
+            CasterContribution.Third -> level / 3
+            else -> 0
+        } }
+        val warlockLevel = classLevels[LevelUpReferenceRules.pactMagic.classId].orZero()
+        val pactMagic = warlockLevel.takeIf { it > 0 }?.let { level ->
+            LevelUpPactMagicCapacity(
+                slotLevel = when (level) { in 1..2 -> 1; in 3..4 -> 2; in 5..6 -> 3; in 7..8 -> 4; else -> 5 },
+                slots = when (level) { 1 -> 1; in 2..10 -> 2; in 11..16 -> 3; else -> 4 },
+            )
+        }
+        val maxHp = (progression.levels.sumOf { it.hitPointGain.rolledValue } +
+            progression.totalLevel * abilities.modifierFor(AbilityIds.CON)).coerceAtLeast(1)
+        return LevelUpSnapshot(
+            totalLevel = progression.totalLevel,
+            classLevels = classLevels.toSortedMap(),
+            classDisplayName = progression.levels.map { it.classId }.distinct()
+                .joinToString(" / ") { id -> "${classesById[id]?.name ?: id} ${classLevels[id]}" },
+            proficiencyBonus = 2 + ((progression.totalLevel.coerceAtLeast(1) - 1) / 4),
+            abilityScores = abilities,
+            maximumHitPoints = maxHp,
+            hitDicePools = pools,
+            proficiencyIds = proficiencyIds,
+            savingThrowAbilityIds = savingThrows,
+            featureIds = featureIds,
+            sharedCasterLevel = sharedCasterLevel,
+            sharedSpellSlots = LevelUpReferenceRules.sharedSpellSlots[sharedCasterLevel].orEmpty(),
+            pactMagic = pactMagic,
+        )
+    }
+
+    private fun LevelUpPlan.toRecord(
+        clazz: CharacterClass,
+        classLevel: Int,
+        resolvedSubclassId: String?,
+        activeFeatureChoiceIds: Set<String>,
+        activeProficiencyChoiceIds: Set<String>,
+        activeFeatChoiceIds: Set<String>,
+        activeAcknowledgementIds: Set<String>,
+    ): CharacterLevelRecord = CharacterLevelRecord(
+        characterLevel = expectedTotalLevel + 1,
+        classId = clazz.id,
+        classLevel = classLevel,
+        subclassId = resolvedSubclassId,
+        hitPointGain = selections.hitPointGain ?: HitPointGain.Fixed(0),
+        featureChoices = selections.featureChoices.filterKeys(activeFeatureChoiceIds::contains).toSortedMap(),
+        proficiencyChoices = selections.proficiencyChoices.filterKeys(activeProficiencyChoiceIds::contains).toSortedMap().map { (id, selected) ->
+            ProficiencyChoiceSelection(id, selected.toSortedSet())
+        },
+        abilityScoreDecision = selections.abilityScoreDecision,
+        featChoices = selections.featChoices.filterKeys(activeFeatChoiceIds::contains).toSortedMap(),
+        spellChanges = selections.spellChanges,
+        ruleAcknowledgements = selections.acknowledgedIssueCodes.filterTo(sortedSetOf(), activeAcknowledgementIds::contains),
+        notes = selections.note?.takeIf(String::isNotBlank),
+    )
+
+    private fun activeFeatureChoices(
+        clazz: CharacterClass,
+        classLevel: Int,
+        subclassId: String?,
+        data: LevelUpReferenceData,
+    ): List<Pair<Feature, Choice>> = buildList {
+        clazz.levels.firstOrNull { it.level == classLevel }?.features.orEmpty().forEach { featureId ->
+            data.featuresById[featureId]?.choice?.let { add(data.featuresById.getValue(featureId) to it) }
+        }
+        subclassId?.let { id -> clazz.subclasses.firstOrNull { it.id == id }?.levels
+            ?.firstOrNull { it.level == classLevel }?.features.orEmpty().forEach { featureId ->
+                data.featuresById[featureId]?.choice?.let { add(data.featuresById.getValue(featureId) to it) }
+            } }
+    }.sortedBy { it.first.id }
+
+    private fun validateChoice(
+        id: String,
+        choice: Choice,
+        selected: Set<String>,
+        label: String,
+        validations: MutableList<LevelUpValidationIssue>,
+    ) {
+        if (selected.size != choice.choose) {
+            validations += blocking(LevelUpValidationCode.ChoiceRequired, "Select ${choice.choose} option(s) for $label.")
+            return
+        }
+        val legal = optionsFor(choice).mapTo(hashSetOf()) { it.id }
+        if (legal.isNotEmpty() && selected.any { it !in legal }) {
+            validations += blocking(LevelUpValidationCode.InvalidChoice, "A selected option is not valid for $label.")
+        }
+    }
+
+    private fun validateFeatChoice(
+        id: String,
+        choice: Choice.AbilityBonusChoice,
+        selected: Set<String>,
+        abilities: AbilityScores,
+        label: String,
+        validations: MutableList<LevelUpValidationIssue>,
+    ) {
+        validateChoice(id, choice, selected, label, validations)
+        val selectedEffects = selected.mapNotNull { ability -> choice.from.firstOrNull { ability in it } }
+        if (selectedEffects.size != selected.size) return
+        val adjusted = selectedEffects.flatMap { it.entries }.fold(abilities) { scores, (ability, amount) ->
+            updateAbility(scores, ability, amount)
+        }
+        if (AbilityIds.standardOrder.any { abilityScore(adjusted, it) > 20 }) {
+            validations += blocking(LevelUpValidationCode.InvalidAbilityScoreIncrease, "A feat cannot increase an ability score above 20.")
+        }
+    }
+
+    private fun optionsFor(choice: Choice): List<LevelUpChoiceOption> = when (choice) {
+        is Choice.OptionsArrayChoice -> choice.from.map(::LevelUpChoiceOption)
+        is Choice.ProficiencyChoice -> choice.from.map(::LevelUpChoiceOption)
+        is Choice.FeatureChoice -> choice.from.map(::LevelUpChoiceOption)
+        is Choice.AbilityBonusChoice -> choice.from.flatMap { it.keys }.distinct().sorted().map(::LevelUpChoiceOption)
+        is Choice.NestedChoice -> choice.from.flatMap(::optionsFor)
+        else -> emptyList()
+    }
+
+    private fun spellPolicyId(policy: SpellLearningPolicy): String = when (policy) {
+        SpellLearningPolicy.None -> "none"
+        is SpellLearningPolicy.Known -> "known"
+        is SpellLearningPolicy.Prepared -> "prepared"
+        is SpellLearningPolicy.Spellbook -> "spellbook"
+    }
+
+    private fun preparationCapacity(
+        policy: SpellLearningPolicy,
+        classLevel: Int,
+        abilities: AbilityScores,
+        plan: LevelUpPlan,
+        data: LevelUpReferenceData,
+    ): Int? {
+        val preparation = when (policy) {
+            is SpellLearningPolicy.Prepared -> policy.preparation
+            is SpellLearningPolicy.Spellbook -> policy.preparation
+            else -> null
+        } ?: return null
+        val afterDecision = applyAbilityDecision(abilities, plan.selections, data)
+        return (classLevel / preparation.levelDivisor + afterDecision.modifierFor(preparation.abilityId))
+            .coerceAtLeast(preparation.minimumPreparedSpells)
+    }
+
+    private fun meetsPrerequisites(abilities: AbilityScores, prerequisites: List<AbilityScorePrerequisite>): Boolean =
+        prerequisites.all { prerequisite ->
+            val checks = prerequisite.abilityScore.map { abilityScore(abilities, it) >= prerequisite.minimumScore }
+            if (prerequisite.atLeastOne) checks.any { it } else checks.all { it }
+        }
+
+    private fun classEligibility(
+        abilities: AbilityScores,
+        progression: CharacterProgression,
+        candidate: CharacterClass,
+        data: LevelUpReferenceData,
+    ): LevelUpClassEligibility {
+        val reasons = buildList {
+            if (progression.classLevels[candidate.id].orZero() >= LevelUpReferenceRules.maximumCharacterLevel) {
+                add("Maximum class level reached.")
+            }
+            if (candidate.id !in progression.classLevels) {
+                (progression.classLevels.keys + candidate.id).sorted().forEach { classId ->
+                    val clazz = data.classesById[classId]
+                    val rules = clazz?.multiClassing
+                    when {
+                        rules == null -> add("Multiclass rules are missing for ${clazz?.name ?: classId}.")
+                        !meetsPrerequisites(abilities, rules.prerequisites) ->
+                            add("Ability prerequisites for ${clazz.name} are not met; confirmation requires an override.")
+                    }
+                }
+            }
+        }
+        return LevelUpClassEligibility(candidate.id, reasons.isEmpty(), reasons)
+    }
+
+    /** Reconstructs the class-owned learned/spellbook state in level order. */
+    internal fun classOwnedSpellIds(progression: CharacterProgression, classId: String): Set<String> =
+        progression.levels.asSequence().filter { it.classId == classId }.fold(linkedSetOf()) { known, record ->
+            record.spellChanges.replaced.forEach { replacement ->
+                known.remove(replacement.removedSpellId)
+                known.add(replacement.learnedSpellId)
+            }
+            known.addAll(record.spellChanges.learned.map { it.spellId })
+            known.addAll(record.spellChanges.addedToSpellbook.map { it.spellId })
+            known
+        }
+
+    private fun meetsFeatPrerequisites(
+        abilities: AbilityScores,
+        proficiencyIds: Set<String>,
+        prerequisites: List<com.github.arhor.spellbindr.domain.model.Prerequisite>,
+    ): Boolean = prerequisites.all { prerequisite -> when (prerequisite) {
+        is com.github.arhor.spellbindr.domain.model.Prerequisite.AbilityScorePrerequisite -> {
+            val checks = prerequisite.abilityScore.map { abilityScore(abilities, it) >= prerequisite.minimumValue }
+            if (prerequisite.atLeastOne) checks.any { it } else checks.all { it }
+        }
+        is com.github.arhor.spellbindr.domain.model.Prerequisite.ProficiencyPrerequisite -> prerequisite.id in proficiencyIds
+        else -> true
+    } }
+
+    private fun applyAbilityDecision(
+        base: AbilityScores,
+        selections: LevelUpSelections,
+        data: LevelUpReferenceData,
+    ): AbilityScores = when (val decision = selections.abilityScoreDecision) {
+        is AbilityScoreDecision.Increase -> decision.increases.entries.fold(base) { scores, (ability, amount) ->
+            updateAbility(scores, ability, amount)
+        }
+        is AbilityScoreDecision.Feat -> {
+            data.featsById[decision.featId]?.let { feat ->
+                val fixed = feat.effects.filterIsInstance<Effect.ModifyAbilityEffect>().flatMap { it.abilities.entries }
+                    .fold(base) { scores, (ability, amount) -> updateAbility(scores, ability, amount) }
+                feat.abilityBonusChoiceId?.let { choiceId ->
+                    val choice = feat.abilityBonusChoice ?: return@let fixed
+                    selections.featChoices[choiceId].orEmpty().fold(fixed) { scores, ability ->
+                        choice.from.firstOrNull { ability in it }.orEmpty().entries.fold(scores) { current, (id, amount) ->
+                            updateAbility(current, id, amount)
+                        }
+                    }
+                } ?: fixed
+            } ?: base
+        }
+        null -> base
+    }
+
+    private fun updateAbility(scores: AbilityScores, ability: String, amount: Int): AbilityScores = when (ability) {
+        AbilityIds.STR -> scores.copy(strength = scores.strength + amount)
+        AbilityIds.DEX -> scores.copy(dexterity = scores.dexterity + amount)
+        AbilityIds.CON -> scores.copy(constitution = scores.constitution + amount)
+        AbilityIds.INT -> scores.copy(intelligence = scores.intelligence + amount)
+        AbilityIds.WIS -> scores.copy(wisdom = scores.wisdom + amount)
+        AbilityIds.CHA -> scores.copy(charisma = scores.charisma + amount)
+        else -> scores
+    }
+
+    private fun abilityScore(scores: AbilityScores, ability: String): Int = when (ability.lowercase()) {
+        AbilityIds.STR -> scores.strength
+        AbilityIds.DEX -> scores.dexterity
+        AbilityIds.CON -> scores.constitution
+        AbilityIds.INT -> scores.intelligence
+        AbilityIds.WIS -> scores.wisdom
+        AbilityIds.CHA -> scores.charisma
+        else -> Int.MIN_VALUE
+    }
+
+    private fun subclassFor(classId: String, progression: CharacterProgression): String? = progression.levels
+        .asReversed().firstOrNull { it.classId == classId && it.subclassId != null }?.subclassId
+
+    private fun casterContributionFor(classId: String, progression: CharacterProgression): CasterContribution {
+        val policy = LevelUpReferenceRules.policyFor(classId) ?: return CasterContribution.None
+        return policy.subclassCasterContributions[subclassFor(classId, progression)] ?: policy.casterContribution
+    }
+
+    private fun Int?.orZero(): Int = this ?: 0
+
+    private fun blocking(code: LevelUpValidationCode, message: String) =
+        LevelUpValidationIssue(code, message, LevelUpValidationSeverity.Blocking)
+
+    private fun overrideable(code: LevelUpValidationCode, message: String) =
+        LevelUpValidationIssue(code, message, LevelUpValidationSeverity.Overrideable)
+}

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/domain/usecase/ObserveAllFeatsUseCase.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/domain/usecase/ObserveAllFeatsUseCase.kt
@@ -1,0 +1,13 @@
+package com.github.arhor.spellbindr.domain.usecase
+
+import com.github.arhor.spellbindr.domain.model.Feat
+import com.github.arhor.spellbindr.domain.model.Loadable
+import com.github.arhor.spellbindr.domain.repository.FeatsRepository
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+class ObserveAllFeatsUseCase @Inject constructor(
+    private val featsRepository: FeatsRepository,
+) {
+    operator fun invoke(): Flow<Loadable<List<Feat>>> = featsRepository.allFeatsState
+}

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/ui/SpellbindrApp.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/ui/SpellbindrApp.kt
@@ -85,7 +85,9 @@ fun SpellbindrApp(onReady: () -> Unit) {
             Scaffold(
                 topBar = { AppTopBar(resolvedConfig) },
                 bottomBar = {
-                    if (!(destination matches AppDestination.GuidedCharacterSetup::class)) {
+                    if (!(destination matches AppDestination.GuidedCharacterSetup::class) &&
+                        !(destination matches AppDestination.CharacterLevelUp::class)
+                    ) {
                         AppBottomBar(controller)
                     }
                 },

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/editor/CharacterEditorScreen.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/editor/CharacterEditorScreen.kt
@@ -224,6 +224,13 @@ private fun CharacterEditorForm(
                 )
             }
         }
+        if (state.isProgressionManaged) {
+            Text(
+                text = "Level, class, ability scores, grants, and spell capacities are managed by Level Up.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
         SectionCard(title = "Identity") {
             OutlinedTextField(
                 value = state.name,
@@ -242,12 +249,14 @@ private fun CharacterEditorForm(
                     onValueChange = onClassChanged,
                     label = { Text("Class") },
                     modifier = Modifier.weight(1f),
+                    enabled = !state.isProgressionManaged,
                 )
                 OutlinedTextField(
                     value = state.level,
                     onValueChange = onLevelChanged,
                     label = { Text("Level") },
                     modifier = Modifier.weight(1f),
+                    enabled = !state.isProgressionManaged,
                     isError = state.levelError != null,
                     supportingText = state.levelError?.let { error -> { Text(error) } },
                     keyboardOptions = KeyboardOptions.Default.copy(
@@ -294,6 +303,7 @@ private fun CharacterEditorForm(
         SectionCard(title = "Ability Scores") {
             AbilityGrid(
                 abilities = state.abilities,
+                enabled = !state.isProgressionManaged,
                 onAbilityChanged = { ability, value ->
                     onAbilityChanged(ability, value)
                 },
@@ -306,6 +316,7 @@ private fun CharacterEditorForm(
                     onValueChange = onProficiencyBonusChanged,
                     label = { Text("Proficiency bonus") },
                     modifier = Modifier.weight(1f),
+                    enabled = !state.isProgressionManaged,
                     keyboardOptions = KeyboardOptions.Default.copy(
                         keyboardType = KeyboardType.Number,
                         imeAction = ImeAction.Next,
@@ -334,6 +345,7 @@ private fun CharacterEditorForm(
                     onValueChange = onMaxHpChanged,
                     label = { Text("Max HP") },
                     modifier = Modifier.weight(1f),
+                    enabled = !state.isProgressionManaged,
                     isError = state.maxHitPointsError != null,
                     supportingText = state.maxHitPointsError?.let { error -> { Text(error) } },
                     keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
@@ -383,6 +395,7 @@ private fun CharacterEditorForm(
                     onValueChange = onHitDiceChanged,
                     label = { Text("Hit Dice") },
                     modifier = Modifier.weight(1f),
+                    enabled = !state.isProgressionManaged,
                 )
             }
         }
@@ -391,6 +404,7 @@ private fun CharacterEditorForm(
                 state.savingThrows.forEach { entry ->
                     SavingThrowRow(
                         entry = entry,
+                        enabled = !state.isProgressionManaged,
                         onProficiencyChanged = {
                             onSavingThrowProficiencyChanged(entry.abilityId, it)
                         },
@@ -403,6 +417,7 @@ private fun CharacterEditorForm(
                 state.skills.forEach { entry ->
                     SkillRow(
                         entry = entry,
+                        enabled = !state.isProgressionManaged,
                         onProficiencyChanged = {
                             onSkillProficiencyChanged(entry.skill, it)
                         },
@@ -512,6 +527,7 @@ private fun SectionCard(
 @Composable
 private fun AbilityGrid(
     abilities: List<AbilityFieldState>,
+    enabled: Boolean,
     onAbilityChanged: (AbilityId, String) -> Unit,
 ) {
     Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
@@ -523,6 +539,7 @@ private fun AbilityGrid(
                 rowItems.forEach { ability ->
                     AbilityCard(
                         state = ability,
+                        enabled = enabled,
                         onAbilityChanged = { value -> onAbilityChanged(ability.abilityId, value) },
                         modifier = Modifier.weight(1f),
                     )
@@ -538,6 +555,7 @@ private fun AbilityGrid(
 @Composable
 private fun AbilityCard(
     state: AbilityFieldState,
+    enabled: Boolean,
     onAbilityChanged: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -561,6 +579,7 @@ private fun AbilityCard(
                 label = { Text("Score") },
                 singleLine = true,
                 isError = state.error != null,
+                enabled = enabled,
                 supportingText = state.error?.let { error -> { Text(error) } },
                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
             )
@@ -576,6 +595,7 @@ private fun AbilityCard(
 @Composable
 private fun SavingThrowRow(
     entry: SavingThrowInputState,
+    enabled: Boolean,
     onProficiencyChanged: (Boolean) -> Unit,
 ) {
     Row(
@@ -589,6 +609,7 @@ private fun SavingThrowRow(
                 Checkbox(
                     checked = entry.proficient,
                     onCheckedChange = onProficiencyChanged,
+                    enabled = enabled,
                 )
                 Text(text = "Proficient")
             }
@@ -603,6 +624,7 @@ private fun SavingThrowRow(
 @Composable
 private fun SkillRow(
     entry: SkillInputState,
+    enabled: Boolean,
     onProficiencyChanged: (Boolean) -> Unit,
     onExpertiseChanged: (Boolean) -> Unit,
 ) {
@@ -622,6 +644,7 @@ private fun SkillRow(
                 Checkbox(
                     checked = entry.proficient,
                     onCheckedChange = onProficiencyChanged,
+                    enabled = enabled,
                 )
                 Text(text = "Proficient")
             }
@@ -629,6 +652,7 @@ private fun SkillRow(
                 Checkbox(
                     checked = entry.expertise,
                     onCheckedChange = onExpertiseChanged,
+                    enabled = enabled,
                 )
                 Text(text = "Expertise")
             }

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/editor/CharacterEditorViewModel.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/editor/CharacterEditorViewModel.kt
@@ -9,12 +9,14 @@ import com.github.arhor.spellbindr.domain.model.AbilityIds
 import com.github.arhor.spellbindr.domain.model.AbilityScores
 import com.github.arhor.spellbindr.domain.model.CharacterSheet
 import com.github.arhor.spellbindr.domain.model.CharacterSheetInputError
+import com.github.arhor.spellbindr.domain.model.CharacterWithProgression
+import com.github.arhor.spellbindr.domain.model.ProgressionState
 import com.github.arhor.spellbindr.domain.model.SavingThrowEntry
 import com.github.arhor.spellbindr.domain.model.Skill
 import com.github.arhor.spellbindr.domain.model.SkillEntry
 import com.github.arhor.spellbindr.domain.usecase.BuildCharacterSheetFromInputsUseCase
 import com.github.arhor.spellbindr.domain.usecase.ComputeDerivedBonusesUseCase
-import com.github.arhor.spellbindr.domain.usecase.LoadCharacterSheetUseCase
+import com.github.arhor.spellbindr.domain.usecase.LoadCharacterWithProgressionUseCase
 import com.github.arhor.spellbindr.domain.usecase.SaveCharacterSheetUseCase
 import com.github.arhor.spellbindr.domain.usecase.ValidateCharacterSheetUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -33,7 +35,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 class CharacterEditorViewModel @Inject constructor(
-    private val loadCharacterSheetUseCase: LoadCharacterSheetUseCase,
+    private val loadCharacterWithProgressionUseCase: LoadCharacterWithProgressionUseCase,
     private val saveCharacterSheetUseCase: SaveCharacterSheetUseCase,
     private val validateCharacterSheetUseCase: ValidateCharacterSheetUseCase,
     private val computeDerivedBonusesUseCase: ComputeDerivedBonusesUseCase,
@@ -61,11 +63,11 @@ class CharacterEditorViewModel @Inject constructor(
     }
 
     private fun observeCharacter(id: String) {
-        loadCharacterSheetUseCase(id)
-            .onEach { sheet ->
-                _uiState.value = if (sheet != null) {
-                    baseSheet = sheet
-                    sheet.toEditorState(computeDerivedBonusesUseCase)
+        loadCharacterWithProgressionUseCase(id)
+            .onEach { character ->
+                _uiState.value = if (character != null) {
+                    baseSheet = character.sheet
+                    character.toEditorState(computeDerivedBonusesUseCase)
                 } else {
                     CharacterEditorUiState.Content(
                         characterId = id,
@@ -126,10 +128,12 @@ class CharacterEditorViewModel @Inject constructor(
     }
 
     private fun onClassChanged(value: String) {
+        if (isManagedCharacter()) return
         updateContent { it.copy(className = value) }
     }
 
     private fun onLevelChanged(value: String) {
+        if (isManagedCharacter()) return
         updateContent { it.copy(level = value, levelError = null) }
     }
 
@@ -150,6 +154,7 @@ class CharacterEditorViewModel @Inject constructor(
     }
 
     private fun onAbilityChanged(abilityId: AbilityId, value: String) {
+        if (isManagedCharacter()) return
         updateContent(recomputeDerivedBonuses = true) { state ->
             state.copy(
                 abilities = state.abilities.map { field ->
@@ -160,6 +165,7 @@ class CharacterEditorViewModel @Inject constructor(
     }
 
     private fun onProficiencyBonusChanged(value: String) {
+        if (isManagedCharacter()) return
         updateContent(recomputeDerivedBonuses = true) { it.copy(proficiencyBonus = value) }
     }
 
@@ -168,6 +174,7 @@ class CharacterEditorViewModel @Inject constructor(
     }
 
     private fun onMaxHpChanged(value: String) {
+        if (isManagedCharacter()) return
         updateContent { it.copy(maxHitPoints = value, maxHitPointsError = null) }
     }
 
@@ -192,10 +199,12 @@ class CharacterEditorViewModel @Inject constructor(
     }
 
     private fun onHitDiceChanged(value: String) {
+        if (isManagedCharacter()) return
         updateContent { it.copy(hitDice = value) }
     }
 
     private fun onSavingThrowProficiencyChanged(abilityId: AbilityId, value: Boolean) {
+        if (isManagedCharacter()) return
         updateContent(recomputeDerivedBonuses = true) { state ->
             state.copy(
                 savingThrows = state.savingThrows.map { entry ->
@@ -206,6 +215,7 @@ class CharacterEditorViewModel @Inject constructor(
     }
 
     private fun onSkillProficiencyChanged(skill: Skill, value: Boolean) {
+        if (isManagedCharacter()) return
         updateContent(recomputeDerivedBonuses = true) { state ->
             state.copy(
                 skills = state.skills.map { entry ->
@@ -216,6 +226,7 @@ class CharacterEditorViewModel @Inject constructor(
     }
 
     private fun onSkillExpertiseChanged(skill: Skill, value: Boolean) {
+        if (isManagedCharacter()) return
         updateContent(recomputeDerivedBonuses = true) { state ->
             state.copy(
                 skills = state.skills.map { entry ->
@@ -289,6 +300,7 @@ class CharacterEditorViewModel @Inject constructor(
 
         viewModelScope.launch {
             val sheet = buildCharacterSheetFromInputsUseCase(validatedState.toDomainInput(), baseSheet)
+                .preservingProgressionOwnedFieldsFrom(baseSheet, validatedState.isProgressionManaged)
             _uiState.update { state ->
                 if (state is CharacterEditorUiState.Content) {
                     state.copy(
@@ -344,6 +356,9 @@ class CharacterEditorViewModel @Inject constructor(
             }
         }
     }
+
+    private fun isManagedCharacter(): Boolean =
+        (_uiState.value as? CharacterEditorUiState.Content)?.isProgressionManaged == true
 }
 
 enum class EditorMode {
@@ -359,6 +374,7 @@ sealed interface CharacterEditorUiState {
     data class Content(
         val characterId: String? = null,
         val mode: EditorMode = EditorMode.Create,
+        val isProgressionManaged: Boolean = false,
         val isSaving: Boolean = false,
         val name: String = "",
         val nameError: String? = null,
@@ -443,45 +459,70 @@ data class SkillInputState(
     }
 }
 
-private fun CharacterSheet.toEditorState(
+private fun CharacterWithProgression.toEditorState(
     computeDerivedBonusesUseCase: ComputeDerivedBonusesUseCase,
 ): CharacterEditorUiState.Content {
-    val baseState = CharacterEditorUiState.Content(
-        characterId = id,
-        mode = EditorMode.Edit,
-        name = name,
-        className = className,
-        level = level.toString(),
-        race = race,
-        background = background,
-        alignment = alignment,
-        experiencePoints = experiencePoints?.toString() ?: "",
-        abilities = abilityScores.toFieldStates(),
-        proficiencyBonus = proficiencyBonus.toString(),
-        inspiration = inspiration,
-        maxHitPoints = maxHitPoints.toString(),
-        currentHitPoints = currentHitPoints.toString(),
-        temporaryHitPoints = temporaryHitPoints.toString(),
-        armorClass = armorClass.toString(),
-        initiative = initiative.toString(),
-        speed = speed,
-        hitDice = hitDice,
-        savingThrows = savingThrows.savingThrowsToInputStates(),
-        skills = skills.skillsToInputStates(),
-        senses = senses,
-        languages = languages,
-        proficiencies = proficiencies,
-        attacksAndCantrips = attacksAndCantrips,
-        featuresAndTraits = featuresAndTraits,
-        equipment = equipment,
-        personalityTraits = personalityTraits,
-        ideals = ideals,
-        bonds = bonds,
-        flaws = flaws,
-        notes = notes,
+    val characterSheet = sheet
+    val isProgressionManaged = progressionState is ProgressionState.Managed
+    return characterSheet.run {
+        val baseState = CharacterEditorUiState.Content(
+            characterId = id,
+            mode = EditorMode.Edit,
+            isProgressionManaged = isProgressionManaged,
+            name = name,
+            className = className,
+            level = level.toString(),
+            race = race,
+            background = background,
+            alignment = alignment,
+            experiencePoints = experiencePoints?.toString() ?: "",
+            abilities = abilityScores.toFieldStates(),
+            proficiencyBonus = proficiencyBonus.toString(),
+            inspiration = inspiration,
+            maxHitPoints = maxHitPoints.toString(),
+            currentHitPoints = currentHitPoints.toString(),
+            temporaryHitPoints = temporaryHitPoints.toString(),
+            armorClass = armorClass.toString(),
+            initiative = initiative.toString(),
+            speed = speed,
+            hitDice = hitDice,
+            savingThrows = savingThrows.savingThrowsToInputStates(),
+            skills = skills.skillsToInputStates(),
+            senses = senses,
+            languages = languages,
+            proficiencies = proficiencies,
+            attacksAndCantrips = attacksAndCantrips,
+            featuresAndTraits = featuresAndTraits,
+            equipment = equipment,
+            personalityTraits = personalityTraits,
+            ideals = ideals,
+            bonds = bonds,
+            flaws = flaws,
+            notes = notes,
+        )
+        val derived = computeDerivedBonusesUseCase(baseState.toDomainInput())
+        baseState.withDerivedBonuses(derived)
+    }
+}
+
+private fun CharacterSheet.preservingProgressionOwnedFieldsFrom(
+    base: CharacterSheet?,
+    isProgressionManaged: Boolean,
+): CharacterSheet {
+    if (!isProgressionManaged || base == null) return this
+    return copy(
+        level = base.level,
+        className = base.className,
+        abilityScores = base.abilityScores,
+        proficiencyBonus = base.proficiencyBonus,
+        maxHitPoints = base.maxHitPoints,
+        hitDice = base.hitDice,
+        spellSlots = base.spellSlots,
+        pactSlots = base.pactSlots,
+        savingThrows = base.savingThrows,
+        skills = base.skills,
+        managedProgression = base.managedProgression,
     )
-    val derived = computeDerivedBonusesUseCase(baseState.toDomainInput())
-    return baseState.withDerivedBonuses(derived)
 }
 
 private fun CharacterSheetInputError.toRequiredMessage(): String = "Required"

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpEffect.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpEffect.kt
@@ -1,0 +1,7 @@
+package com.github.arhor.spellbindr.ui.feature.character.levelup
+
+sealed interface CharacterLevelUpEffect {
+    data object Cancelled : CharacterLevelUpEffect
+    data object Completed : CharacterLevelUpEffect
+    data class Message(val text: String) : CharacterLevelUpEffect
+}

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpIntent.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpIntent.kt
@@ -1,0 +1,22 @@
+package com.github.arhor.spellbindr.ui.feature.character.levelup
+
+import com.github.arhor.spellbindr.domain.model.AbilityScoreDecision
+import com.github.arhor.spellbindr.domain.model.HitPointGain
+import com.github.arhor.spellbindr.domain.model.SpellChanges
+
+sealed interface CharacterLevelUpIntent {
+    data class ClassSelected(val classId: String) : CharacterLevelUpIntent
+    data class SubclassSelected(val subclassId: String) : CharacterLevelUpIntent
+    data class ChoiceToggled(val requirementId: String, val optionId: String, val maximum: Int) : CharacterLevelUpIntent
+    data class HitPointsSelected(val gain: HitPointGain) : CharacterLevelUpIntent
+    data class AbilityScoreDecisionSelected(val decision: AbilityScoreDecision) : CharacterLevelUpIntent
+    data class SpellChangesSelected(val changes: SpellChanges) : CharacterLevelUpIntent
+    data class AcknowledgementChanged(val issueCode: String, val acknowledged: Boolean) : CharacterLevelUpIntent
+    data object NextClicked : CharacterLevelUpIntent
+    data object BackClicked : CharacterLevelUpIntent
+    data object CancelClicked : CharacterLevelUpIntent
+    data object ConfirmClicked : CharacterLevelUpIntent
+    data object ReloadClicked : CharacterLevelUpIntent
+}
+
+typealias CharacterLevelUpDispatch = (CharacterLevelUpIntent) -> Unit

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpRoute.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpRoute.kt
@@ -1,0 +1,49 @@
+package com.github.arhor.spellbindr.ui.feature.character.levelup
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.github.arhor.spellbindr.ui.components.AppTopBarConfig
+import com.github.arhor.spellbindr.ui.components.AppTopBarNavigation
+import com.github.arhor.spellbindr.ui.components.LocalSnackbarHostState
+import com.github.arhor.spellbindr.ui.components.ProvideTopBarState
+import com.github.arhor.spellbindr.ui.components.TopBarState
+import kotlinx.coroutines.flow.collectLatest
+
+@Composable
+fun CharacterLevelUpRoute(
+    onBack: () -> Unit,
+    onFinished: () -> Unit,
+    vm: CharacterLevelUpViewModel = hiltViewModel(),
+) {
+    val state by vm.uiState.collectAsStateWithLifecycle()
+    val snackbar = LocalSnackbarHostState.current
+    LaunchedEffect(vm) {
+        vm.effects.collectLatest { effect ->
+            when (effect) {
+                CharacterLevelUpEffect.Cancelled -> onBack()
+                CharacterLevelUpEffect.Completed -> onFinished()
+                is CharacterLevelUpEffect.Message -> snackbar.showSnackbar(effect.text)
+            }
+        }
+    }
+    val title = (state as? CharacterLevelUpUiState.Content)?.let {
+        "Level up · ${it.step.title} (${it.currentStepIndex + 1}/${it.steps.size})"
+    } ?: "Level up"
+    ProvideTopBarState(
+        topBarState = TopBarState(
+            config = AppTopBarConfig(
+                title = title,
+                navigation = AppTopBarNavigation.Back {
+                    val content = state as? CharacterLevelUpUiState.Content
+                    if (content != null && content.currentStepIndex > 0) vm.dispatch(CharacterLevelUpIntent.BackClicked)
+                    else vm.dispatch(CharacterLevelUpIntent.CancelClicked)
+                },
+            ),
+        ),
+    ) {
+        CharacterLevelUpScreen(state = state, dispatch = vm::dispatch)
+    }
+}

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpScreen.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpScreen.kt
@@ -1,0 +1,151 @@
+package com.github.arhor.spellbindr.ui.feature.character.levelup
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.github.arhor.spellbindr.domain.model.AbilityIds
+import com.github.arhor.spellbindr.domain.model.AbilityScoreDecision
+import com.github.arhor.spellbindr.domain.model.Choice
+import com.github.arhor.spellbindr.domain.model.HitPointGain
+import com.github.arhor.spellbindr.domain.model.LevelUpRequirement
+import com.github.arhor.spellbindr.domain.model.LevelUpValidationSeverity
+
+@Composable
+fun CharacterLevelUpScreen(
+    state: CharacterLevelUpUiState,
+    dispatch: CharacterLevelUpDispatch,
+    modifier: Modifier = Modifier,
+) {
+    when (state) {
+        CharacterLevelUpUiState.Loading -> Box(modifier.fillMaxSize(), contentAlignment = Alignment.Center) { CircularProgressIndicator() }
+        is CharacterLevelUpUiState.Failure -> MessagePane(state.message, modifier)
+        is CharacterLevelUpUiState.Unavailable -> MessagePane("${state.title}\n\n${state.explanation}", modifier)
+        is CharacterLevelUpUiState.Content -> Content(state, dispatch, modifier)
+    }
+}
+
+@Composable
+private fun Content(state: CharacterLevelUpUiState.Content, dispatch: CharacterLevelUpDispatch, modifier: Modifier) {
+    Column(
+        modifier = modifier.fillMaxSize().verticalScroll(rememberScrollState()).padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        Text("${state.characterName}: level ${state.preview.before.totalLevel} → ${state.preview.after.totalLevel}", style = MaterialTheme.typography.titleMedium)
+        when (state.step) {
+            CharacterLevelUpStep.Class -> {
+                val requirement = state.preview.requirements
+                    .filterIsInstance<LevelUpRequirement.ClassSelection>().firstOrNull()
+                state.classes.forEach { clazz ->
+                    val eligibility = requirement?.eligibility?.firstOrNull { it.classId == clazz.id }
+                    val label = buildString {
+                        append(clazz.name)
+                        eligibility?.reasons?.takeIf { it.isNotEmpty() }?.let { append(" — "); append(it.joinToString(" ")) }
+                    }
+                    ChoiceRow(label, state.plan.selectedClassId == clazz.id) { dispatch(CharacterLevelUpIntent.ClassSelected(clazz.id)) }
+                }
+            }
+            CharacterLevelUpStep.Choices -> state.preview.requirements.forEach { requirement ->
+                when (requirement) {
+                    is LevelUpRequirement.SubclassSelection -> {
+                        SectionTitle("Choose subclass")
+                        requirement.options.forEach { option -> ChoiceRow(option.label, requirement.selectedSubclassId == option.id) { dispatch(CharacterLevelUpIntent.SubclassSelected(option.id)) } }
+                    }
+                    is LevelUpRequirement.ChoiceSelection -> {
+                        SectionTitle("${requirement.label} · choose ${requirement.choice.choose}")
+                        choiceOptions(requirement.choice).forEach { option ->
+                            FilterChip(
+                                selected = option in requirement.selectedOptionIds,
+                                onClick = { dispatch(CharacterLevelUpIntent.ChoiceToggled(requirement.id, option, requirement.choice.choose)) },
+                                label = { Text(option) },
+                            )
+                        }
+                    }
+                    else -> Unit
+                }
+            }
+            CharacterLevelUpStep.HitPoints -> state.preview.requirements.filterIsInstance<LevelUpRequirement.HitPoints>().firstOrNull()?.let { hp ->
+                Text("Choose hit points for d${hp.hitDie}. Your Constitution modifier is applied during materialization.")
+                ChoiceRow("Fixed (${hp.hitDie / 2 + 1})", hp.selectedGain is HitPointGain.Fixed) { dispatch(CharacterLevelUpIntent.HitPointsSelected(HitPointGain.Fixed(hp.hitDie / 2 + 1))) }
+                (1..hp.hitDie).forEach { value ->
+                    FilterChip(selected = hp.selectedGain == HitPointGain.Rolled(value), onClick = { dispatch(CharacterLevelUpIntent.HitPointsSelected(HitPointGain.Rolled(value))) }, label = { Text("Rolled $value") })
+                }
+                Text("A manual result can be recorded after choosing the closest rolled value.", style = MaterialTheme.typography.bodySmall)
+            }
+            CharacterLevelUpStep.AbilityScore -> state.preview.requirements.filterIsInstance<LevelUpRequirement.AbilityScoreImprovement>().firstOrNull()?.let { asi ->
+                Text("Choose an ability score improvement or a feat.")
+                AbilityIds.standardOrder.forEach { ability ->
+                    ChoiceRow("+${asi.abilityPoints} ${ability.uppercase()}", asi.selectedDecision == AbilityScoreDecision.Increase(mapOf(ability to asi.abilityPoints))) {
+                        dispatch(CharacterLevelUpIntent.AbilityScoreDecisionSelected(AbilityScoreDecision.Increase(mapOf(ability to asi.abilityPoints))))
+                    }
+                }
+                if (asi.allowsFeat) state.feats.forEach { feat -> ChoiceRow("Feat: ${feat.name}", asi.selectedDecision == AbilityScoreDecision.Feat(feat.id)) { dispatch(CharacterLevelUpIntent.AbilityScoreDecisionSelected(AbilityScoreDecision.Feat(feat.id))) } }
+            }
+            CharacterLevelUpStep.Spells -> {
+                val spellRequirement = state.preview.requirements.filterIsInstance<LevelUpRequirement.SpellDecisions>().firstOrNull()
+                Text("${spellRequirement?.policyId ?: "Spellcasting"} decisions are validated for this class level.")
+                spellRequirement?.preparationCapacity?.let { Text("You may prepare up to $it spells after leveling. Prepared spells remain mutable play state.") }
+                Text("Learned, replaced, and spellbook changes will be listed here when required by the class policy.")
+            }
+            CharacterLevelUpStep.Review -> {
+                state.staleMessage?.let { WarningCard(it); Button(onClick = { dispatch(CharacterLevelUpIntent.ReloadClicked) }) { Text("Reload draft") } }
+                state.persistenceMessage?.let(::WarningCard)
+                ReviewRow("Total level", state.preview.before.totalLevel.toString(), state.preview.after.totalLevel.toString())
+                ReviewRow("Class", state.preview.before.classDisplayName, state.preview.after.classDisplayName)
+                ReviewRow("Proficiency bonus", "+${state.preview.before.proficiencyBonus}", "+${state.preview.after.proficiencyBonus}")
+                ReviewRow("Maximum HP", state.preview.before.maximumHitPoints.toString(), state.preview.after.maximumHitPoints.toString())
+                state.preview.validations.forEach { issue ->
+                    if (issue.severity == LevelUpValidationSeverity.Overrideable) {
+                        val checked = issue.acknowledgementId in state.plan.selections.acknowledgedIssueCodes
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            Checkbox(checked, onCheckedChange = { dispatch(CharacterLevelUpIntent.AcknowledgementChanged(issue.acknowledgementId, it)) })
+                            Text(issue.message)
+                        }
+                    } else WarningCard(issue.message)
+                }
+            }
+        }
+        Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(12.dp, Alignment.End)) {
+            OutlinedButton(onClick = { dispatch(CharacterLevelUpIntent.CancelClicked) }) { Text("Cancel") }
+            if (state.currentStepIndex > 0) OutlinedButton(onClick = { dispatch(CharacterLevelUpIntent.BackClicked) }) { Text("Back") }
+            if (state.isReview) Button(enabled = state.canConfirm, onClick = { dispatch(CharacterLevelUpIntent.ConfirmClicked) }) { Text(if (state.isSaving) "Saving…" else "Confirm level up") }
+            else Button(onClick = { dispatch(CharacterLevelUpIntent.NextClicked) }) { Text("Next") }
+        }
+    }
+}
+
+@Composable private fun ChoiceRow(label: String, selected: Boolean, onClick: () -> Unit) = Surface(onClick = onClick, modifier = Modifier.fillMaxWidth(), shape = MaterialTheme.shapes.medium) { Row(Modifier.padding(12.dp), verticalAlignment = Alignment.CenterVertically) { RadioButton(selected, onClick = onClick); Text(label) } }
+@Composable private fun SectionTitle(text: String) = Text(text, style = MaterialTheme.typography.titleSmall)
+@Composable private fun WarningCard(text: String) = Surface(color = MaterialTheme.colorScheme.errorContainer, shape = MaterialTheme.shapes.medium) { Text(text, Modifier.fillMaxWidth().padding(12.dp), color = MaterialTheme.colorScheme.onErrorContainer) }
+@Composable private fun ReviewRow(label: String, before: String, after: String) = Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) { Text(label); Text("$before → $after") }
+@Composable private fun MessagePane(text: String, modifier: Modifier) = Box(modifier.fillMaxSize().padding(32.dp), contentAlignment = Alignment.Center) { Text(text) }
+
+private fun choiceOptions(choice: Choice): List<String> = when (choice) {
+    is Choice.FavoredEnemyChoice -> choice.from
+    is Choice.TerrainTypeChoice -> choice.from
+    is Choice.ProficiencyChoice -> choice.from
+    is Choice.FeatureChoice -> choice.from
+    is Choice.OptionsArrayChoice -> choice.from
+    is Choice.EquipmentChoice -> choice.from
+    is Choice.AbilityBonusChoice -> choice.from.map { option -> option.entries.joinToString { "${it.key} +${it.value}" } }
+    is Choice.ResourceListChoice, is Choice.EquipmentCategoriesChoice, is Choice.NestedChoice,
+    is Choice.FromAllChoice, is Choice.IdealChoice -> emptyList()
+}

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpUiState.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpUiState.kt
@@ -1,0 +1,56 @@
+package com.github.arhor.spellbindr.ui.feature.character.levelup
+
+import androidx.compose.runtime.Immutable
+import com.github.arhor.spellbindr.domain.model.CharacterClass
+import com.github.arhor.spellbindr.domain.model.Feat
+import com.github.arhor.spellbindr.domain.model.LevelUpPlan
+import com.github.arhor.spellbindr.domain.model.LevelUpPreview
+import com.github.arhor.spellbindr.domain.model.LevelUpRequirement
+import com.github.arhor.spellbindr.domain.model.Spell
+import kotlinx.serialization.Serializable
+
+@Serializable
+enum class CharacterLevelUpStep(val title: String) {
+    Class("Class"),
+    Choices("Subclass & choices"),
+    HitPoints("Hit points"),
+    AbilityScore("ASI or feat"),
+    Spells("Spells"),
+    Review("Review"),
+}
+
+internal fun characterLevelUpSteps(requirements: List<LevelUpRequirement>): List<CharacterLevelUpStep> = buildList {
+    add(CharacterLevelUpStep.Class)
+    if (requirements.any { it is LevelUpRequirement.SubclassSelection || it is LevelUpRequirement.ChoiceSelection }) {
+        add(CharacterLevelUpStep.Choices)
+    }
+    if (requirements.any { it is LevelUpRequirement.HitPoints }) add(CharacterLevelUpStep.HitPoints)
+    if (requirements.any { it is LevelUpRequirement.AbilityScoreImprovement }) add(CharacterLevelUpStep.AbilityScore)
+    if (requirements.any { it is LevelUpRequirement.SpellDecisions }) add(CharacterLevelUpStep.Spells)
+    add(CharacterLevelUpStep.Review)
+}
+
+sealed interface CharacterLevelUpUiState {
+    @Immutable data object Loading : CharacterLevelUpUiState
+    @Immutable data class Failure(val message: String) : CharacterLevelUpUiState
+    @Immutable data class Unavailable(val title: String, val explanation: String) : CharacterLevelUpUiState
+
+    @Immutable
+    data class Content(
+        val characterName: String,
+        val plan: LevelUpPlan,
+        val preview: LevelUpPreview,
+        val classes: List<CharacterClass>,
+        val feats: List<Feat>,
+        val spells: List<Spell>,
+        val steps: List<CharacterLevelUpStep>,
+        val step: CharacterLevelUpStep,
+        val currentStepIndex: Int,
+        val isSaving: Boolean = false,
+        val staleMessage: String? = null,
+        val persistenceMessage: String? = null,
+    ) : CharacterLevelUpUiState {
+        val isReview: Boolean get() = step == CharacterLevelUpStep.Review
+        val canConfirm: Boolean get() = isReview && preview.canConfirm && !isSaving
+    }
+}

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpViewModel.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpViewModel.kt
@@ -1,0 +1,209 @@
+package com.github.arhor.spellbindr.ui.feature.character.levelup
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.github.arhor.spellbindr.domain.model.AbilityScoreDecision
+import com.github.arhor.spellbindr.domain.model.ApplyLevelUpResult
+import com.github.arhor.spellbindr.domain.model.CharacterClass
+import com.github.arhor.spellbindr.domain.model.CharacterWithProgression
+import com.github.arhor.spellbindr.domain.model.Feat
+import com.github.arhor.spellbindr.domain.model.HitPointGain
+import com.github.arhor.spellbindr.domain.model.LevelUpChoiceCategory
+import com.github.arhor.spellbindr.domain.model.LevelUpPlan
+import com.github.arhor.spellbindr.domain.model.LevelUpPreview
+import com.github.arhor.spellbindr.domain.model.LevelUpReferenceData
+import com.github.arhor.spellbindr.domain.model.LevelUpReferenceRules
+import com.github.arhor.spellbindr.domain.model.LevelUpRequirement
+import com.github.arhor.spellbindr.domain.model.Loadable
+import com.github.arhor.spellbindr.domain.model.ProgressionState
+import com.github.arhor.spellbindr.domain.model.Spell
+import com.github.arhor.spellbindr.domain.model.SpellChanges
+import com.github.arhor.spellbindr.domain.usecase.ApplyLevelUpUseCase
+import com.github.arhor.spellbindr.domain.usecase.CreateLevelUpPlanUseCase
+import com.github.arhor.spellbindr.domain.usecase.LoadCharacterWithProgressionUseCase
+import com.github.arhor.spellbindr.domain.usecase.ObserveAllCharacterClassesUseCase
+import com.github.arhor.spellbindr.domain.usecase.ObserveAllFeatsUseCase
+import com.github.arhor.spellbindr.domain.usecase.ObserveAllFeaturesUseCase
+import com.github.arhor.spellbindr.domain.usecase.ObserveAllSpellsUseCase
+import com.github.arhor.spellbindr.domain.usecase.RebuildLevelUpPlanUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import javax.inject.Inject
+
+@HiltViewModel
+class CharacterLevelUpViewModel @Inject constructor(
+    loadCharacter: LoadCharacterWithProgressionUseCase,
+    observeClasses: ObserveAllCharacterClassesUseCase,
+    observeFeatures: ObserveAllFeaturesUseCase,
+    observeFeats: ObserveAllFeatsUseCase,
+    observeSpells: ObserveAllSpellsUseCase,
+    private val createPlan: CreateLevelUpPlanUseCase,
+    private val rebuildPlan: RebuildLevelUpPlanUseCase,
+    private val applyLevelUp: ApplyLevelUpUseCase,
+    private val savedStateHandle: SavedStateHandle,
+) : ViewModel() {
+    private val characterId: String? = savedStateHandle["characterId"]
+    private val draft = MutableStateFlow(restoredDraft())
+    private var latestReady: SourceState.Ready? = null
+    private val _effects = MutableSharedFlow<CharacterLevelUpEffect>()
+    val effects = _effects.asSharedFlow()
+
+    private data class ReferenceState(
+        val classes: List<CharacterClass>,
+        val features: List<com.github.arhor.spellbindr.domain.model.Feature>,
+        val feats: List<Feat>,
+        val spells: List<Spell>,
+    )
+
+    private val source = if (characterId == null) {
+        kotlinx.coroutines.flow.flowOf<SourceState>(SourceState.Failure("Missing character id"))
+    } else {
+        combine(
+            loadCharacter(characterId),
+            observeClasses(),
+            observeFeatures(),
+            observeFeats(),
+            observeSpells(),
+        ) { character, classes, features, feats, spells ->
+            when {
+                character == null -> SourceState.Failure("Character not found")
+                classes is Loadable.Failure || features is Loadable.Failure ||
+                    feats is Loadable.Failure || spells is Loadable.Failure ->
+                    SourceState.Failure("Unable to load level-up reference data")
+                classes is Loadable.Content && features is Loadable.Content &&
+                    feats is Loadable.Content && spells is Loadable.Content -> SourceState.Ready(
+                    character,
+                    ReferenceState(classes.data, features.data, feats.data, spells.data),
+                )
+                else -> SourceState.Loading
+            }
+        }
+    }
+
+    val uiState = combine(source, draft) { source, draft -> render(source, draft) }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5_000), CharacterLevelUpUiState.Loading)
+
+    fun dispatch(intent: CharacterLevelUpIntent) {
+        when (intent) {
+            is CharacterLevelUpIntent.ClassSelected -> updatePlan { it.copy(selectedClassId = intent.classId, selections = it.selections.copy(subclassId = null, featureChoices = emptyMap(), proficiencyChoices = emptyMap(), hitPointGain = null, abilityScoreDecision = null, featChoices = emptyMap(), spellChanges = SpellChanges())) }
+            is CharacterLevelUpIntent.SubclassSelected -> updatePlan { it.copy(selections = it.selections.copy(subclassId = intent.subclassId)) }
+            is CharacterLevelUpIntent.ChoiceToggled -> toggleChoice(intent)
+            is CharacterLevelUpIntent.HitPointsSelected -> updatePlan { it.copy(selections = it.selections.copy(hitPointGain = intent.gain)) }
+            is CharacterLevelUpIntent.AbilityScoreDecisionSelected -> updatePlan { it.copy(selections = it.selections.copy(abilityScoreDecision = intent.decision, featChoices = emptyMap())) }
+            is CharacterLevelUpIntent.SpellChangesSelected -> updatePlan { it.copy(selections = it.selections.copy(spellChanges = intent.changes)) }
+            is CharacterLevelUpIntent.AcknowledgementChanged -> updatePlan { plan ->
+                val codes = plan.selections.acknowledgedIssueCodes.toMutableSet().apply {
+                    if (intent.acknowledged) add(intent.issueCode) else remove(intent.issueCode)
+                }
+                plan.copy(selections = plan.selections.copy(acknowledgedIssueCodes = codes))
+            }
+            CharacterLevelUpIntent.NextClicked -> move(1)
+            CharacterLevelUpIntent.BackClicked -> move(-1)
+            CharacterLevelUpIntent.CancelClicked -> viewModelScope.launch { _effects.emit(CharacterLevelUpEffect.Cancelled) }
+            CharacterLevelUpIntent.ConfirmClicked -> confirm()
+            CharacterLevelUpIntent.ReloadClicked -> reloadDraft()
+        }
+    }
+
+    private fun render(source: SourceState, draft: SavedDraft?): CharacterLevelUpUiState {
+        latestReady = source as? SourceState.Ready
+        return when (source) {
+        SourceState.Loading -> CharacterLevelUpUiState.Loading
+        is SourceState.Failure -> CharacterLevelUpUiState.Failure(source.message)
+        is SourceState.Ready -> {
+            val managed = source.character.progressionState as? ProgressionState.Managed
+                ?: return CharacterLevelUpUiState.Unavailable("Set up level progression", "Reconciliation is not yet available for this character.")
+            val progression = managed.progression
+            if (progression.totalLevel >= LevelUpReferenceRules.maximumCharacterLevel) {
+                return CharacterLevelUpUiState.Unavailable("Maximum level reached", "This character is already level 20.")
+            }
+            val reference = LevelUpReferenceData(source.reference.classes, source.reference.features, source.reference.feats, LevelUpReferenceRules.referenceDataVersion, source.reference.spells)
+            val restored = draft?.plan?.takeIf { it.expectedTotalLevel == progression.totalLevel && it.rulesetId == progression.rulesetId && it.referenceDataVersion == reference.referenceDataVersion }
+            val plan = restored ?: createPlan(progression)
+            if (restored == null && draft != null) clearSavedDraft()
+            val preview = rebuildPlan(source.character.sheet, progression, plan, reference)
+            val steps = characterLevelUpSteps(preview.requirements)
+            val requested = restored?.let { draft.step } ?: CharacterLevelUpStep.Class
+            val step = requested.takeIf(steps::contains) ?: steps.first()
+            CharacterLevelUpUiState.Content(source.character.sheet.name, plan, preview, source.reference.classes, source.reference.feats, source.reference.spells, steps, step, steps.indexOf(step), draft?.isSaving == true, draft?.staleMessage, draft?.persistenceMessage)
+        }
+        }
+    }
+
+    private fun updatePlan(transform: (LevelUpPlan) -> LevelUpPlan) {
+        val content = uiState.value as? CharacterLevelUpUiState.Content ?: return
+        setDraft(SavedDraft(content.step, transform(content.plan)))
+    }
+
+    private fun toggleChoice(intent: CharacterLevelUpIntent.ChoiceToggled) {
+        val content = uiState.value as? CharacterLevelUpUiState.Content ?: return
+        val requirement = content.preview.requirements.filterIsInstance<LevelUpRequirement.ChoiceSelection>().firstOrNull { it.id == intent.requirementId } ?: return
+        updatePlan { plan ->
+            val target = when (requirement.category) {
+                LevelUpChoiceCategory.Feature -> plan.selections.featureChoices
+                LevelUpChoiceCategory.Proficiency -> plan.selections.proficiencyChoices
+                LevelUpChoiceCategory.Feat -> plan.selections.featChoices
+            }.toMutableMap()
+            val selected = target[intent.requirementId].orEmpty().toMutableSet()
+            if (!selected.remove(intent.optionId)) {
+                if (selected.size >= intent.maximum) selected.remove(selected.first())
+                selected.add(intent.optionId)
+            }
+            target[intent.requirementId] = selected
+            val selections = when (requirement.category) {
+                LevelUpChoiceCategory.Feature -> plan.selections.copy(featureChoices = target)
+                LevelUpChoiceCategory.Proficiency -> plan.selections.copy(proficiencyChoices = target)
+                LevelUpChoiceCategory.Feat -> plan.selections.copy(featChoices = target)
+            }
+            plan.copy(selections = selections)
+        }
+    }
+
+    private fun move(delta: Int) {
+        val content = uiState.value as? CharacterLevelUpUiState.Content ?: return
+        val next = (content.currentStepIndex + delta).coerceIn(0, content.steps.lastIndex)
+        setDraft(SavedDraft(content.steps[next], content.plan))
+    }
+
+    private fun reloadDraft() {
+        clearSavedDraft()
+        draft.value = null
+    }
+
+    private fun confirm() {
+        val content = uiState.value as? CharacterLevelUpUiState.Content ?: return
+        if (!content.canConfirm || characterId == null) return
+        val ready = latestReady ?: return
+        val reference = LevelUpReferenceData(ready.reference.classes, ready.reference.features, ready.reference.feats, LevelUpReferenceRules.referenceDataVersion, ready.reference.spells)
+        setDraft(SavedDraft(content.step, content.plan, isSaving = true))
+        viewModelScope.launch {
+            when (val result = applyLevelUp(characterId, content.plan.expectedTotalLevel, content.plan, reference)) {
+                is ApplyLevelUpResult.Success -> { clearSavedDraft(); _effects.emit(CharacterLevelUpEffect.Completed) }
+                ApplyLevelUpResult.StaleState -> setDraft(SavedDraft(CharacterLevelUpStep.Review, content.plan, staleMessage = "The character changed. Reload this draft before confirming."))
+                is ApplyLevelUpResult.PersistenceFailure -> setDraft(SavedDraft(CharacterLevelUpStep.Review, content.plan, persistenceMessage = result.message.ifBlank { "Unable to save. Your reviewed choices are ready to retry." }))
+                is ApplyLevelUpResult.ValidationFailure -> setDraft(SavedDraft(CharacterLevelUpStep.Review, content.plan, persistenceMessage = result.issues.joinToString("\n") { it.message }))
+                ApplyLevelUpResult.MissingCharacter -> _effects.emit(CharacterLevelUpEffect.Message("Character not found"))
+                ApplyLevelUpResult.UnmanagedCharacter -> _effects.emit(CharacterLevelUpEffect.Message("This character is not managed"))
+            }
+        }
+    }
+
+    private fun setDraft(value: SavedDraft) { draft.value = value; savedStateHandle[DRAFT_KEY] = JSON.encodeToString(SavedDraft.serializer(), value) }
+    private fun clearSavedDraft() { savedStateHandle.remove<String>(DRAFT_KEY) }
+    private fun restoredDraft(): SavedDraft? = savedStateHandle.get<String>(DRAFT_KEY)?.let { runCatching { JSON.decodeFromString(SavedDraft.serializer(), it) }.getOrNull() }
+
+    @Serializable
+    private data class SavedDraft(val step: CharacterLevelUpStep, val plan: LevelUpPlan, val isSaving: Boolean = false, val staleMessage: String? = null, val persistenceMessage: String? = null)
+    private sealed interface SourceState { data object Loading : SourceState; data class Failure(val message: String) : SourceState; data class Ready(val character: CharacterWithProgression, val reference: ReferenceState) : SourceState }
+    companion object { private const val DRAFT_KEY = "character-level-up-draft"; private val JSON = Json { ignoreUnknownKeys = true } }
+}

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/sheet/CharacterSheetIntent.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/sheet/CharacterSheetIntent.kt
@@ -43,6 +43,7 @@ sealed interface CharacterSheetIntent {
     data object CancelEditMode : CharacterSheetIntent
     data object SaveEditsClicked : CharacterSheetIntent
     data object OpenFullEditorClicked : CharacterSheetIntent
+    data object LevelUpClicked : CharacterSheetIntent
     data object DeleteCharacterClicked : CharacterSheetIntent
     data object LongRestConfirmed : CharacterSheetIntent
     data object ShortRestConfirmed : CharacterSheetIntent

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/sheet/CharacterSheetRoute.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/sheet/CharacterSheetRoute.kt
@@ -52,6 +52,7 @@ fun CharacterSheetRoute(
     onOpenSpellDetail: (String) -> Unit,
     onAddSpells: (String) -> Unit,
     onOpenFullEditor: (String) -> Unit,
+    onLevelUp: (String) -> Unit,
     onCharacterDeleted: () -> Unit,
     onBack: () -> Unit,
     modifier: Modifier = Modifier,
@@ -96,6 +97,7 @@ fun CharacterSheetRoute(
             is CharacterSheetIntent.SpellSelected -> onOpenSpellDetail(intent.spellId)
             CharacterSheetIntent.AddSpellsClicked -> contentState?.characterId?.let(onAddSpells)
             CharacterSheetIntent.OpenFullEditorClicked -> contentState?.characterId?.let(onOpenFullEditor)
+            CharacterSheetIntent.LevelUpClicked -> contentState?.characterId?.let(onLevelUp)
             CharacterSheetIntent.LongRestClicked -> showLongRestConfirmation = true
             CharacterSheetIntent.ShortRestClicked -> showShortRestConfirmation = true
             else -> vm.dispatch(intent)
@@ -135,6 +137,23 @@ fun CharacterSheetRoute(
                         expanded = overflowExpanded,
                         onDismissRequest = { overflowExpanded = false },
                     ) {
+                        DropdownMenuItem(
+                            text = {
+                                Text(
+                                    when (val progression = contentState?.progression) {
+                                        is com.github.arhor.spellbindr.ui.feature.character.sheet.model.ProgressionSummaryUiModel.Managed ->
+                                            if (progression.totalLevel >= 20) "Level up · Maximum level reached" else "Level up"
+                                        else -> "Set up level progression"
+                                    },
+                                )
+                            },
+                            onClick = {
+                                overflowExpanded = false
+                                dispatch(CharacterSheetIntent.LevelUpClicked)
+                            },
+                            enabled = (contentState?.progression as? com.github.arhor.spellbindr.ui.feature.character.sheet.model.ProgressionSummaryUiModel.Managed)
+                                ?.totalLevel in 1..19,
+                        )
                         DropdownMenuItem(
                             text = { Text("Open full editor") },
                             onClick = {

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/sheet/CharacterSheetScreen.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/sheet/CharacterSheetScreen.kt
@@ -83,6 +83,7 @@ internal fun CharacterSheetScreen(
                     onConcentrationClear = { dispatch(CharacterSheetIntent.ConcentrationCleared) },
                     onAddWeaponClick = { dispatch(CharacterSheetIntent.AddWeaponClicked) },
                     onWeaponSelected = { dispatch(CharacterSheetIntent.WeaponSelected(it)) },
+                    onLevelUp = { dispatch(CharacterSheetIntent.LevelUpClicked) },
                     modifier = modifier,
                 )
                 state.weaponEditorState?.let { editor ->

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/sheet/CharacterSheetViewModel.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/sheet/CharacterSheetViewModel.kt
@@ -143,6 +143,7 @@ class CharacterSheetViewModel @Inject constructor(
             is CharacterSheetIntent.CancelEditMode -> cancelEditMode()
             is CharacterSheetIntent.SaveEditsClicked -> saveInlineEdits()
             is CharacterSheetIntent.OpenFullEditorClicked -> Unit
+            is CharacterSheetIntent.LevelUpClicked -> Unit
             is CharacterSheetIntent.DeleteCharacterClicked -> deleteCharacter()
             is CharacterSheetIntent.LongRestConfirmed -> longRest()
             is CharacterSheetIntent.ShortRestConfirmed -> shortRest()

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/sheet/components/CharacterSheetContent.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/sheet/components/CharacterSheetContent.kt
@@ -54,6 +54,7 @@ internal fun CharacterSheetContent(
     onConcentrationClear: () -> Unit,
     onAddWeaponClick: () -> Unit,
     onWeaponSelected: (String) -> Unit,
+    onLevelUp: () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     val tabs = CharacterSheetTab.entries
@@ -109,6 +110,7 @@ internal fun CharacterSheetContent(
                     progression = state.progression,
                     editMode = state.editMode,
                     editingState = state.editingState,
+                    onLevelUp = onLevelUp,
                     modifier = Modifier.fillMaxSize(),
                 )
 
@@ -171,6 +173,7 @@ private fun CharacterSheetContentPreview() {
             onConcentrationClear = {},
             onAddWeaponClick = {},
             onWeaponSelected = {},
+            onLevelUp = {},
             modifier = Modifier.fillMaxSize(),
         )
     }

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/sheet/components/ProgressionSummaryCard.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/sheet/components/ProgressionSummaryCard.kt
@@ -8,6 +8,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.Button
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -18,6 +20,7 @@ import com.github.arhor.spellbindr.ui.feature.character.sheet.model.ProgressionS
 @Composable
 internal fun ProgressionSummaryCard(
     progression: ProgressionSummaryUiModel,
+    onLevelUp: () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     Surface(
@@ -35,7 +38,7 @@ internal fun ProgressionSummaryCard(
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
             when (progression) {
-                is ProgressionSummaryUiModel.Managed -> ManagedProgressionSummary(progression)
+                is ProgressionSummaryUiModel.Managed -> ManagedProgressionSummary(progression, onLevelUp)
                 is ProgressionSummaryUiModel.Unmanaged -> UnmanagedProgressionSummary(progression)
             }
         }
@@ -45,6 +48,7 @@ internal fun ProgressionSummaryCard(
 @Composable
 private fun ManagedProgressionSummary(
     progression: ProgressionSummaryUiModel.Managed,
+    onLevelUp: () -> Unit,
 ) {
     Row(
         modifier = Modifier.fillMaxWidth(),
@@ -81,6 +85,9 @@ private fun ManagedProgressionSummary(
             )
         }
     }
+    Button(onClick = onLevelUp, enabled = progression.totalLevel < 20, modifier = Modifier.fillMaxWidth()) {
+        Text(if (progression.totalLevel >= 20) "Maximum level reached" else "Level up")
+    }
 }
 
 @Composable
@@ -97,4 +104,7 @@ private fun UnmanagedProgressionSummary(
         style = MaterialTheme.typography.bodyMedium,
         color = MaterialTheme.colorScheme.onSurface,
     )
+    OutlinedButton(onClick = {}, enabled = false, modifier = Modifier.fillMaxWidth()) {
+        Text("Set up level progression")
+    }
 }

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/sheet/components/tabs/overview/OverviewTab.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/sheet/components/tabs/overview/OverviewTab.kt
@@ -23,6 +23,7 @@ fun OverviewTab(
     progression: ProgressionSummaryUiModel,
     editMode: SheetEditMode,
     editingState: CharacterSheetEditingState?,
+    onLevelUp: () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -40,6 +41,7 @@ fun OverviewTab(
         )
         ProgressionSummaryCard(
             progression = progression,
+            onLevelUp = onLevelUp,
         )
     }
 }

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/ui/navigation/AppDestinations.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/ui/navigation/AppDestinations.kt
@@ -24,6 +24,9 @@ sealed class AppDestination(open val title: String) {
     data class CharacterEditor(val characterId: String? = null) : AppDestination(title = "Character Editor")
 
     @Serializable
+    data class CharacterLevelUp(val characterId: String) : AppDestination(title = "Level up")
+
+    @Serializable
     data object GuidedCharacterSetup : AppDestination(title = "Guided setup")
 
     @Serializable

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/ui/navigation/AppNavGraph.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/ui/navigation/AppNavGraph.kt
@@ -15,6 +15,7 @@ import com.github.arhor.spellbindr.ui.feature.character.guided.GuidedCharacterSe
 import com.github.arhor.spellbindr.ui.feature.character.list.CharactersListRoute
 import com.github.arhor.spellbindr.ui.feature.character.list.model.CharacterListItem
 import com.github.arhor.spellbindr.ui.feature.character.list.model.CreateCharacterMode
+import com.github.arhor.spellbindr.ui.feature.character.levelup.CharacterLevelUpRoute
 import com.github.arhor.spellbindr.ui.feature.character.sheet.CHARACTER_SPELL_SELECTION_RESULT_KEY
 import com.github.arhor.spellbindr.ui.feature.character.sheet.CharacterSheetRoute
 import com.github.arhor.spellbindr.ui.feature.character.sheet.CharacterSheetRouteArgs
@@ -117,8 +118,15 @@ private fun NavGraphBuilder.charactersNavGraph(controller: NavHostController) {
             onOpenSpellDetail = { controller.navigate(AppDestination.SpellDetails(it)) },
             onAddSpells = { controller.navigate(AppDestination.CharacterSpellPicker(it)) },
             onOpenFullEditor = { controller.navigate(AppDestination.CharacterEditor(it)) },
+            onLevelUp = { controller.navigate(AppDestination.CharacterLevelUp(it)) },
             onCharacterDeleted = controller::navigateUp,
             onBack = controller::navigateUp,
+        )
+    }
+    composable<AppDestination.CharacterLevelUp> {
+        CharacterLevelUpRoute(
+            onBack = controller::navigateUp,
+            onFinished = controller::navigateUp,
         )
     }
     composable<AppDestination.CharacterSpellPicker> {

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/data/repository/CharacterRepositoryImplTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/data/repository/CharacterRepositoryImplTest.kt
@@ -1,6 +1,7 @@
 package com.github.arhor.spellbindr.data.repository
 
 import com.github.arhor.spellbindr.data.local.database.CharacterProgressionJsonCodec
+import com.github.arhor.spellbindr.data.local.database.SpellbindrDatabase
 import com.github.arhor.spellbindr.data.local.database.dao.CharacterDao
 import com.github.arhor.spellbindr.data.local.database.entity.CharacterEntity
 import com.github.arhor.spellbindr.data.local.database.entity.CharacterProgressionEntity
@@ -38,7 +39,8 @@ class CharacterRepositoryImplTest {
             classDiscriminator = "type"
         }
     )
-    private val repository = CharacterRepositoryImpl(characterDao, progressionJsonCodec)
+    private val database = mockk<SpellbindrDatabase>(relaxed = true)
+    private val repository = CharacterRepositoryImpl(characterDao, progressionJsonCodec, database)
 
     @Test
     fun `observeCharacterWithProgression should map unmanaged state when progression row is missing`() = runTest {

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/domain/model/LevelUpReferenceDataIntegrityTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/domain/model/LevelUpReferenceDataIntegrityTest.kt
@@ -1,0 +1,172 @@
+package com.github.arhor.spellbindr.domain.model
+
+import com.google.common.truth.Truth.assertThat
+import kotlinx.serialization.json.Json
+import org.junit.Test
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+
+class LevelUpReferenceDataIntegrityTest {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        classDiscriminator = "type"
+    }
+
+    @Test
+    fun `decode should provide one complete policy for every bundled character class`() {
+        // Given
+        val classes = decodeAsset<List<CharacterClass>>("classes.json")
+
+        // When
+        val policies = classes.associate { it.id to LevelUpReferenceRules.policyFor(it.id) }
+
+        // Then
+        assertThat(classes).hasSize(12)
+        assertThat(policies.keys).containsExactlyElementsIn(LevelUpReferenceRules.classPolicies.keys)
+        assertThat(policies.values).doesNotContain(null)
+        assertThat(classes.map { it.multiClassing }).doesNotContain(null)
+    }
+
+    @Test
+    fun `decode should provide contiguous levels and valid feature references for every class`() {
+        // Given
+        val classes = decodeAsset<List<CharacterClass>>("classes.json")
+        val features = decodeAsset<List<Feature>>("features.json").associateBy(Feature::id)
+
+        // When
+        val missingFeatureReferences = classes.flatMap { characterClass ->
+            (characterClass.levels + characterClass.subclasses.flatMap { it.levels.orEmpty() })
+                .flatMap { level -> level.features.filterNot(features::containsKey) }
+                .map { featureId -> "${characterClass.id}:$featureId" }
+        }
+
+        // Then
+        classes.forEach { characterClass ->
+            assertThat(characterClass.levels.map(ClassLevel::level)).containsExactlyElementsIn(1..20).inOrder()
+            assertThat(characterClass.levels.map(ClassLevel::id).toSet()).hasSize(20)
+        }
+        assertThat(missingFeatureReferences).isEmpty()
+    }
+
+    @Test
+    fun `decode should align every subclass acquisition policy with bundled subclass levels`() {
+        // Given
+        val classes = decodeAsset<List<CharacterClass>>("classes.json")
+
+        // When
+        val acquisitionLevels = classes.associate { characterClass ->
+            characterClass.id to characterClass.subclasses.minOf { it.levels.orEmpty().minOf(ClassLevel::level) }
+        }
+
+        // Then
+        acquisitionLevels.forEach { (classId, level) ->
+            assertThat(LevelUpReferenceRules.policyFor(classId)?.subclass?.level).isEqualTo(level)
+        }
+    }
+
+    @Test
+    fun `decode should preserve all typed multiclass prerequisites grants and choices`() {
+        // Given
+        val classes = decodeAsset<List<CharacterClass>>("classes.json")
+
+        // When
+        val multiclassRules = classes.associate { it.id to requireNotNull(it.multiClassing) }
+
+        // Then
+        multiclassRules.forEach { (classId, rule) ->
+            assertThat(rule.prerequisites).isNotEmpty()
+            rule.prerequisites.forEach { prerequisite ->
+                assertThat(prerequisite.abilityScore).isNotEmpty()
+                assertThat(prerequisite.abilityScore.all { it in AbilityIds.standardOrder }).isTrue()
+                assertThat(prerequisite.minimumScore).isAtLeast(1)
+            }
+            assertThat(rule.proficiencyChoices.mapIndexed { index, _ -> rule.proficiencyChoiceId(classId, index) })
+                .containsNoDuplicates()
+        }
+    }
+
+    @Test
+    fun `levelUpCapability should resolve every feature choice to a stable selection requirement`() {
+        // Given
+        val features = decodeAsset<List<Feature>>("features.json")
+
+        // When
+        val capabilities = features.associate { it.id to it.levelUpCapability() }
+
+        // Then
+        features.filter { it.choice != null }.forEach { feature ->
+            val capability = capabilities.getValue(feature.id)
+            assertThat(capability).isInstanceOf(FeatureCapability.Selection::class.java)
+            assertThat((capability as FeatureCapability.Selection).choiceId).isEqualTo("${feature.id}:choice")
+        }
+        assertThat(features.filter { it.choice == null }.map { capabilities.getValue(it.id) })
+            .containsOnly(FeatureCapability.Descriptive)
+    }
+
+    @Test
+    fun `decode should provide valid prerequisites structured effects and stable choices for every feat`() {
+        // Given
+        val feats = decodeAsset<List<Feat>>("feats.json")
+        val proficiencyIds = decodeAsset<List<Proficiency>>("proficiencies.json").map(Proficiency::id).toSet()
+
+        // When
+        val featChoiceIds = feats.mapNotNull(Feat::abilityBonusChoiceId)
+
+        // Then
+        assertThat(feats.map(Feat::id)).containsNoDuplicates()
+        assertThat(featChoiceIds).containsNoDuplicates()
+        feats.forEach { feat ->
+            feat.prerequisites.forEach { prerequisite ->
+                when (prerequisite) {
+                    is Prerequisite.AbilityScorePrerequisite -> {
+                        assertThat(prerequisite.abilityScore.all { it in AbilityIds.standardOrder }).isTrue()
+                    }
+                    is Prerequisite.ProficiencyPrerequisite -> {
+                        assertThat(proficiencyIds).contains(prerequisite.id)
+                    }
+                    else -> error("Unexpected feat prerequisite for ${feat.id}: $prerequisite")
+                }
+            }
+            feat.abilityBonusChoice?.from?.flatMap { it.keys }?.forEach { abilityId ->
+                assertThat(AbilityIds.standardOrder).contains(abilityId)
+            }
+        }
+    }
+
+    @Test
+    fun `reference rules should provide complete xp and slot tables and spell policies`() {
+        // Given
+        val classes = decodeAsset<List<CharacterClass>>("classes.json")
+
+        // When
+        val policies = classes.associateBy({ it.id }, { LevelUpReferenceRules.policyFor(it.id)!! })
+
+        // Then
+        assertThat(LevelUpReferenceRules.experienceThresholds.keys).containsExactlyElementsIn(1..20).inOrder()
+        assertThat(LevelUpReferenceRules.sharedSpellSlots.keys).containsExactlyElementsIn(1..20).inOrder()
+        LevelUpReferenceRules.sharedSpellSlots.values.forEach { slots ->
+            assertThat(slots.keys.all { it in 1..9 }).isTrue()
+            assertThat(slots.values.all { it > 0 }).isTrue()
+        }
+        assertThat(policies.filterValues { it.casterContribution == CasterContribution.Full }.keys)
+            .containsExactly("bard", "cleric", "druid", "sorcerer", "wizard")
+        assertThat(policies.filterValues { it.casterContribution == CasterContribution.Half }.keys)
+            .containsExactly("paladin", "ranger")
+        assertThat(policies.getValue("warlock").casterContribution).isEqualTo(CasterContribution.Pact)
+        assertThat(LevelUpReferenceRules.pactMagic.classId).isEqualTo("warlock")
+    }
+
+    private inline fun <reified T> decodeAsset(fileName: String): T =
+        json.decodeFromString(assetPath(fileName).toFile().readText())
+
+    private fun assetPath(fileName: String): Path {
+        var current = Paths.get(System.getProperty("user.dir")).toAbsolutePath()
+        while (true) {
+            val candidate = current.resolve(Paths.get("app", "src", "main", "assets", "data", fileName))
+            if (Files.exists(candidate)) return candidate
+            current = current.parent ?: error("Expected bundled asset $fileName")
+        }
+    }
+}

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/domain/usecase/LevelUpProgressionEngineTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/domain/usecase/LevelUpProgressionEngineTest.kt
@@ -1,0 +1,339 @@
+package com.github.arhor.spellbindr.domain.usecase
+
+import com.github.arhor.spellbindr.domain.model.AbilityIds
+import com.github.arhor.spellbindr.domain.model.AbilityScorePrerequisite
+import com.github.arhor.spellbindr.domain.model.AbilityScores
+import com.github.arhor.spellbindr.domain.model.CharacterClass
+import com.github.arhor.spellbindr.domain.model.CharacterLevelRecord
+import com.github.arhor.spellbindr.domain.model.CharacterProgression
+import com.github.arhor.spellbindr.domain.model.CharacterSheet
+import com.github.arhor.spellbindr.domain.model.ClassSpellRef
+import com.github.arhor.spellbindr.domain.model.Choice
+import com.github.arhor.spellbindr.domain.model.ClassLevel
+import com.github.arhor.spellbindr.domain.model.Feature
+import com.github.arhor.spellbindr.domain.model.Feat
+import com.github.arhor.spellbindr.domain.model.HitPointGain
+import com.github.arhor.spellbindr.domain.model.LevelUpPlan
+import com.github.arhor.spellbindr.domain.model.LevelUpReferenceData
+import com.github.arhor.spellbindr.domain.model.LevelUpSelections
+import com.github.arhor.spellbindr.domain.model.LevelUpValidationCode
+import com.github.arhor.spellbindr.domain.model.LevelUpValidationSeverity
+import com.github.arhor.spellbindr.domain.model.MultiClassing
+import com.github.arhor.spellbindr.domain.model.ProgressionOrigin
+import com.github.arhor.spellbindr.domain.model.Prerequisite
+import com.github.arhor.spellbindr.domain.model.Spell
+import com.github.arhor.spellbindr.domain.model.SpellChanges
+import com.github.arhor.spellbindr.domain.model.SpellReplacement
+import com.github.arhor.spellbindr.domain.model.EntityRef
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class LevelUpProgressionEngineTest {
+
+    @Test
+    fun `rebuild should derive the next level from ordered class history when returning to an earlier class`() {
+        // Given
+        val progression = progression("fighter", "wizard", "fighter")
+        val sheet = CharacterSheet(id = "character", level = 3)
+        val plan = plan(expectedLevel = 3, classId = "fighter", hitPoints = HitPointGain.Fixed(6))
+
+        // When
+        val preview = LevelUpProgressionEngine.rebuild(sheet, progression, plan, referenceData())
+
+        // Then
+        assertThat(preview.after.classLevels).containsExactly("fighter", 3, "wizard", 1)
+        assertThat(preview.after.totalLevel).isEqualTo(4)
+    }
+
+    @Test
+    fun `rebuild should require acknowledgement when a new class multiclass prerequisite is not met`() {
+        // Given
+        val progression = progression("fighter")
+        val sheet = CharacterSheet(id = "character", level = 1, abilityScores = AbilityScores(strength = 13, intelligence = 12))
+        val plan = plan(expectedLevel = 1, classId = "wizard", hitPoints = HitPointGain.Fixed(6))
+
+        // When
+        val preview = LevelUpProgressionEngine.rebuild(sheet, progression, plan, referenceData())
+
+        // Then
+        assertThat(preview.validations).contains(
+            issue(LevelUpValidationCode.MulticlassPrerequisite, LevelUpValidationSeverity.Overrideable),
+        )
+        assertThat(preview.canConfirm).isFalse()
+    }
+
+    @Test
+    fun `rebuild should block a level up when the character is already level twenty`() {
+        // Given
+        val progression = progression(List(20) { "fighter" })
+        val sheet = CharacterSheet(id = "character", level = 20)
+        val plan = plan(expectedLevel = 20, classId = "fighter", hitPoints = HitPointGain.Fixed(6))
+
+        // When
+        val preview = LevelUpProgressionEngine.rebuild(sheet, progression, plan, referenceData())
+
+        // Then
+        assertThat(preview.validations.map { it.code }).contains(LevelUpValidationCode.MaximumCharacterLevel)
+        assertThat(preview.canConfirm).isFalse()
+    }
+
+    @Test
+    fun `rebuild should apply constitution improvements to every hit die when an ASI raises constitution`() {
+        // Given
+        val progression = progression(List(3) { "fighter" })
+        val sheet = CharacterSheet(id = "character", level = 3, abilityScores = AbilityScores(constitution = 10))
+        val plan = plan(
+            expectedLevel = 3,
+            classId = "fighter",
+            hitPoints = HitPointGain.Fixed(6),
+            selections = LevelUpSelections(
+                hitPointGain = HitPointGain.Fixed(6),
+                abilityScoreDecision = com.github.arhor.spellbindr.domain.model.AbilityScoreDecision.Increase(
+                    mapOf(AbilityIds.CON to 2),
+                ),
+            ),
+        )
+
+        // When
+        val preview = LevelUpProgressionEngine.rebuild(sheet, progression, plan, referenceData())
+
+        // Then
+        assertThat(preview.after.maximumHitPoints - preview.before.maximumHitPoints).isEqualTo(10)
+        assertThat(preview.after.abilityScores.constitution).isEqualTo(12)
+    }
+
+    @Test
+    fun `rebuild should produce equal previews when inputs are unchanged`() {
+        // Given
+        val progression = progression("fighter")
+        val sheet = CharacterSheet(id = "character", level = 1)
+        val plan = plan(expectedLevel = 1, classId = "fighter", hitPoints = HitPointGain.Fixed(6))
+
+        // When
+        val previews = List(2) { LevelUpProgressionEngine.rebuild(sheet, progression, plan, referenceData()) }
+
+        // Then
+        assertThat(previews[0]).isEqualTo(previews[1])
+    }
+
+    @Test
+    fun `rebuild should block confirmation when no class has been selected`() {
+        // Given
+        val plan = LevelUpPlan(1, CharacterProgression.SUPPORTED_RULESET_ID, "test-v1")
+
+        // When
+        val preview = LevelUpProgressionEngine.rebuild(CharacterSheet(id = "character", level = 1), progression("fighter"), plan, referenceData())
+
+        // Then
+        assertThat(preview.validations.map { it.code }).contains(LevelUpValidationCode.ChoiceRequired)
+    }
+
+    @Test
+    fun `rebuild should block a subclass selected before its acquisition level`() {
+        // Given
+        val plan = plan(1, "fighter", HitPointGain.Fixed(6), LevelUpSelections(subclassId = "champion", hitPointGain = HitPointGain.Fixed(6)))
+
+        // When
+        val preview = LevelUpProgressionEngine.rebuild(CharacterSheet(id = "character", level = 1), progression("fighter"), plan, referenceData())
+
+        // Then
+        assertThat(preview.validations.map { it.code }).contains(LevelUpValidationCode.StickySubclass)
+    }
+
+    @Test
+    fun `rebuild should expose later subclass feature choices when a sticky subclass gains a feature`() {
+        // Given
+        val championFeature = Feature("champion-feature", "Champion feature", emptyList(), Choice.OptionsArrayChoice(1, listOf("a")))
+        val champion = com.github.arhor.spellbindr.domain.model.Subclass("champion", "Champion", emptyList(), subclassFlavor = "Martial", levels = listOf(ClassLevel("champion-3", 3, listOf(championFeature.id))))
+        val championFighter = fighter.copy(subclasses = listOf(champion))
+        val existing = progression("fighter", "fighter").copy(levels = listOf(
+            CharacterLevelRecord(1, "fighter", 1, hitPointGain = HitPointGain.Fixed(10)),
+            CharacterLevelRecord(2, "fighter", 2, subclassId = "champion", hitPointGain = HitPointGain.Fixed(6)),
+        ))
+        val plan = plan(2, "fighter", HitPointGain.Fixed(6), LevelUpSelections(hitPointGain = HitPointGain.Fixed(6), featureChoices = mapOf("champion-feature:choice" to setOf("a"))))
+
+        // When
+        val preview = LevelUpProgressionEngine.rebuild(CharacterSheet(id = "character", level = 2), existing, plan, LevelUpReferenceData(listOf(championFighter, wizard), listOf(championFeature), referenceDataVersion = "test-v1"))
+
+        // Then
+        assertThat(preview.requirements.filterIsInstance<com.github.arhor.spellbindr.domain.model.LevelUpRequirement.ChoiceSelection>().map { it.id }).contains("champion-feature:choice")
+    }
+
+    @Test
+    fun `rebuild should enforce feat proficiency prerequisites and ability score caps when selecting a feat`() {
+        // Given
+        val feat = Feat(
+            id = "strong-feat",
+            name = "Strong feat",
+            desc = emptyList(),
+            prerequisites = listOf(Prerequisite.ProficiencyPrerequisite("skill-athletics")),
+            abilityBonusChoice = Choice.AbilityBonusChoice(1, listOf(mapOf(AbilityIds.STR to 1))),
+        )
+        val selections = LevelUpSelections(
+            hitPointGain = HitPointGain.Fixed(6),
+            abilityScoreDecision = com.github.arhor.spellbindr.domain.model.AbilityScoreDecision.Feat(feat.id),
+            featChoices = mapOf("strong-feat:ability-bonus" to setOf(AbilityIds.STR)),
+        )
+        val data = LevelUpReferenceData(listOf(fighter, wizard), emptyList(), listOf(feat), "test-v1")
+        val proficientData = LevelUpReferenceData(listOf(fighter.copy(proficiencies = listOf("skill-athletics")), wizard), emptyList(), listOf(feat), "test-v1")
+
+        // When
+        val missingProficiency = LevelUpProgressionEngine.rebuild(CharacterSheet(id = "character", level = 3), progression(List(3) { "fighter" }), plan(3, "fighter", HitPointGain.Fixed(6), selections), data)
+        val capped = LevelUpProgressionEngine.rebuild(CharacterSheet(id = "character", level = 3, abilityScores = AbilityScores(strength = 20)), progression(List(3) { "fighter" }), plan(3, "fighter", HitPointGain.Fixed(6), selections), proficientData)
+
+        // Then
+        assertThat(missingProficiency.validations.map { it.code }).contains(LevelUpValidationCode.FeatPrerequisite)
+        assertThat(capped.validations.map { it.code }).contains(LevelUpValidationCode.InvalidAbilityScoreIncrease)
+    }
+
+    @Test
+    fun `rebuild should calculate shared and pact magic slots separately when the character has wizard and warlock levels`() {
+        // Given
+        val warlock = characterClass("warlock", 8, emptyList())
+        val progression = progression("wizard", "warlock", "wizard")
+        val sheet = CharacterSheet(id = "character", level = 3)
+        val plan = plan(3, "wizard", HitPointGain.Fixed(4))
+        val data = LevelUpReferenceData(listOf(fighter, wizard, warlock), emptyList(), referenceDataVersion = "test-v1")
+
+        // When
+        val preview = LevelUpProgressionEngine.rebuild(sheet, progression, plan, data)
+
+        // Then
+        assertThat(preview.before.sharedSpellSlots).containsExactly(1, 2)
+        assertThat(preview.before.pactMagic?.slotLevel).isEqualTo(1)
+        assertThat(preview.before.pactMagic?.slots).isEqualTo(1)
+    }
+
+    @Test
+    fun `rebuild should reject a spell that is not on the selected class list when choosing a known spell`() {
+        // Given
+        val bard = characterClass("bard", 8, emptyList()).copy(levels = (1..20).map { level ->
+            ClassLevel("bard-$level", level, emptyList(), if (level == 1) com.github.arhor.spellbindr.domain.model.LevelSpellcasting(2, 4, mapOf("1" to 2)) else null)
+        })
+        val spell = Spell("wizard-only", "Wizard only", emptyList(), 1, "Self", false, EntityRef("evocation"), "Instant", "1 action", listOf(EntityRef("wizard")), emptyList(), false, source = "SRD")
+        val selections = LevelUpSelections(hitPointGain = HitPointGain.Fixed(8), spellChanges = SpellChanges(learned = setOf(ClassSpellRef("bard", spell.id))))
+        val data = LevelUpReferenceData(listOf(fighter, wizard, bard), emptyList(), spells = listOf(spell), referenceDataVersion = "test-v1")
+
+        // When
+        val preview = LevelUpProgressionEngine.rebuild(CharacterSheet(id = "character", level = 0), CharacterProgression("srd-5e-2014-v1", "test-v1", ProgressionOrigin.Guided, emptyList()), plan(0, "bard", HitPointGain.Fixed(8), selections), data)
+
+        // Then
+        assertThat(preview.validations.map { it.code }).contains(LevelUpValidationCode.SpellPolicy)
+    }
+
+    @Test
+    fun `rebuild should reject replacement when removed spell is not in reconstructed class spell state`() {
+        // Given
+        val bard = characterClass("bard", 8, emptyList()).copy(levels = (1..20).map { level ->
+            ClassLevel("bard-$level", level, emptyList(), com.github.arhor.spellbindr.domain.model.LevelSpellcasting(2, if (level == 1) 2 else 3, mapOf("1" to 2)))
+        })
+        fun bardSpell(id: String) = Spell(id, id, emptyList(), 1, "Self", false, EntityRef("evocation"),
+            "Instant", "1 action", listOf(EntityRef("bard")), emptyList(), false, source = "SRD")
+        val existing = progression("bard").copy(levels = listOf(
+            progression("bard").levels.single().copy(
+                spellChanges = SpellChanges(learned = setOf(ClassSpellRef("bard", "known"))),
+            ),
+        ))
+        val selections = LevelUpSelections(
+            hitPointGain = HitPointGain.Fixed(5),
+            spellChanges = SpellChanges(
+                learned = setOf(ClassSpellRef("bard", "level-gain")),
+                replaced = setOf(SpellReplacement("bard", "not-known", "replacement")),
+            ),
+        )
+
+        // When
+        val preview = LevelUpProgressionEngine.rebuild(
+            CharacterSheet(id = "character", level = 1), existing,
+            plan(1, "bard", HitPointGain.Fixed(5), selections),
+            LevelUpReferenceData(listOf(fighter, wizard, bard), emptyList(), spells =
+                listOf(bardSpell("known"), bardSpell("level-gain"), bardSpell("replacement")), referenceDataVersion = "test-v1"),
+        )
+
+        // Then
+        assertThat(preview.validations.map { it.message }).contains(
+            "Replacements must remove a currently known class spell and learn a distinct, non-duplicate spell.",
+        )
+    }
+
+    @Test
+    fun `rebuild should expose per-class reason when multiclass prerequisite requires override`() {
+        // Given
+        val sheet = CharacterSheet(id = "character", level = 1, abilityScores = AbilityScores(strength = 13, intelligence = 10))
+
+        // When
+        val requirement = LevelUpProgressionEngine.rebuild(
+            sheet, progression("fighter"), plan(1, "fighter", HitPointGain.Fixed(6)), referenceData(),
+        ).requirements.filterIsInstance<com.github.arhor.spellbindr.domain.model.LevelUpRequirement.ClassSelection>().single()
+
+        // Then
+        assertThat(requirement.eligibility.single { it.classId == "wizard" }.eligible).isFalse()
+        assertThat(requirement.eligibility.single { it.classId == "wizard" }.reasons.single()).contains("override")
+    }
+
+    private fun issue(code: LevelUpValidationCode, severity: LevelUpValidationSeverity) =
+        com.github.arhor.spellbindr.domain.model.LevelUpValidationIssue(code, "Ability prerequisites for Wizard are not met.", severity)
+
+    private fun plan(
+        expectedLevel: Int,
+        classId: String,
+        hitPoints: HitPointGain,
+        selections: LevelUpSelections = LevelUpSelections(hitPointGain = hitPoints),
+    ) = LevelUpPlan(
+        expectedTotalLevel = expectedLevel,
+        rulesetId = CharacterProgression.SUPPORTED_RULESET_ID,
+        referenceDataVersion = "test-v1",
+        selectedClassId = classId,
+        selections = selections,
+    )
+
+    private fun progression(vararg classIds: String): CharacterProgression = progression(classIds.toList())
+
+    private fun progression(classIds: List<String>): CharacterProgression = CharacterProgression(
+        referenceDataVersion = "test-v1",
+        origin = ProgressionOrigin.Guided,
+        levels = classIds.mapIndexed { index, classId ->
+            CharacterLevelRecord(
+                characterLevel = index + 1,
+                classId = classId,
+                classLevel = classIds.take(index + 1).count { it == classId },
+                hitPointGain = HitPointGain.Fixed(if (index == 0) 10 else 6),
+            )
+        },
+    )
+
+    private fun referenceData() = LevelUpReferenceData(
+        classes = listOf(fighter, wizard),
+        features = emptyList(),
+        referenceDataVersion = "test-v1",
+    )
+
+    private companion object {
+        val fighter = characterClass(
+            id = "fighter",
+            hitDie = 10,
+            prerequisites = listOf(AbilityScorePrerequisite(listOf(AbilityIds.STR), 13)),
+        )
+        val wizard = characterClass(
+            id = "wizard",
+            hitDie = 6,
+            prerequisites = listOf(AbilityScorePrerequisite(listOf(AbilityIds.INT), 13)),
+        )
+
+        fun characterClass(
+            id: String,
+            hitDie: Int,
+            prerequisites: List<AbilityScorePrerequisite>,
+        ) = CharacterClass(
+            id = id,
+            name = id.replaceFirstChar { it.uppercase() },
+            multiClassing = MultiClassing(prerequisites = prerequisites),
+            hitDie = hitDie,
+            proficiencies = emptyList(),
+            proficiencyChoices = emptyList(),
+            savingThrows = emptyList(),
+            subclasses = emptyList(),
+            levels = (1..20).map { level -> ClassLevel("$id-$level", level, emptyList()) },
+        )
+    }
+}

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/character/editor/CharacterEditorViewModelTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/character/editor/CharacterEditorViewModelTest.kt
@@ -2,11 +2,23 @@ package com.github.arhor.spellbindr.ui.feature.character.editor
 
 import androidx.lifecycle.SavedStateHandle
 import com.github.arhor.spellbindr.MainDispatcherRule
+import com.github.arhor.spellbindr.domain.model.AbilityIds
+import com.github.arhor.spellbindr.domain.model.CharacterProgression
+import com.github.arhor.spellbindr.domain.model.CharacterSheet
+import com.github.arhor.spellbindr.domain.model.CharacterWithProgression
+import com.github.arhor.spellbindr.domain.model.ProgressionOrigin
+import com.github.arhor.spellbindr.domain.model.ProgressionState
+import com.github.arhor.spellbindr.domain.model.Skill
 import com.github.arhor.spellbindr.domain.usecase.BuildCharacterSheetFromInputsUseCase
 import com.github.arhor.spellbindr.domain.usecase.ComputeDerivedBonusesUseCase
+import com.github.arhor.spellbindr.domain.usecase.LoadCharacterWithProgressionUseCase
 import com.github.arhor.spellbindr.domain.usecase.ValidateCharacterSheetUseCase
 import com.google.common.truth.Truth.assertThat
+import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
 import org.junit.Rule
 import org.junit.Test
 
@@ -19,7 +31,7 @@ class CharacterEditorViewModelTest {
     fun `dispatch should update name in content state when name changes`() {
         // Given
         val vm = CharacterEditorViewModel(
-            loadCharacterSheetUseCase = mockk(relaxed = true),
+            loadCharacterWithProgressionUseCase = mockk(relaxed = true),
             saveCharacterSheetUseCase = mockk(relaxed = true),
             validateCharacterSheetUseCase = mockk<ValidateCharacterSheetUseCase>(relaxed = true),
             computeDerivedBonusesUseCase = mockk<ComputeDerivedBonusesUseCase>(relaxed = true),
@@ -33,5 +45,65 @@ class CharacterEditorViewModelTest {
         // Then
         val state = vm.uiState.value as CharacterEditorUiState.Content
         assertThat(state.name).isEqualTo("Astra")
+    }
+
+    @Test
+    fun `dispatch should retain progression-owned values when managed character is edited`() = runTest {
+        // Given
+        val loadCharacterWithProgressionUseCase = mockk<LoadCharacterWithProgressionUseCase>()
+        every { loadCharacterWithProgressionUseCase("character-1") } returns flowOf(
+            CharacterWithProgression(
+                sheet = CharacterSheet(
+                    id = "character-1",
+                    className = "Wizard",
+                    level = 3,
+                    proficiencyBonus = 2,
+                    maxHitPoints = 14,
+                    hitDice = "3d6",
+                ),
+                progressionState = ProgressionState.Managed(
+                    CharacterProgression(
+                        referenceDataVersion = "test",
+                        origin = ProgressionOrigin.Guided,
+                        levels = emptyList(),
+                    ),
+                ),
+            ),
+        )
+        val vm = CharacterEditorViewModel(
+            loadCharacterWithProgressionUseCase = loadCharacterWithProgressionUseCase,
+            saveCharacterSheetUseCase = mockk(relaxed = true),
+            validateCharacterSheetUseCase = mockk(relaxed = true),
+            computeDerivedBonusesUseCase = ComputeDerivedBonusesUseCase(),
+            buildCharacterSheetFromInputsUseCase = mockk(relaxed = true),
+            savedStateHandle = SavedStateHandle(mapOf("characterId" to "character-1")),
+        )
+        advanceUntilIdle()
+
+        // When
+        vm.dispatch(CharacterEditorIntent.ClassChanged("Fighter"))
+        vm.dispatch(CharacterEditorIntent.LevelChanged("4"))
+        vm.dispatch(CharacterEditorIntent.MaxHpChanged("99"))
+        vm.dispatch(CharacterEditorIntent.HitDiceChanged("4d10"))
+        vm.dispatch(CharacterEditorIntent.AbilityChanged(AbilityIds.STR, "20"))
+        vm.dispatch(CharacterEditorIntent.ProficiencyBonusChanged("8"))
+        vm.dispatch(CharacterEditorIntent.SavingThrowProficiencyChanged(AbilityIds.STR, true))
+        vm.dispatch(CharacterEditorIntent.SkillProficiencyChanged(Skill.ATHLETICS, true))
+        vm.dispatch(CharacterEditorIntent.NameChanged("Astra"))
+        vm.dispatch(CharacterEditorIntent.NotesChanged("Still editable"))
+
+        // Then
+        val state = vm.uiState.value as CharacterEditorUiState.Content
+        assertThat(state.isProgressionManaged).isTrue()
+        assertThat(state.className).isEqualTo("Wizard")
+        assertThat(state.level).isEqualTo("3")
+        assertThat(state.maxHitPoints).isEqualTo("14")
+        assertThat(state.hitDice).isEqualTo("3d6")
+        assertThat(state.abilities.first { it.abilityId == AbilityIds.STR }.score).isEqualTo("10")
+        assertThat(state.proficiencyBonus).isEqualTo("2")
+        assertThat(state.savingThrows.first { it.abilityId == AbilityIds.STR }.proficient).isFalse()
+        assertThat(state.skills.first { it.skill == Skill.ATHLETICS }.proficient).isFalse()
+        assertThat(state.name).isEqualTo("Astra")
+        assertThat(state.notes).isEqualTo("Still editable")
     }
 }

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpStepPlannerTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpStepPlannerTest.kt
@@ -1,0 +1,45 @@
+package com.github.arhor.spellbindr.ui.feature.character.levelup
+
+import com.github.arhor.spellbindr.domain.model.LevelUpRequirement
+import com.github.arhor.spellbindr.domain.model.SpellChanges
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class CharacterLevelUpStepPlannerTest {
+
+    @Test
+    fun `characterLevelUpSteps should keep conditional steps in wizard order when requirements are unordered`() {
+        // Given
+        val requirements = listOf(
+            LevelUpRequirement.SpellDecisions("wizard:2:spells", "wizard", 2, "spellbook", SpellChanges()),
+            LevelUpRequirement.HitPoints(hitDie = 6, selectedGain = null),
+            LevelUpRequirement.ClassSelection(
+                eligibleClassIds = listOf("wizard"),
+                selectedClassId = "wizard",
+            ),
+        )
+
+        // When
+        val result = characterLevelUpSteps(requirements)
+
+        // Then
+        assertThat(result).containsExactly(
+            CharacterLevelUpStep.Class,
+            CharacterLevelUpStep.HitPoints,
+            CharacterLevelUpStep.Spells,
+            CharacterLevelUpStep.Review,
+        ).inOrder()
+    }
+
+    @Test
+    fun `characterLevelUpSteps should omit conditional steps when plan has no requirements`() {
+        // Given
+        val requirements = emptyList<LevelUpRequirement>()
+
+        // When
+        val result = characterLevelUpSteps(requirements)
+
+        // Then
+        assertThat(result).containsExactly(CharacterLevelUpStep.Class, CharacterLevelUpStep.Review).inOrder()
+    }
+}

--- a/docs/level-up-progress.md
+++ b/docs/level-up-progress.md
@@ -1,0 +1,53 @@
+# Multiclass Level-Up Implementation Ledger
+
+- [x] 1. Reference-data normalization and integrity tests
+  - Activated typed multiclass prerequisites, grants, and stable choice identifiers from `classes.json`.
+  - Added feat reference loading and typed level-up policies for all 12 SRD classes, XP, shared slots, Pact Magic,
+    subclass acquisition, ASI/feat grants, spell learning/preparation/spellbooks, and feature capabilities.
+  - Added `LevelUpReferenceDataIntegrityTest` coverage for class levels, subclasses, feature references and choices,
+    feats, multiclass data, spell policies, XP thresholds, and slot tables.
+- [x] 2. Progression plan, validation, and calculation engine
+  - Added serializable level-up drafts, typed requirements, validation severities, previews, acknowledgement ids,
+    and backward-compatible persisted feat choices, acknowledgements, and notes.
+  - Added deterministic class ordering, level-limit, multiclass, sticky-subclass, feature/proficiency/HP/ASI/feat,
+    proficiency/HP/hit-die, and shared-caster preview calculations. Spell detail remains owned by item 3.
+  - Authored focused engine tests (static inspection only; Gradle deliberately not run after the device reboot).
+- [x] 3. Spellcasting and feat policies
+  - Added class-level spell legality and exact known, prepared-cantrip, and spellbook selection policies using the
+    bundled progression tables; added preparation-capacity notices and spell reference data to the pure engine.
+  - Added separately represented Pact Magic capacity, per-class multiclass rounding, and representable third-caster
+    subclass contributions for Eldritch Knight and Arcane Trickster.
+  - Hardened feat ability-effect cap validation and preserved feat-owned stable selection ids.
+  - Static diff inspection only; Gradle deliberately not run under the machine constraint.
+- [x] 4. Materialization and atomic repository transaction
+  - Added `ApplyLevelUpUseCase` and typed repository outcomes. Confirmation reloads the character and progression,
+    validates the plan, appends exactly one record, and writes the materialized sheet/progression in one Room
+    `withTransaction` block.
+  - Managed materialization now stores structured hit-die pools and structured grants separately from free text,
+    preserves mutable sheet state, and clamps previously expended shared/Pact slots to recalculated capacities.
+- [x] 5. Managed-editor restrictions
+  - The full editor now observes `CharacterWithProgression` and disables progression-owned class, level, ability,
+    proficiency, maximum-HP, hit-dice, saving-throw, and skill controls for managed characters.
+  - Level-up ownership is also enforced by the editor state reducer and save path; mutable play state and free-text
+    fields remain editable, while spell capacities and structured grants are preserved from the managed snapshot.
+  - Added focused managed-editor state coverage (static inspection only; Gradle deliberately not run under the
+    machine constraint).
+- [x] 6. Level Up MVI, navigation, and sheet entry points
+  - Added the typed `CharacterLevelUp(characterId)` destination and dispatch-contract Intent/Route/Screen/ViewModel,
+    one-off effects, dynamic requirement-driven steps, review acknowledgements, and atomic confirmation handling.
+  - Draft selections persist as serialized ids in `SavedStateHandle` and restore only when level, ruleset, and bundled
+    reference version still match. Stale and persistence failures retain review choices for reload or retry.
+  - Added enabled level-up actions for managed levels 1–19 and disabled maximum-level/unmanaged actions on both the
+    progression card and sheet overflow menu. Static diff inspection only; Gradle deliberately not run.
+- [x] 7. Integration, screenshots, documentation, and full verification
+  - Completed the final static integration pass: replacement validation now reconstructs class-owned spell state,
+    rejects missing/self/duplicate replacements, class selection exposes per-class eligibility reasons while keeping
+    prerequisite acknowledgement overrides, and persistence keeps manual and progression proficiency ids separate.
+  - Prepared-caster materialization preserves only representably eligible prepared spells up to the recalculated
+    capacity; the current sheet model does not distinguish Wizard spellbook contents from prepared Wizard spells, so
+    Wizard entries remain preserved as spellbook state rather than being capacity-trimmed.
+  - Added focused engine regression coverage and audited the new UI/persistence signatures and imports.
+  - Verification limit: `git diff --check` only. Gradle, Room instrumentation, screenshots, and device validation were
+    deliberately not run after the device reboot and must be completed on a compatible higher-capacity runner.
+
+Review status and verification evidence will be recorded under each item as work lands.


### PR DESCRIPTION
## Summary

- add typed multiclass, feat, subclass, HP, ASI, spellcasting, and progression rules for all 12 bundled SRD classes
- add deterministic level-up planning, validation, review, and stale-safe atomic persistence
- add the Level Up MVI wizard, character-sheet entry points, and managed-editor restrictions
- preserve mutable play state while keeping progression-owned grants separate from user-authored data
- add focused reference-data, engine, editor, and wizard tests

## User impact

Managed characters can initiate a one-level Level Up flow from the progression card or sheet overflow menu, including multiclass eligibility, dynamic choices, HP, ASI/feats, spells, warnings, review, and confirmation. Level-20 and unmanaged characters receive disabled explanatory actions.

## Validation

- `git diff --check` passed
- independent static reviews completed for each subsystem and the integrated change
- Gradle, Room instrumentation, screenshot generation, and device validation were not run after a Gradle attempt rebooted the development device; CI should perform the JVM/lint build checks
- richer spell replacement controls and arbitrary manual-HP input remain candidates for follow-up UI refinement

## Notes

Implementation ledger: `docs/level-up-progress.md`
