### PR TITLE
feat: show class progression in level-up review

### DIFF
--- a/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpClassProgressionReview.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpClassProgressionReview.kt
@@ -1,0 +1,82 @@
+package com.github.arhor.spellbindr.ui.feature.character.levelup
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.github.arhor.spellbindr.domain.model.LevelUpRequirement
+
+@Composable
+internal fun CharacterLevelUpClassProgressionReview(state: CharacterLevelUpUiState.Content) {
+    val before = state.preview.before
+    val after = state.preview.after
+    val selectedClassId = state.plan.selectedClassId
+    val selectedClassName = selectedClassId?.let { classId ->
+        state.classes.firstOrNull { it.id == classId }?.name ?: classId
+    }
+
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = MaterialTheme.shapes.medium,
+        tonalElevation = 1.dp,
+    ) {
+        Column(
+            modifier = Modifier.padding(12.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Text("Class progression", style = MaterialTheme.typography.titleSmall)
+            ClassProgressionReviewRow(
+                label = "Total level",
+                before = before.totalLevel.toString(),
+                after = after.totalLevel.toString(),
+            )
+            if (selectedClassId != null && selectedClassName != null) {
+                ClassProgressionReviewRow(
+                    label = "$selectedClassName level",
+                    before = before.classLevels[selectedClassId].orZero().toString(),
+                    after = after.classLevels[selectedClassId].orZero().toString(),
+                )
+            }
+            ClassProgressionReviewRow(
+                label = "Class levels",
+                before = before.classDisplayName,
+                after = after.classDisplayName,
+            )
+            selectedSubclassName(state, selectedClassId)?.let { subclassName ->
+                Text("New subclass: $subclassName", style = MaterialTheme.typography.bodyMedium)
+            }
+        }
+    }
+}
+
+@Composable
+private fun ClassProgressionReviewRow(label: String, before: String, after: String) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Text(label)
+        Text("$before → $after")
+    }
+}
+
+private fun selectedSubclassName(
+    state: CharacterLevelUpUiState.Content,
+    selectedClassId: String?,
+): String? {
+    val requirement = state.preview.requirements
+        .filterIsInstance<LevelUpRequirement.SubclassSelection>()
+        .firstOrNull { selectedClassId == null || it.classId == selectedClassId }
+        ?: return null
+    val selectedSubclassId = requirement.selectedSubclassId ?: return null
+    return requirement.options.firstOrNull { it.id == selectedSubclassId }?.label ?: selectedSubclassId
+}
+
+private fun Int?.orZero(): Int = this ?: 0

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpScreen.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpScreen.kt
@@ -258,8 +258,7 @@ private fun Content(state: CharacterLevelUpUiState.Content, dispatch: CharacterL
                     ) { Text("Reload draft") }
                 }
                 state.persistenceMessage?.let { WarningCard(it) }
