### PR TITLE
feat: show durability changes in level-up review

### DIFF
--- a/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpDurabilityReview.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpDurabilityReview.kt
@@ -53,7 +53,7 @@ internal fun CharacterLevelUpDurabilityReview(state: CharacterLevelUpUiState.Con
 
             val beforePools = before.hitDicePools.associate { it.dieSize to it.total }
             val afterPools = after.hitDicePools.associate { it.dieSize to it.total }
-            (beforePools.keys + afterPools.keys).sorted().forEach { dieSize ->
+            (beforePools.keys + afterPools.keys).toSet().sorted().forEach { dieSize ->
                 DurabilityReviewRow(
                     label = "d$dieSize hit dice",
                     before = beforePools[dieSize].orZero().toString(),

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpDurabilityReview.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpDurabilityReview.kt
@@ -1,0 +1,98 @@
+package com.github.arhor.spellbindr.ui.feature.character.levelup
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.github.arhor.spellbindr.domain.model.AbilityIds
+import com.github.arhor.spellbindr.domain.model.HitPointGain
+import com.github.arhor.spellbindr.domain.model.LevelUpRequirement
+
+@Composable
+internal fun CharacterLevelUpDurabilityReview(state: CharacterLevelUpUiState.Content) {
+    val before = state.preview.before
+    val after = state.preview.after
+    val hitPointRequirement = state.preview.requirements
+        .filterIsInstance<LevelUpRequirement.HitPoints>()
+        .firstOrNull()
+    val hitPointGain = hitPointRequirement?.selectedGain ?: state.plan.selections.hitPointGain
+    val constitutionModifier = after.abilityScores.modifierFor(AbilityIds.CON)
+
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = MaterialTheme.shapes.medium,
+        tonalElevation = 1.dp,
+    ) {
+        Column(
+            modifier = Modifier.padding(12.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Text("Durability", style = MaterialTheme.typography.titleSmall)
+            DurabilityReviewRow(
+                label = "Maximum HP",
+                before = before.maximumHitPoints.toString(),
+                after = after.maximumHitPoints.toString(),
+            )
+            hitPointGain?.let { gain ->
+                DurabilityValueRow(
+                    label = "New level HP",
+                    value = (gain.rolledValue + constitutionModifier).signed(),
+                )
+                DurabilityValueRow(
+                    label = "HP method",
+                    value = gain.reviewLabel(hitPointRequirement?.hitDie, constitutionModifier),
+                )
+            }
+
+            val beforePools = before.hitDicePools.associate { it.dieSize to it.total }
+            val afterPools = after.hitDicePools.associate { it.dieSize to it.total }
+            (beforePools.keys + afterPools.keys).sorted().forEach { dieSize ->
+                DurabilityReviewRow(
+                    label = "d$dieSize hit dice",
+                    before = beforePools[dieSize].orZero().toString(),
+                    after = afterPools[dieSize].orZero().toString(),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun DurabilityReviewRow(label: String, before: String, after: String) {
+    DurabilityValueRow(label, "$before → $after")
+}
+
+@Composable
+private fun DurabilityValueRow(label: String, value: String) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Text(label)
+        Text(value)
+    }
+}
+
+private fun HitPointGain.reviewLabel(hitDie: Int?, constitutionModifier: Int): String {
+    val method = when (this) {
+        is HitPointGain.Fixed -> "Fixed"
+        is HitPointGain.Rolled -> "Rolled"
+        is HitPointGain.Manual -> "Manual"
+    }
+    val base = when {
+        this is HitPointGain.Manual || hitDie == null -> rolledValue.toString()
+        else -> "$rolledValue on d$hitDie"
+    }
+    return "$method ($base) + CON ${constitutionModifier.signed()}"
+}
+
+private fun Int.signed(): String = if (this >= 0) "+$this" else toString()
+
+private fun Int?.orZero(): Int = this ?: 0

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpScreen.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpScreen.kt
@@ -260,7 +260,7 @@ private fun Content(state: CharacterLevelUpUiState.Content, dispatch: CharacterL
                 state.persistenceMessage?.let { WarningCard(it) }
                 CharacterLevelUpClassProgressionReview(state)
                 ReviewRow("Proficiency bonus", "+${state.preview.before.proficiencyBonus}", "+${state.preview.after.proficiencyBonus}")
-                ReviewRow("Maximum HP", state.preview.before.maximumHitPoints.toString(), state.preview.after.maximumHitPoints.toString())
+                CharacterLevelUpDurabilityReview(state)
                 state.preview.validations.forEach { issue ->
                     if (issue.severity == LevelUpValidationSeverity.Overrideable) {
                         val checked = issue.acknowledgementId in state.plan.selections.acknowledgedIssueCodes

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpDurabilityReviewTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpDurabilityReviewTest.kt
@@ -76,7 +76,7 @@ class CharacterLevelUpDurabilityReviewTest {
         val state = reviewState(
             selectedClassId = wizard.id,
             classes = listOf(fighter, wizard),
-            hitPointGain = HitPointGain.Rolled(7),
+            hitPointGain = HitPointGain.Rolled(5),
             hitDie = 6,
             before = snapshot(
                 totalLevel = 4,
@@ -90,7 +90,7 @@ class CharacterLevelUpDurabilityReviewTest {
                 totalLevel = 5,
                 classLevels = mapOf(fighter.id to 3, wizard.id to 2),
                 classDisplayName = "Fighter 3 / Wizard 2",
-                maximumHitPoints = 44,
+                maximumHitPoints = 42,
                 hitDicePools = listOf(LevelUpHitDicePool(6, 2), LevelUpHitDicePool(10, 3)),
                 constitution = 14,
             ),
@@ -100,8 +100,8 @@ class CharacterLevelUpDurabilityReviewTest {
         setContent(state)
 
         // Then
-        composeTestRule.onNodeWithText("+9").assertExists()
-        composeTestRule.onNodeWithText("Rolled (7 on d6) + CON +2").assertExists()
+        composeTestRule.onNodeWithText("+7").assertExists()
+        composeTestRule.onNodeWithText("Rolled (5 on d6) + CON +2").assertExists()
         composeTestRule.onNodeWithText("d6 hit dice").assertExists()
         composeTestRule.onNodeWithText("d10 hit dice").assertExists()
         assertThat(composeTestRule.onAllNodesWithText("1 → 2").fetchSemanticsNodes()).hasSize(2)

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpDurabilityReviewTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpDurabilityReviewTest.kt
@@ -1,0 +1,223 @@
+package com.github.arhor.spellbindr.ui.feature.character.levelup
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.arhor.spellbindr.domain.model.AbilityScores
+import com.github.arhor.spellbindr.domain.model.CharacterClass
+import com.github.arhor.spellbindr.domain.model.HitPointGain
+import com.github.arhor.spellbindr.domain.model.LevelUpHitDicePool
+import com.github.arhor.spellbindr.domain.model.LevelUpPlan
+import com.github.arhor.spellbindr.domain.model.LevelUpPreview
+import com.github.arhor.spellbindr.domain.model.LevelUpRequirement
+import com.github.arhor.spellbindr.domain.model.LevelUpSelections
+import com.github.arhor.spellbindr.domain.model.LevelUpSnapshot
+import com.github.arhor.spellbindr.ui.theme.AppTheme
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class CharacterLevelUpDurabilityReviewTest {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun `CharacterLevelUpScreen should show fixed HP contribution and single-class hit dice when reviewing level-up`() {
+        // Given
+        val fighter = characterClass("fighter", "Fighter", hitDie = 10)
+        val state = reviewState(
+            selectedClassId = fighter.id,
+            classes = listOf(fighter),
+            hitPointGain = HitPointGain.Fixed(6),
+            hitDie = 10,
+            before = snapshot(
+                totalLevel = 2,
+                classLevels = mapOf(fighter.id to 2),
+                classDisplayName = "Fighter 2",
+                maximumHitPoints = 20,
+                hitDicePools = listOf(LevelUpHitDicePool(10, 2)),
+                constitution = 14,
+            ),
+            after = snapshot(
+                totalLevel = 3,
+                classLevels = mapOf(fighter.id to 3),
+                classDisplayName = "Fighter 3",
+                maximumHitPoints = 28,
+                hitDicePools = listOf(LevelUpHitDicePool(10, 3)),
+                constitution = 14,
+            ),
+        )
+
+        // When
+        setContent(state)
+
+        // Then
+        composeTestRule.onNodeWithText("Durability").assertExists()
+        composeTestRule.onNodeWithText("Maximum HP").assertExists()
+        composeTestRule.onNodeWithText("20 → 28").assertExists()
+        composeTestRule.onNodeWithText("New level HP").assertExists()
+        composeTestRule.onNodeWithText("+8").assertExists()
+        composeTestRule.onNodeWithText("HP method").assertExists()
+        composeTestRule.onNodeWithText("Fixed (6 on d10) + CON +2").assertExists()
+        composeTestRule.onNodeWithText("d10 hit dice").assertExists()
+        assertThat(composeTestRule.onAllNodesWithText("2 → 3").fetchSemanticsNodes()).hasSize(3)
+    }
+
+    @Test
+    fun `CharacterLevelUpScreen should show rolled HP and all hit-die pools when reviewing multiclass level-up`() {
+        // Given
+        val fighter = characterClass("fighter", "Fighter", hitDie = 10)
+        val wizard = characterClass("wizard", "Wizard", hitDie = 6)
+        val state = reviewState(
+            selectedClassId = wizard.id,
+            classes = listOf(fighter, wizard),
+            hitPointGain = HitPointGain.Rolled(7),
+            hitDie = 6,
+            before = snapshot(
+                totalLevel = 4,
+                classLevels = mapOf(fighter.id to 3, wizard.id to 1),
+                classDisplayName = "Fighter 3 / Wizard 1",
+                maximumHitPoints = 35,
+                hitDicePools = listOf(LevelUpHitDicePool(6, 1), LevelUpHitDicePool(10, 3)),
+                constitution = 14,
+            ),
+            after = snapshot(
+                totalLevel = 5,
+                classLevels = mapOf(fighter.id to 3, wizard.id to 2),
+                classDisplayName = "Fighter 3 / Wizard 2",
+                maximumHitPoints = 44,
+                hitDicePools = listOf(LevelUpHitDicePool(6, 2), LevelUpHitDicePool(10, 3)),
+                constitution = 14,
+            ),
+        )
+
+        // When
+        setContent(state)
+
+        // Then
+        composeTestRule.onNodeWithText("+9").assertExists()
+        composeTestRule.onNodeWithText("Rolled (7 on d6) + CON +2").assertExists()
+        composeTestRule.onNodeWithText("d6 hit dice").assertExists()
+        composeTestRule.onNodeWithText("d10 hit dice").assertExists()
+        assertThat(composeTestRule.onAllNodesWithText("1 → 2").fetchSemanticsNodes()).hasSize(2)
+        composeTestRule.onNodeWithText("3 → 3").assertExists()
+    }
+
+    @Test
+    fun `CharacterLevelUpScreen should label manual HP method when reviewing level-up`() {
+        // Given
+        val rogue = characterClass("rogue", "Rogue", hitDie = 8)
+        val state = reviewState(
+            selectedClassId = rogue.id,
+            classes = listOf(rogue),
+            hitPointGain = HitPointGain.Manual(9),
+            hitDie = 8,
+            before = snapshot(
+                totalLevel = 3,
+                classLevels = mapOf(rogue.id to 3),
+                classDisplayName = "Rogue 3",
+                maximumHitPoints = 30,
+                hitDicePools = listOf(LevelUpHitDicePool(8, 3)),
+                constitution = 12,
+            ),
+            after = snapshot(
+                totalLevel = 4,
+                classLevels = mapOf(rogue.id to 4),
+                classDisplayName = "Rogue 4",
+                maximumHitPoints = 40,
+                hitDicePools = listOf(LevelUpHitDicePool(8, 4)),
+                constitution = 12,
+            ),
+        )
+
+        // When
+        setContent(state)
+
+        // Then
+        composeTestRule.onNodeWithText("+10").assertExists()
+        composeTestRule.onNodeWithText("Manual (9) + CON +1").assertExists()
+    }
+
+    private fun setContent(state: CharacterLevelUpUiState.Content) {
+        composeTestRule.setContent {
+            AppTheme {
+                CharacterLevelUpScreen(
+                    state = state,
+                    dispatch = {},
+                )
+            }
+        }
+    }
+
+    private fun reviewState(
+        selectedClassId: String,
+        classes: List<CharacterClass>,
+        hitPointGain: HitPointGain,
+        hitDie: Int,
+        before: LevelUpSnapshot,
+        after: LevelUpSnapshot,
+    ) = CharacterLevelUpUiState.Content(
+        characterName = "Test hero",
+        plan = LevelUpPlan(
+            expectedTotalLevel = before.totalLevel,
+            rulesetId = "srd-5e-2014-v1",
+            referenceDataVersion = "test-v1",
+            selectedClassId = selectedClassId,
+            selections = LevelUpSelections(hitPointGain = hitPointGain),
+        ),
+        preview = LevelUpPreview(
+            before = before,
+            after = after,
+            requirements = listOf(LevelUpRequirement.HitPoints(
+                hitDie = hitDie,
+                fixedGain = hitDie / 2 + 1,
+                selectedGain = hitPointGain,
+            )),
+            validations = emptyList(),
+        ),
+        classes = classes,
+        feats = emptyList(),
+        spells = emptyList(),
+        steps = listOf(CharacterLevelUpStep.HitPoints, CharacterLevelUpStep.Review),
+        step = CharacterLevelUpStep.Review,
+        currentStepIndex = 1,
+    )
+
+    private fun snapshot(
+        totalLevel: Int,
+        classLevels: Map<String, Int>,
+        classDisplayName: String,
+        maximumHitPoints: Int,
+        hitDicePools: List<LevelUpHitDicePool>,
+        constitution: Int,
+    ) = LevelUpSnapshot(
+        totalLevel = totalLevel,
+        classLevels = classLevels,
+        classDisplayName = classDisplayName,
+        proficiencyBonus = 2,
+        abilityScores = AbilityScores(constitution = constitution),
+        maximumHitPoints = maximumHitPoints,
+        hitDicePools = hitDicePools,
+        proficiencyIds = emptySet(),
+        savingThrowAbilityIds = emptySet(),
+        featureIds = emptySet(),
+        sharedCasterLevel = 0,
+        sharedSpellSlots = emptyMap(),
+    )
+
+    private fun characterClass(id: String, name: String, hitDie: Int) = CharacterClass(
+        id = id,
+        name = name,
+        hitDie = hitDie,
+        proficiencies = emptyList(),
+        proficiencyChoices = emptyList(),
+        savingThrows = emptyList(),
+        subclasses = emptyList(),
+        levels = emptyList(),
+    )
+}


### PR DESCRIPTION
Closes #159

## What changed

- add a dedicated **Durability** section to the level-up review
- show maximum HP before/after and the new level's HP contribution
- show the selected fixed, rolled, or manual HP method together with the Constitution modifier used for the new level
- show every hit-die pool by die size, including unchanged pools in multiclass progressions
- replace the previous standalone maximum-HP review row
- add focused Compose/Robolectric coverage under `app/src/test` for fixed, rolled, and manual HP plus single-class and multiclass hit-die pools

## Scope

This is review-only. `LevelUpProgressionEngine`, persistence, and materialization behavior are unchanged; the UI consumes the existing `LevelUpPreview` snapshots and HP requirement/selection data.

## Validation

GitHub Actions is the authoritative validation for this branch.