### PR TITLE
feat: add informational level-up guidance

### DIFF
--- a/app/src/main/kotlin/com/github/arhor/spellbindr/domain/model/LevelUpPlan.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/domain/model/LevelUpPlan.kt
@@ -34,6 +34,7 @@ data class LevelUpSelections(
 enum class LevelUpValidationSeverity {
     Blocking,
     Overrideable,
+    Informational,
 }
 
 @Serializable

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpScreen.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpScreen.kt
@@ -262,22 +262,26 @@ private fun Content(state: CharacterLevelUpUiState.Content, dispatch: CharacterL
                 ReviewRow("Proficiency bonus", "+${state.preview.before.proficiencyBonus}", "+${state.preview.after.proficiencyBonus}")
                 CharacterLevelUpDurabilityReview(state)
                 state.preview.validations.forEach { issue ->
-                    if (issue.severity == LevelUpValidationSeverity.Overrideable) {
-                        val checked = issue.acknowledgementId in state.plan.selections.acknowledgedIssueCodes
-                        Row(verticalAlignment = Alignment.CenterVertically) {
-                            Checkbox(
-                                checked = checked,
-                                enabled = !state.isSaving,
-                                onCheckedChange = {
-                                    dispatch(CharacterLevelUpIntent.AcknowledgementChanged(
-                                        issue.acknowledgementId,
-                                        it,
-                                    ))
-                                },
-                            )
-                            Text(issue.message)
+                    when (issue.severity) {
+                        LevelUpValidationSeverity.Blocking -> WarningCard(issue.message)
+                        LevelUpValidationSeverity.Overrideable -> {
+                            val checked = issue.acknowledgementId in state.plan.selections.acknowledgedIssueCodes
+                            Row(verticalAlignment = Alignment.CenterVertically) {
+                                Checkbox(
+                                    checked = checked,
+                                    enabled = !state.isSaving,
+                                    onCheckedChange = {
+                                        dispatch(CharacterLevelUpIntent.AcknowledgementChanged(
+                                            issue.acknowledgementId,
+                                            it,
+                                        ))
+                                    },
+                                )
+                                Text(issue.message)
+                            }
                         }
-                    } else WarningCard(issue.message)
+                        LevelUpValidationSeverity.Informational -> InformationalCard(issue.message)
+                    }
                 }
             }
         }
@@ -518,6 +522,7 @@ private fun SpellChanges.toggleFeatureGrant(
 @Composable private fun ChoiceRow(label: String, selected: Boolean, onClick: () -> Unit) = Surface(onClick = onClick, modifier = Modifier.fillMaxWidth(), shape = MaterialTheme.shapes.medium) { Row(Modifier.padding(12.dp), verticalAlignment = Alignment.CenterVertically) { RadioButton(selected, onClick = onClick); Text(label) } }
 @Composable private fun SectionTitle(text: String) = Text(text, style = MaterialTheme.typography.titleSmall)
 @Composable private fun WarningCard(text: String) = Surface(color = MaterialTheme.colorScheme.errorContainer, shape = MaterialTheme.shapes.medium) { Text(text, Modifier.fillMaxWidth().padding(12.dp), color = MaterialTheme.colorScheme.onErrorContainer) }
+@Composable private fun InformationalCard(text: String) = Surface(color = MaterialTheme.colorScheme.surfaceVariant, shape = MaterialTheme.shapes.medium) { Text(text, Modifier.fillMaxWidth().padding(12.dp), color = MaterialTheme.colorScheme.onSurfaceVariant) }
 @Composable private fun ReviewRow(label: String, before: String, after: String) = Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) { Text(label); Text("$before → $after") }
 @Composable private fun MessagePane(text: String, modifier: Modifier) = Box(modifier.fillMaxSize().padding(32.dp), contentAlignment = Alignment.Center) { Text(text) }
 

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpUiState.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpUiState.kt
@@ -13,6 +13,8 @@ import com.github.arhor.spellbindr.domain.model.LevelUpPlan
 import com.github.arhor.spellbindr.domain.model.LevelUpPreview
 import com.github.arhor.spellbindr.domain.model.LevelUpRequirement
 import com.github.arhor.spellbindr.domain.model.LevelUpValidationCode
+import com.github.arhor.spellbindr.domain.model.LevelUpValidationIssue
+import com.github.arhor.spellbindr.domain.model.LevelUpValidationSeverity
 import com.github.arhor.spellbindr.domain.model.Spell
 import kotlinx.serialization.Serializable
 
@@ -64,6 +66,12 @@ sealed interface CharacterLevelUpUiState {
         val isReview: Boolean get() = step == CharacterLevelUpStep.Review
         val canConfirm: Boolean get() = isReview && preview.canConfirm && !isSaving
         val canAdvance: Boolean get() = !isSaving && canAdvanceFromCurrentStep()
+        val blockingIssues: List<LevelUpValidationIssue>
+            get() = preview.validations.filter { it.severity == LevelUpValidationSeverity.Blocking }
+        val overrideableIssues: List<LevelUpValidationIssue>
+            get() = preview.validations.filter { it.severity == LevelUpValidationSeverity.Overrideable }
+        val informationalIssues: List<LevelUpValidationIssue>
+            get() = preview.validations.filter { it.severity == LevelUpValidationSeverity.Informational }
 
         private fun canAdvanceFromCurrentStep(): Boolean = when (step) {
             CharacterLevelUpStep.Class -> preview.requirements
@@ -92,7 +100,7 @@ sealed interface CharacterLevelUpUiState {
                 .filterIsInstance<LevelUpRequirement.SpellDecisions>()
                 .singleOrNull()
                 ?.isComplete() == true &&
-                preview.validations.none { it.code == LevelUpValidationCode.SpellPolicy }
+                !hasBlockingValidation(LevelUpValidationCode.SpellPolicy)
             CharacterLevelUpStep.Review -> false
         }
 
@@ -108,7 +116,12 @@ sealed interface CharacterLevelUpUiState {
                 LevelUpValidationCode.ChoiceRequired,
                 LevelUpValidationCode.InvalidChoice,
             )
-            if (preview.validations.any { it.code in abilityIssueCodes }) return false
+            if (preview.validations.any {
+                    it.severity == LevelUpValidationSeverity.Blocking && it.code in abilityIssueCodes
+                }
+            ) {
+                return false
+            }
             val requirement = preview.requirements
                 .filterIsInstance<LevelUpRequirement.AbilityScoreImprovement>()
                 .singleOrNull() ?: return false
@@ -131,6 +144,11 @@ sealed interface CharacterLevelUpUiState {
                 null -> false
             }
         }
+
+        private fun hasBlockingValidation(code: LevelUpValidationCode): Boolean =
+            preview.validations.any {
+                it.severity == LevelUpValidationSeverity.Blocking && it.code == code
+            }
     }
 }
 

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/domain/usecase/LevelUpValidationSeverityTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/domain/usecase/LevelUpValidationSeverityTest.kt
@@ -1,0 +1,142 @@
+package com.github.arhor.spellbindr.domain.usecase
+
+import com.github.arhor.spellbindr.domain.model.AbilityScores
+import com.github.arhor.spellbindr.domain.model.CharacterClass
+import com.github.arhor.spellbindr.domain.model.CharacterProgression
+import com.github.arhor.spellbindr.domain.model.HitPointGain
+import com.github.arhor.spellbindr.domain.model.LevelUpPlan
+import com.github.arhor.spellbindr.domain.model.LevelUpPreview
+import com.github.arhor.spellbindr.domain.model.LevelUpReferenceData
+import com.github.arhor.spellbindr.domain.model.LevelUpRequirement
+import com.github.arhor.spellbindr.domain.model.LevelUpSelections
+import com.github.arhor.spellbindr.domain.model.LevelUpSnapshot
+import com.github.arhor.spellbindr.domain.model.LevelUpValidationCode
+import com.github.arhor.spellbindr.domain.model.LevelUpValidationIssue
+import com.github.arhor.spellbindr.domain.model.LevelUpValidationSeverity
+import com.github.arhor.spellbindr.domain.model.ProgressionOrigin
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class LevelUpValidationSeverityTest {
+
+    @Test
+    fun `informational validation should not block confirmation or require acknowledgement`() {
+        val guidance = validation(
+            code = LevelUpValidationCode.ExperienceThreshold,
+            severity = LevelUpValidationSeverity.Informational,
+        )
+
+        val preview = preview(validations = listOf(guidance))
+
+        assertThat(preview.canConfirm).isTrue()
+        assertThat(preview.requirements.filterIsInstance<LevelUpRequirement.Acknowledgement>()).isEmpty()
+    }
+
+    @Test
+    fun `informational validation should coexist with blocking and overrideable findings`() {
+        val guidance = validation(
+            code = LevelUpValidationCode.ExperienceThreshold,
+            severity = LevelUpValidationSeverity.Informational,
+        )
+        val overrideable = validation(
+            code = LevelUpValidationCode.MulticlassPrerequisite,
+            severity = LevelUpValidationSeverity.Overrideable,
+        )
+        val blocking = validation(
+            code = LevelUpValidationCode.ChoiceRequired,
+            severity = LevelUpValidationSeverity.Blocking,
+        )
+        val acknowledgedWarning = LevelUpRequirement.Acknowledgement(
+            id = overrideable.acknowledgementId,
+            issue = overrideable,
+            acknowledged = true,
+        )
+
+        assertThat(preview(listOf(guidance, overrideable), listOf(acknowledgedWarning)).canConfirm).isTrue()
+        assertThat(preview(listOf(guidance, blocking, overrideable), listOf(acknowledgedWarning)).canConfirm).isFalse()
+    }
+
+    @Test
+    fun `recordFor should persist acknowledgements for overrideable findings only`() {
+        val guidance = validation(
+            code = LevelUpValidationCode.ExperienceThreshold,
+            severity = LevelUpValidationSeverity.Informational,
+        )
+        val overrideable = validation(
+            code = LevelUpValidationCode.MulticlassPrerequisite,
+            severity = LevelUpValidationSeverity.Overrideable,
+        )
+        val clazz = characterClass()
+        val progression = CharacterProgression(
+            referenceDataVersion = "test-v1",
+            origin = ProgressionOrigin.Guided,
+            levels = emptyList(),
+        )
+        val plan = LevelUpPlan(
+            expectedTotalLevel = 0,
+            rulesetId = CharacterProgression.SUPPORTED_RULESET_ID,
+            referenceDataVersion = "test-v1",
+            selectedClassId = clazz.id,
+            selections = LevelUpSelections(hitPointGain = HitPointGain.Fixed(clazz.hitDie)),
+        )
+
+        val record = LevelUpProgressionEngine.recordFor(
+            plan = plan,
+            clazz = clazz,
+            classLevel = 1,
+            progression = progression,
+            referenceData = LevelUpReferenceData(
+                classes = listOf(clazz),
+                features = emptyList(),
+                referenceDataVersion = "test-v1",
+            ),
+            validations = listOf(guidance, overrideable),
+        )
+
+        assertThat(record.ruleAcknowledgements).containsExactly(overrideable.acknowledgementId)
+    }
+
+    private fun validation(
+        code: LevelUpValidationCode,
+        severity: LevelUpValidationSeverity,
+    ) = LevelUpValidationIssue(code, "${severity.name} finding", severity)
+
+    private fun preview(
+        validations: List<LevelUpValidationIssue>,
+        requirements: List<LevelUpRequirement> = emptyList(),
+    ): LevelUpPreview {
+        val snapshot = snapshot()
+        return LevelUpPreview(
+            before = snapshot,
+            after = snapshot.copy(totalLevel = snapshot.totalLevel + 1),
+            requirements = requirements,
+            validations = validations,
+        )
+    }
+
+    private fun snapshot() = LevelUpSnapshot(
+        totalLevel = 1,
+        classLevels = mapOf("fighter" to 1),
+        classDisplayName = "Fighter 1",
+        proficiencyBonus = 2,
+        abilityScores = AbilityScores(),
+        maximumHitPoints = 10,
+        hitDicePools = emptyList(),
+        proficiencyIds = emptySet(),
+        savingThrowAbilityIds = emptySet(),
+        featureIds = emptySet(),
+        sharedCasterLevel = 0,
+        sharedSpellSlots = emptyMap(),
+    )
+
+    private fun characterClass() = CharacterClass(
+        id = "fighter",
+        name = "Fighter",
+        hitDie = 10,
+        proficiencies = emptyList(),
+        proficiencyChoices = emptyList(),
+        savingThrows = emptyList(),
+        subclasses = emptyList(),
+        levels = emptyList(),
+    )
+}

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/domain/usecase/LevelUpValidationSeverityTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/domain/usecase/LevelUpValidationSeverityTest.kt
@@ -77,7 +77,13 @@ class LevelUpValidationSeverityTest {
             rulesetId = CharacterProgression.SUPPORTED_RULESET_ID,
             referenceDataVersion = "test-v1",
             selectedClassId = clazz.id,
-            selections = LevelUpSelections(hitPointGain = HitPointGain.Fixed(clazz.hitDie)),
+            selections = LevelUpSelections(
+                hitPointGain = HitPointGain.Fixed(clazz.hitDie),
+                acknowledgedIssueCodes = setOf(
+                    guidance.acknowledgementId,
+                    overrideable.acknowledgementId,
+                ),
+            ),
         )
 
         val record = LevelUpProgressionEngine.recordFor(

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpGuidanceScreenTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpGuidanceScreenTest.kt
@@ -4,7 +4,6 @@ import androidx.activity.ComponentActivity
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.isToggleable
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
-import androidx.compose.ui.test.onAllNodes
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.github.arhor.spellbindr.domain.model.AbilityScores

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpGuidanceScreenTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpGuidanceScreenTest.kt
@@ -1,0 +1,137 @@
+package com.github.arhor.spellbindr.ui.feature.character.levelup
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.isToggleable
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodes
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.arhor.spellbindr.domain.model.AbilityScores
+import com.github.arhor.spellbindr.domain.model.LevelUpPlan
+import com.github.arhor.spellbindr.domain.model.LevelUpPreview
+import com.github.arhor.spellbindr.domain.model.LevelUpRequirement
+import com.github.arhor.spellbindr.domain.model.LevelUpSnapshot
+import com.github.arhor.spellbindr.domain.model.LevelUpValidationCode
+import com.github.arhor.spellbindr.domain.model.LevelUpValidationIssue
+import com.github.arhor.spellbindr.domain.model.LevelUpValidationSeverity
+import com.github.arhor.spellbindr.ui.theme.AppTheme
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class CharacterLevelUpGuidanceScreenTest {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun `informational guidance should render without acknowledgement and keep confirmation enabled`() {
+        val guidance = issue(
+            code = LevelUpValidationCode.ExperienceThreshold,
+            message = "You can review the experience threshold before confirming.",
+            severity = LevelUpValidationSeverity.Informational,
+        )
+
+        setContent(reviewState(validations = listOf(guidance)))
+
+        composeTestRule.onNodeWithText(guidance.message).assertExists()
+        composeTestRule.onNodeWithText("Confirm level up").assertIsEnabled()
+        assertThat(composeTestRule.onAllNodes(isToggleable()).fetchSemanticsNodes()).isEmpty()
+    }
+
+    @Test
+    fun `informational guidance should coexist with blocking and overrideable findings`() {
+        val guidance = issue(
+            code = LevelUpValidationCode.ExperienceThreshold,
+            message = "Informational guidance.",
+            severity = LevelUpValidationSeverity.Informational,
+        )
+        val warning = issue(
+            code = LevelUpValidationCode.MulticlassPrerequisite,
+            message = "Overrideable warning.",
+            severity = LevelUpValidationSeverity.Overrideable,
+        )
+        val blocking = issue(
+            code = LevelUpValidationCode.ChoiceRequired,
+            message = "Blocking error.",
+            severity = LevelUpValidationSeverity.Blocking,
+        )
+        val acknowledgement = LevelUpRequirement.Acknowledgement(
+            id = warning.acknowledgementId,
+            issue = warning,
+            acknowledged = false,
+        )
+
+        setContent(
+            reviewState(
+                validations = listOf(guidance, warning, blocking),
+                requirements = listOf(acknowledgement),
+            ),
+        )
+
+        composeTestRule.onNodeWithText(guidance.message).assertExists()
+        composeTestRule.onNodeWithText(warning.message).assertExists()
+        composeTestRule.onNodeWithText(blocking.message).assertExists()
+        assertThat(composeTestRule.onAllNodes(isToggleable()).fetchSemanticsNodes()).hasSize(1)
+    }
+
+    private fun setContent(state: CharacterLevelUpUiState.Content) {
+        composeTestRule.setContent {
+            AppTheme {
+                CharacterLevelUpScreen(state = state, dispatch = {})
+            }
+        }
+    }
+
+    private fun reviewState(
+        validations: List<LevelUpValidationIssue>,
+        requirements: List<LevelUpRequirement> = emptyList(),
+    ): CharacterLevelUpUiState.Content {
+        val before = snapshot()
+        return CharacterLevelUpUiState.Content(
+            characterName = "Test hero",
+            plan = LevelUpPlan(
+                expectedTotalLevel = before.totalLevel,
+                rulesetId = "srd-5e-2014-v1",
+                referenceDataVersion = "test-v1",
+                selectedClassId = "fighter",
+            ),
+            preview = LevelUpPreview(
+                before = before,
+                after = before.copy(totalLevel = before.totalLevel + 1),
+                requirements = requirements,
+                validations = validations,
+            ),
+            classes = emptyList(),
+            feats = emptyList(),
+            spells = emptyList(),
+            steps = listOf(CharacterLevelUpStep.Class, CharacterLevelUpStep.Review),
+            step = CharacterLevelUpStep.Review,
+            currentStepIndex = 1,
+        )
+    }
+
+    private fun issue(
+        code: LevelUpValidationCode,
+        message: String,
+        severity: LevelUpValidationSeverity,
+    ) = LevelUpValidationIssue(code, message, severity)
+
+    private fun snapshot() = LevelUpSnapshot(
+        totalLevel = 3,
+        classLevels = mapOf("fighter" to 3),
+        classDisplayName = "Fighter 3",
+        proficiencyBonus = 2,
+        abilityScores = AbilityScores(),
+        maximumHitPoints = 24,
+        hitDicePools = emptyList(),
+        proficiencyIds = emptySet(),
+        savingThrowAbilityIds = emptySet(),
+        featureIds = emptySet(),
+        sharedCasterLevel = 0,
+        sharedSpellSlots = emptyMap(),
+    )
+}

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpGuidanceViewModelTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpGuidanceViewModelTest.kt
@@ -1,0 +1,172 @@
+package com.github.arhor.spellbindr.ui.feature.character.levelup
+
+import androidx.lifecycle.SavedStateHandle
+import com.github.arhor.spellbindr.MainDispatcherRule
+import com.github.arhor.spellbindr.domain.model.AbilityScores
+import com.github.arhor.spellbindr.domain.model.CharacterClass
+import com.github.arhor.spellbindr.domain.model.CharacterLevelRecord
+import com.github.arhor.spellbindr.domain.model.CharacterProgression
+import com.github.arhor.spellbindr.domain.model.CharacterSheet
+import com.github.arhor.spellbindr.domain.model.CharacterWithProgression
+import com.github.arhor.spellbindr.domain.model.HitPointGain
+import com.github.arhor.spellbindr.domain.model.LevelUpPlan
+import com.github.arhor.spellbindr.domain.model.LevelUpPreview
+import com.github.arhor.spellbindr.domain.model.LevelUpReferenceRules
+import com.github.arhor.spellbindr.domain.model.LevelUpRequirement
+import com.github.arhor.spellbindr.domain.model.LevelUpSnapshot
+import com.github.arhor.spellbindr.domain.model.LevelUpValidationCode
+import com.github.arhor.spellbindr.domain.model.LevelUpValidationIssue
+import com.github.arhor.spellbindr.domain.model.LevelUpValidationSeverity
+import com.github.arhor.spellbindr.domain.model.Loadable
+import com.github.arhor.spellbindr.domain.model.ProgressionOrigin
+import com.github.arhor.spellbindr.domain.model.ProgressionState
+import com.github.arhor.spellbindr.domain.usecase.ApplyLevelUpUseCase
+import com.github.arhor.spellbindr.domain.usecase.CreateLevelUpPlanUseCase
+import com.github.arhor.spellbindr.domain.usecase.LoadCharacterWithProgressionUseCase
+import com.github.arhor.spellbindr.domain.usecase.ObserveAllCharacterClassesUseCase
+import com.github.arhor.spellbindr.domain.usecase.ObserveAllFeatsUseCase
+import com.github.arhor.spellbindr.domain.usecase.ObserveAllFeaturesUseCase
+import com.github.arhor.spellbindr.domain.usecase.ObserveAllLanguagesUseCase
+import com.github.arhor.spellbindr.domain.usecase.ObserveAllSpellsUseCase
+import com.github.arhor.spellbindr.domain.usecase.RebuildLevelUpPlanUseCase
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+
+class CharacterLevelUpGuidanceViewModelTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    @Test
+    fun `uiState should propagate informational findings from rebuilt preview`() =
+        runTest(mainDispatcherRule.dispatcher) {
+            val loadCharacter = mockk<LoadCharacterWithProgressionUseCase>()
+            val observeClasses = mockk<ObserveAllCharacterClassesUseCase>()
+            val observeFeatures = mockk<ObserveAllFeaturesUseCase>()
+            val observeFeats = mockk<ObserveAllFeatsUseCase>()
+            val observeSpells = mockk<ObserveAllSpellsUseCase>()
+            val observeLanguages = mockk<ObserveAllLanguagesUseCase>()
+            val createPlan = mockk<CreateLevelUpPlanUseCase>()
+            val rebuildPlan = mockk<RebuildLevelUpPlanUseCase>()
+            val applyLevelUp = mockk<ApplyLevelUpUseCase>()
+            val progression = progression()
+            val plan = LevelUpPlan(
+                expectedTotalLevel = progression.totalLevel,
+                rulesetId = progression.rulesetId,
+                referenceDataVersion = progression.referenceDataVersion,
+                selectedClassId = "fighter",
+            )
+            val guidance = LevelUpValidationIssue(
+                code = LevelUpValidationCode.ExperienceThreshold,
+                message = "Guidance from the progression engine.",
+                severity = LevelUpValidationSeverity.Informational,
+            )
+            val classSelection = LevelUpRequirement.ClassSelection(
+                eligibleClassIds = listOf("fighter"),
+                selectedClassId = "fighter",
+            )
+
+            every { loadCharacter(CHARACTER_ID) } returns flowOf(
+                CharacterWithProgression(
+                    sheet = CharacterSheet(id = CHARACTER_ID, name = "Mira", level = progression.totalLevel),
+                    progressionState = ProgressionState.Managed(progression),
+                ),
+            )
+            every { observeClasses() } returns flowOf(Loadable.Content(listOf(characterClass())))
+            every { observeFeatures() } returns flowOf(Loadable.Content(emptyList()))
+            every { observeFeats() } returns flowOf(Loadable.Content(emptyList()))
+            every { observeSpells() } returns flowOf(Loadable.Content(emptyList()))
+            every { observeLanguages() } returns flowOf(Loadable.Content(emptyList()))
+            every { createPlan(any()) } returns plan
+            every { rebuildPlan(any(), any(), any(), any()) } returns preview(
+                plan = plan,
+                requirements = listOf(classSelection),
+                validations = listOf(guidance),
+            )
+
+            val viewModel = CharacterLevelUpViewModel(
+                loadCharacter = loadCharacter,
+                observeClasses = observeClasses,
+                observeFeatures = observeFeatures,
+                observeFeats = observeFeats,
+                observeSpells = observeSpells,
+                observeLanguages = observeLanguages,
+                createPlan = createPlan,
+                rebuildPlan = rebuildPlan,
+                applyLevelUp = applyLevelUp,
+                savedStateHandle = SavedStateHandle(mapOf("characterId" to CHARACTER_ID)),
+            )
+            val collector = launch { viewModel.uiState.collect { } }
+            advanceUntilIdle()
+
+            val content = viewModel.uiState.value as CharacterLevelUpUiState.Content
+            assertThat(content.preview.validations).containsExactly(guidance)
+            assertThat(content.informationalIssues).containsExactly(guidance)
+            assertThat(content.blockingIssues).isEmpty()
+            assertThat(content.overrideableIssues).isEmpty()
+
+            collector.cancel()
+        }
+
+    private fun progression() = CharacterProgression(
+        referenceDataVersion = LevelUpReferenceRules.referenceDataVersion,
+        origin = ProgressionOrigin.Guided,
+        levels = listOf(
+            CharacterLevelRecord(
+                characterLevel = 1,
+                classId = "fighter",
+                classLevel = 1,
+                hitPointGain = HitPointGain.Fixed(10),
+            ),
+        ),
+    )
+
+    private fun characterClass() = CharacterClass(
+        id = "fighter",
+        name = "Fighter",
+        hitDie = 10,
+        proficiencies = emptyList(),
+        proficiencyChoices = emptyList(),
+        savingThrows = emptyList(),
+        subclasses = emptyList(),
+        levels = emptyList(),
+    )
+
+    private fun preview(
+        plan: LevelUpPlan,
+        requirements: List<LevelUpRequirement>,
+        validations: List<LevelUpValidationIssue>,
+    ): LevelUpPreview {
+        val before = LevelUpSnapshot(
+            totalLevel = plan.expectedTotalLevel,
+            classLevels = mapOf("fighter" to plan.expectedTotalLevel),
+            classDisplayName = "Fighter ${plan.expectedTotalLevel}",
+            proficiencyBonus = 2,
+            abilityScores = AbilityScores(),
+            maximumHitPoints = 10,
+            hitDicePools = emptyList(),
+            proficiencyIds = emptySet(),
+            savingThrowAbilityIds = emptySet(),
+            featureIds = emptySet(),
+            sharedCasterLevel = 0,
+            sharedSpellSlots = emptyMap(),
+        )
+        return LevelUpPreview(
+            before = before,
+            after = before.copy(totalLevel = before.totalLevel + 1),
+            requirements = requirements,
+            validations = validations,
+        )
+    }
+
+    private companion object {
+        const val CHARACTER_ID = "character-1"
+    }
+}

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpValidationStateTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpValidationStateTest.kt
@@ -1,0 +1,144 @@
+package com.github.arhor.spellbindr.ui.feature.character.levelup
+
+import com.github.arhor.spellbindr.domain.model.AbilityIds
+import com.github.arhor.spellbindr.domain.model.AbilityScoreDecision
+import com.github.arhor.spellbindr.domain.model.AbilityScores
+import com.github.arhor.spellbindr.domain.model.LevelUpPlan
+import com.github.arhor.spellbindr.domain.model.LevelUpPreview
+import com.github.arhor.spellbindr.domain.model.LevelUpRequirement
+import com.github.arhor.spellbindr.domain.model.LevelUpSelections
+import com.github.arhor.spellbindr.domain.model.LevelUpSnapshot
+import com.github.arhor.spellbindr.domain.model.LevelUpValidationCode
+import com.github.arhor.spellbindr.domain.model.LevelUpValidationIssue
+import com.github.arhor.spellbindr.domain.model.LevelUpValidationSeverity
+import com.github.arhor.spellbindr.domain.model.SpellChanges
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class CharacterLevelUpValidationStateTest {
+
+    @Test
+    fun `informational spell policy finding should not disable next`() {
+        val requirement = LevelUpRequirement.SpellDecisions(
+            id = "bard:2:spells",
+            classId = "bard",
+            classLevel = 2,
+            policyId = "known",
+            changes = SpellChanges(),
+        )
+        val guidance = validation(
+            code = LevelUpValidationCode.SpellPolicy,
+            severity = LevelUpValidationSeverity.Informational,
+        )
+
+        val state = content(
+            step = CharacterLevelUpStep.Spells,
+            requirements = listOf(requirement),
+            validations = listOf(guidance),
+        )
+
+        assertThat(state.canAdvance).isTrue()
+        assertThat(state.informationalIssues).containsExactly(guidance)
+    }
+
+    @Test
+    fun `blocking spell policy finding should continue to disable next`() {
+        val requirement = LevelUpRequirement.SpellDecisions(
+            id = "bard:2:spells",
+            classId = "bard",
+            classLevel = 2,
+            policyId = "known",
+            changes = SpellChanges(),
+        )
+        val blocking = validation(
+            code = LevelUpValidationCode.SpellPolicy,
+            severity = LevelUpValidationSeverity.Blocking,
+        )
+
+        val state = content(
+            step = CharacterLevelUpStep.Spells,
+            requirements = listOf(requirement),
+            validations = listOf(blocking),
+        )
+
+        assertThat(state.canAdvance).isFalse()
+        assertThat(state.blockingIssues).containsExactly(blocking)
+    }
+
+    @Test
+    fun `informational ability finding should not disable a complete ability decision`() {
+        val decision = AbilityScoreDecision.Increase(mapOf(AbilityIds.STR to 2))
+        val requirement = LevelUpRequirement.AbilityScoreImprovement(
+            id = "fighter:4:asi",
+            classId = "fighter",
+            abilityPoints = 2,
+            maximumAbilityScore = 20,
+            allowsFeat = true,
+            selectedDecision = decision,
+        )
+        val guidance = validation(
+            code = LevelUpValidationCode.AbilityScoreDecisionRequired,
+            severity = LevelUpValidationSeverity.Informational,
+        )
+
+        val state = content(
+            step = CharacterLevelUpStep.AbilityScore,
+            requirements = listOf(requirement),
+            validations = listOf(guidance),
+            selections = LevelUpSelections(abilityScoreDecision = decision),
+        )
+
+        assertThat(state.canAdvance).isTrue()
+    }
+
+    private fun validation(
+        code: LevelUpValidationCode,
+        severity: LevelUpValidationSeverity,
+    ) = LevelUpValidationIssue(code, "${severity.name} finding", severity)
+
+    private fun content(
+        step: CharacterLevelUpStep,
+        requirements: List<LevelUpRequirement>,
+        validations: List<LevelUpValidationIssue>,
+        selections: LevelUpSelections = LevelUpSelections(),
+    ): CharacterLevelUpUiState.Content {
+        val before = snapshot()
+        return CharacterLevelUpUiState.Content(
+            characterName = "Test hero",
+            plan = LevelUpPlan(
+                expectedTotalLevel = before.totalLevel,
+                rulesetId = "srd-5e-2014-v1",
+                referenceDataVersion = "test-v1",
+                selectedClassId = "fighter",
+                selections = selections,
+            ),
+            preview = LevelUpPreview(
+                before = before,
+                after = before.copy(totalLevel = before.totalLevel + 1),
+                requirements = requirements,
+                validations = validations,
+            ),
+            classes = emptyList(),
+            feats = emptyList(),
+            spells = emptyList(),
+            steps = listOf(step, CharacterLevelUpStep.Review),
+            step = step,
+            currentStepIndex = 0,
+        )
+    }
+
+    private fun snapshot() = LevelUpSnapshot(
+        totalLevel = 3,
+        classLevels = mapOf("fighter" to 3),
+        classDisplayName = "Fighter 3",
+        proficiencyBonus = 2,
+        abilityScores = AbilityScores(),
+        maximumHitPoints = 24,
+        hitDicePools = emptyList(),
+        proficiencyIds = emptySet(),
+        savingThrowAbilityIds = emptySet(),
+        featureIds = emptySet(),
+        sharedCasterLevel = 0,
+        sharedSpellSlots = emptyMap(),
+    )
+}


### PR DESCRIPTION
Closes #165

## What changed
- add `Informational` to the shared level-up validation severity model
- expose blocking, overrideable, and informational findings through level-up wizard UI state
- keep informational findings out of step readiness, confirmation, and acknowledgement semantics
- render informational guidance with neutral styling and no override affordance
- add focused domain, ViewModel, state, and Robolectric UI coverage for info-only and mixed-severity cases

## Scope
No new validation rules are introduced. This change only adds the severity plumbing and test fixtures so later ADR-0012 guidance rules can emit passive findings without affecting progression.

## Validation
GitHub Actions CI is the authoritative validation for this project and will run on this pull request.