-                ReviewRow("Total level", state.preview.before.totalLevel.toString(), state.preview.after.totalLevel.toString())
-                ReviewRow("Class", state.preview.before.classDisplayName, state.preview.after.classDisplayName)
+                CharacterLevelUpClassProgressionReview(state)
                 ReviewRow("Proficiency bonus", "+${state.preview.before.proficiencyBonus}", "+${state.preview.after.proficiencyBonus}")
                 ReviewRow("Maximum HP", state.preview.before.maximumHitPoints.toString(), state.preview.after.maximumHitPoints.toString())
                 state.preview.validations.forEach { issue ->

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpClassProgressionReviewTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpClassProgressionReviewTest.kt
@@ -1,7 +1,6 @@
 package com.github.arhor.spellbindr.ui.feature.character.levelup
 
 import androidx.activity.ComponentActivity
-import androidx.compose.ui.test.assertDoesNotExist
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpClassProgressionReviewTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpClassProgressionReviewTest.kt
@@ -1,0 +1,170 @@
+package com.github.arhor.spellbindr.ui.feature.character.levelup
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.assertDoesNotExist
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.arhor.spellbindr.domain.model.AbilityScores
+import com.github.arhor.spellbindr.domain.model.CharacterClass
+import com.github.arhor.spellbindr.domain.model.LevelUpChoiceOption
+import com.github.arhor.spellbindr.domain.model.LevelUpPlan
+import com.github.arhor.spellbindr.domain.model.LevelUpPreview
+import com.github.arhor.spellbindr.domain.model.LevelUpRequirement
+import com.github.arhor.spellbindr.domain.model.LevelUpSelections
+import com.github.arhor.spellbindr.domain.model.LevelUpSnapshot
+import com.github.arhor.spellbindr.ui.theme.AppTheme
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class CharacterLevelUpClassProgressionReviewTest {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun `CharacterLevelUpScreen should show single-class progression and selected subclass when reviewing level-up`() {
+        // Given
+        val fighter = characterClass("fighter", "Fighter")
+        val subclassRequirement = LevelUpRequirement.SubclassSelection(
+            id = "fighter:3:subclass",
+            classId = fighter.id,
+            options = listOf(LevelUpChoiceOption("champion", "Champion")),
+            selectedSubclassId = "champion",
+        )
+        val state = reviewState(
+            selectedClassId = fighter.id,
+            classes = listOf(fighter),
+            before = snapshot(
+                totalLevel = 2,
+                classLevels = mapOf(fighter.id to 2),
+                classDisplayName = "Fighter 2",
+            ),
+            after = snapshot(
+                totalLevel = 3,
+                classLevels = mapOf(fighter.id to 3),
+                classDisplayName = "Fighter 3",
+            ),
+            requirements = listOf(subclassRequirement),
+            selections = LevelUpSelections(subclassId = "champion"),
+        )
+
+        // When
+        setContent(state)
+
+        // Then
+        composeTestRule.onNodeWithText("Class progression").assertExists()
+        composeTestRule.onNodeWithText("Total level").assertExists()
+        composeTestRule.onNodeWithText("Fighter level").assertExists()
+        composeTestRule.onNodeWithText("Class levels").assertExists()
+        assertThat(composeTestRule.onAllNodesWithText("2 → 3").fetchSemanticsNodes()).hasSize(2)
+        composeTestRule.onNodeWithText("Fighter 2 → Fighter 3").assertExists()
+        composeTestRule.onNodeWithText("New subclass: Champion").assertExists()
+    }
+
+    @Test
+    fun `CharacterLevelUpScreen should show multiclass distribution and selected class level when reviewing multiclass level-up`() {
+        // Given
+        val fighter = characterClass("fighter", "Fighter")
+        val wizard = characterClass("wizard", "Wizard")
+        val state = reviewState(
+            selectedClassId = wizard.id,
+            classes = listOf(fighter, wizard),
+            before = snapshot(
+                totalLevel = 4,
+                classLevels = mapOf(fighter.id to 3, wizard.id to 1),
+                classDisplayName = "Fighter 3 / Wizard 1",
+            ),
+            after = snapshot(
+                totalLevel = 5,
+                classLevels = mapOf(fighter.id to 3, wizard.id to 2),
+                classDisplayName = "Fighter 3 / Wizard 2",
+            ),
+        )
+
+        // When
+        setContent(state)
+
+        // Then
+        composeTestRule.onNodeWithText("4 → 5").assertExists()
+        composeTestRule.onNodeWithText("Wizard level").assertExists()
+        composeTestRule.onNodeWithText("1 → 2").assertExists()
+        composeTestRule.onNodeWithText("Fighter 3 / Wizard 1 → Fighter 3 / Wizard 2").assertExists()
+        composeTestRule.onNodeWithText("New subclass", substring = true).assertDoesNotExist()
+    }
+
+    private fun setContent(state: CharacterLevelUpUiState.Content) {
+        composeTestRule.setContent {
+            AppTheme {
+                CharacterLevelUpScreen(
+                    state = state,
+                    dispatch = {},
+                )
+            }
+        }
+    }
+
+    private fun reviewState(
+        selectedClassId: String,
+        classes: List<CharacterClass>,
+        before: LevelUpSnapshot,
+        after: LevelUpSnapshot,
+        requirements: List<LevelUpRequirement> = emptyList(),
+        selections: LevelUpSelections = LevelUpSelections(),
+    ) = CharacterLevelUpUiState.Content(
+        characterName = "Test hero",
+        plan = LevelUpPlan(
+            expectedTotalLevel = before.totalLevel,
+            rulesetId = "srd-5e-2014-v1",
+            referenceDataVersion = "test-v1",
+            selectedClassId = selectedClassId,
+            selections = selections,
+        ),
+        preview = LevelUpPreview(
+            before = before,
+            after = after,
+            requirements = requirements,
+            validations = emptyList(),
+        ),
+        classes = classes,
+        feats = emptyList(),
+        spells = emptyList(),
+        steps = listOf(CharacterLevelUpStep.Class, CharacterLevelUpStep.Review),
+        step = CharacterLevelUpStep.Review,
+        currentStepIndex = 1,
+    )
+
+    private fun snapshot(
+        totalLevel: Int,
+        classLevels: Map<String, Int>,
+        classDisplayName: String,
+    ) = LevelUpSnapshot(
+        totalLevel = totalLevel,
+        classLevels = classLevels,
+        classDisplayName = classDisplayName,
+        proficiencyBonus = 2,
+        abilityScores = AbilityScores(),
+        maximumHitPoints = 24,
+        hitDicePools = emptyList(),
+        proficiencyIds = emptySet(),
+        savingThrowAbilityIds = emptySet(),
+        featureIds = emptySet(),
+        sharedCasterLevel = 0,
+        sharedSpellSlots = emptyMap(),
+    )
+
+    private fun characterClass(id: String, name: String) = CharacterClass(
+        id = id,
+        name = name,
+        hitDie = 10,
+        proficiencies = emptyList(),
+        proficiencyChoices = emptyList(),
+        savingThrows = emptyList(),
+        subclasses = emptyList(),
+        levels = emptyList(),
+    )
+}


### PR DESCRIPTION
Closes #158

## What changed
- add a dedicated **Class progression** section to the level-up review
- show before/after total level, selected class level, and full class-level distribution
- explicitly call out a newly selected subclass
- replace the previous generic total/class rows with the focused progression section
- add single-class and multiclass Compose UI coverage under `app/src/test` (Robolectric), with no new `androidTest` coverage

## Scope
The level-up engine and persistence behavior are unchanged. The review consumes data already present in `LevelUpPreview`, `LevelUpPlan`, and the subclass selection requirement.

## Validation
GitHub Actions CI is the authoritative validation for this project and will run on this pull request.