### PR TITLE
feat: retry level-up reference data loading

### DIFF
--- a/app/src/main/kotlin/com/github/arhor/spellbindr/data/local/assets/DefaultAssetBootstrapper.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/data/local/assets/DefaultAssetBootstrapper.kt
@@ -3,6 +3,7 @@ package com.github.arhor.spellbindr.data.local.assets
 import com.github.arhor.spellbindr.di.AppCoroutineScope
 import com.github.arhor.spellbindr.domain.AssetBootstrapper
 import com.github.arhor.spellbindr.domain.model.AssetBootstrapState
+import com.github.arhor.spellbindr.domain.model.Loadable
 import com.github.arhor.spellbindr.logging.LoggerFactory
 import com.github.arhor.spellbindr.logging.error
 import com.github.arhor.spellbindr.logging.getLogger
@@ -11,6 +12,7 @@ import com.github.arhor.spellbindr.utils.toCapitalCase
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -51,6 +53,15 @@ class DefaultAssetBootstrapper @Inject constructor(
 
             deferredLoadJob.join()
             logger.info { "Deferred initialization phase complete" }
+        }
+    }
+
+    override suspend fun retryFailedLoads() {
+        coroutineScope {
+            assetsDataStores
+                .filter { it.data.value is Loadable.Failure }
+                .map { async { it.initialize() } }
+                .awaitAll()
         }
     }
 

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/domain/AssetBootstrapper.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/domain/AssetBootstrapper.kt
@@ -6,4 +6,5 @@ import kotlinx.coroutines.flow.StateFlow
 interface AssetBootstrapper {
     val state: StateFlow<AssetBootstrapState>
     fun start()
+    suspend fun retryFailedLoads()
 }

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpFailurePane.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpFailurePane.kt
@@ -1,0 +1,30 @@
+package com.github.arhor.spellbindr.ui.feature.character.levelup
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+internal fun CharacterLevelUpFailurePane(
+    message: String,
+    onRetry: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier.fillMaxSize().padding(32.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(16.dp, Alignment.CenterVertically),
+    ) {
+        Text(message)
+        Button(onClick = onRetry) {
+            Text("Retry")
+        }
+    }
+}

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpIntent.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpIntent.kt
@@ -19,6 +19,7 @@ sealed interface CharacterLevelUpIntent {
     data object CancelClicked : CharacterLevelUpIntent
     data object ConfirmClicked : CharacterLevelUpIntent
     data object ReloadClicked : CharacterLevelUpIntent
+    data object RetryClicked : CharacterLevelUpIntent
 }
 
 typealias CharacterLevelUpDispatch = (CharacterLevelUpIntent) -> Unit

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpRoute.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpRoute.kt
@@ -3,6 +3,7 @@ package com.github.arhor.spellbindr.ui.feature.character.levelup
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.github.arhor.spellbindr.ui.components.AppTopBarConfig
@@ -44,6 +45,23 @@ fun CharacterLevelUpRoute(
             ),
         ),
     ) {
-        CharacterLevelUpScreen(state = state, dispatch = vm::dispatch)
+        CharacterLevelUpRouteContent(state = state, dispatch = vm::dispatch)
+    }
+}
+
+@Composable
+internal fun CharacterLevelUpRouteContent(
+    state: CharacterLevelUpUiState,
+    dispatch: CharacterLevelUpDispatch,
+    modifier: Modifier = Modifier,
+) {
+    if (state is CharacterLevelUpUiState.Failure && state.canRetry) {
+        CharacterLevelUpFailurePane(
+            message = state.message,
+            onRetry = { dispatch(CharacterLevelUpIntent.RetryClicked) },
+            modifier = modifier,
+        )
+    } else {
+        CharacterLevelUpScreen(state = state, dispatch = dispatch, modifier = modifier)
     }
 }

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpUiState.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpUiState.kt
@@ -45,7 +45,7 @@ internal fun characterLevelUpSteps(requirements: List<LevelUpRequirement>): List
 
 sealed interface CharacterLevelUpUiState {
     @Immutable data object Loading : CharacterLevelUpUiState
-    @Immutable data class Failure(val message: String) : CharacterLevelUpUiState
+    @Immutable data class Failure(val message: String, val canRetry: Boolean = false) : CharacterLevelUpUiState
     @Immutable data class Unavailable(val title: String, val explanation: String) : CharacterLevelUpUiState
 
     @Immutable

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpViewModel.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpViewModel.kt
@@ -3,6 +3,7 @@ package com.github.arhor.spellbindr.ui.feature.character.levelup
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.github.arhor.spellbindr.domain.AssetBootstrapper
 import com.github.arhor.spellbindr.domain.model.AbilityScoreDecision
 import com.github.arhor.spellbindr.domain.model.ApplyLevelUpResult
 import com.github.arhor.spellbindr.domain.model.CharacterClass
@@ -30,6 +31,7 @@ import com.github.arhor.spellbindr.domain.usecase.ObserveAllLanguagesUseCase
 import com.github.arhor.spellbindr.domain.usecase.ObserveAllSpellsUseCase
 import com.github.arhor.spellbindr.domain.usecase.RebuildLevelUpPlanUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -50,6 +52,7 @@ class CharacterLevelUpViewModel @Inject constructor(
     observeFeats: ObserveAllFeatsUseCase,
     observeSpells: ObserveAllSpellsUseCase,
     observeLanguages: ObserveAllLanguagesUseCase,
+    private val assetBootstrapper: AssetBootstrapper,
     private val createPlan: CreateLevelUpPlanUseCase,
     private val rebuildPlan: RebuildLevelUpPlanUseCase,
     private val applyLevelUp: ApplyLevelUpUseCase,
@@ -59,6 +62,7 @@ class CharacterLevelUpViewModel @Inject constructor(
     private val draft = MutableStateFlow(restoredDraft())
     private var latestReady: SourceState.Ready? = null
     private var confirmationInFlight = false
+    private var retryInFlight = false
     private val _effects = MutableSharedFlow<CharacterLevelUpEffect>()
     val effects = _effects.asSharedFlow()
 
@@ -100,7 +104,7 @@ class CharacterLevelUpViewModel @Inject constructor(
                 character == null -> SourceState.Failure("Character not found")
                 classes is Loadable.Failure || features is Loadable.Failure ||
                     feats is Loadable.Failure || spells is Loadable.Failure || languages is Loadable.Failure ->
-                    SourceState.Failure("Unable to load level-up reference data")
+                    SourceState.Failure("Unable to load level-up reference data", retryable = true)
                 classes is Loadable.Content && features is Loadable.Content &&
                     feats is Loadable.Content && spells is Loadable.Content && languages is Loadable.Content -> SourceState.Ready(
                     character,
@@ -136,6 +140,7 @@ class CharacterLevelUpViewModel @Inject constructor(
             CharacterLevelUpIntent.CancelClicked -> cancel()
             CharacterLevelUpIntent.ConfirmClicked -> confirm()
             CharacterLevelUpIntent.ReloadClicked -> reloadDraft()
+            CharacterLevelUpIntent.RetryClicked -> retryReferenceData()
         }
     }
 
@@ -143,7 +148,7 @@ class CharacterLevelUpViewModel @Inject constructor(
         latestReady = source as? SourceState.Ready
         return when (source) {
         SourceState.Loading -> CharacterLevelUpUiState.Loading
-        is SourceState.Failure -> CharacterLevelUpUiState.Failure(source.message)
+        is SourceState.Failure -> CharacterLevelUpUiState.Failure(source.message, source.retryable)
         is SourceState.Ready -> {
             val managed = source.character.progressionState as? ProgressionState.Managed
                 ?: return CharacterLevelUpUiState.Unavailable("Set up level progression", "Reconciliation is not yet available for this character.")
@@ -234,6 +239,24 @@ class CharacterLevelUpViewModel @Inject constructor(
         draft.value = null
     }
 
+    private fun retryReferenceData() {
+        if (retryInFlight) return
+        val failure = uiState.value as? CharacterLevelUpUiState.Failure ?: return
+        if (!failure.canRetry) return
+        retryInFlight = true
+        viewModelScope.launch {
+            try {
+                assetBootstrapper.retryFailedLoads()
+            } catch (error: CancellationException) {
+                throw error
+            } catch (_: Exception) {
+                // The observed asset state remains failed, so the retry action stays available.
+            } finally {
+                retryInFlight = false
+            }
+        }
+    }
+
     private fun cancel() {
         if (confirmationInFlight) return
         viewModelScope.launch { _effects.emit(CharacterLevelUpEffect.Cancelled) }
@@ -306,6 +329,6 @@ class CharacterLevelUpViewModel @Inject constructor(
 
     @Serializable
     private data class SavedDraft(val step: CharacterLevelUpStep, val plan: LevelUpPlan, val isSaving: Boolean = false, val staleMessage: String? = null, val persistenceMessage: String? = null)
-    private sealed interface SourceState { data object Loading : SourceState; data class Failure(val message: String) : SourceState; data class Ready(val character: CharacterWithProgression, val reference: ReferenceState) : SourceState }
+    private sealed interface SourceState { data object Loading : SourceState; data class Failure(val message: String, val retryable: Boolean = false) : SourceState; data class Ready(val character: CharacterWithProgression, val reference: ReferenceState) : SourceState }
     companion object { private const val DRAFT_KEY = "character-level-up-draft"; private val JSON = Json { ignoreUnknownKeys = true } }
 }

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/data/local/assets/DefaultAssetBootstrapperRetryTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/data/local/assets/DefaultAssetBootstrapperRetryTest.kt
@@ -1,0 +1,37 @@
+package com.github.arhor.spellbindr.data.local.assets
+
+import com.github.arhor.spellbindr.domain.model.Loadable
+import com.github.arhor.spellbindr.logging.NoOpLoggerFactory
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+class DefaultAssetBootstrapperRetryTest {
+
+    @Test
+    fun `retryFailedLoads should initialize only failed asset stores`() = runTest {
+        // Given
+        val failedStore = mockk<AssetDataStore<List<String>>>()
+        val readyStore = mockk<AssetDataStore<List<String>>>()
+        every { failedStore.data } returns MutableStateFlow(Loadable.Failure(RuntimeException("boom")))
+        every { readyStore.data } returns MutableStateFlow(Loadable.Content(listOf("ready")))
+        coEvery { failedStore.initialize() } returns Unit
+        coEvery { readyStore.initialize() } returns Unit
+        val bootstrapper = DefaultAssetBootstrapper(
+            appCoroutineScope = this,
+            assetsDataStores = setOf(failedStore, readyStore),
+            loggerFactory = NoOpLoggerFactory,
+        )
+
+        // When
+        bootstrapper.retryFailedLoads()
+
+        // Then
+        coVerify(exactly = 1) { failedStore.initialize() }
+        coVerify(exactly = 0) { readyStore.initialize() }
+    }
+}

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/data/local/assets/DefaultAssetBootstrapperRetryTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/data/local/assets/DefaultAssetBootstrapperRetryTest.kt
@@ -17,7 +17,7 @@ class DefaultAssetBootstrapperRetryTest {
         // Given
         val failedStore = mockk<AssetDataStore<List<String>>>()
         val readyStore = mockk<AssetDataStore<List<String>>>()
-        every { failedStore.data } returns MutableStateFlow(Loadable.Failure(RuntimeException("boom")))
+        every { failedStore.data } returns MutableStateFlow(Loadable.Failure(cause = RuntimeException("boom")))
         every { readyStore.data } returns MutableStateFlow(Loadable.Content(listOf("ready")))
         coEvery { failedStore.initialize() } returns Unit
         coEvery { readyStore.initialize() } returns Unit

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpGuidanceViewModelTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpGuidanceViewModelTest.kt
@@ -2,6 +2,7 @@ package com.github.arhor.spellbindr.ui.feature.character.levelup
 
 import androidx.lifecycle.SavedStateHandle
 import com.github.arhor.spellbindr.MainDispatcherRule
+import com.github.arhor.spellbindr.domain.AssetBootstrapper
 import com.github.arhor.spellbindr.domain.model.AbilityScores
 import com.github.arhor.spellbindr.domain.model.CharacterClass
 import com.github.arhor.spellbindr.domain.model.CharacterLevelRecord
@@ -53,6 +54,7 @@ class CharacterLevelUpGuidanceViewModelTest {
             val observeFeats = mockk<ObserveAllFeatsUseCase>()
             val observeSpells = mockk<ObserveAllSpellsUseCase>()
             val observeLanguages = mockk<ObserveAllLanguagesUseCase>()
+            val assetBootstrapper = mockk<AssetBootstrapper>()
             val createPlan = mockk<CreateLevelUpPlanUseCase>()
             val rebuildPlan = mockk<RebuildLevelUpPlanUseCase>()
             val applyLevelUp = mockk<ApplyLevelUpUseCase>()
@@ -98,6 +100,7 @@ class CharacterLevelUpGuidanceViewModelTest {
                 observeFeats = observeFeats,
                 observeSpells = observeSpells,
                 observeLanguages = observeLanguages,
+                assetBootstrapper = assetBootstrapper,
                 createPlan = createPlan,
                 rebuildPlan = rebuildPlan,
                 applyLevelUp = applyLevelUp,

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpRetryScreenTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpRetryScreenTest.kt
@@ -1,0 +1,59 @@
+package com.github.arhor.spellbindr.ui.feature.character.levelup
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.assertDoesNotExist
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.performClick
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.arhor.spellbindr.ui.theme.AppTheme
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class CharacterLevelUpRetryScreenTest {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun `retryable failure should show retry and dispatch retry intent`() {
+        // Given
+        val intents = mutableListOf<CharacterLevelUpIntent>()
+        composeTestRule.setContent {
+            AppTheme {
+                CharacterLevelUpRouteContent(
+                    state = CharacterLevelUpUiState.Failure(
+                        message = "Unable to load level-up reference data",
+                        canRetry = true,
+                    ),
+                    dispatch = intents::add,
+                )
+            }
+        }
+
+        // When
+        composeTestRule.onNodeWithText("Retry").performClick()
+
+        // Then
+        assertThat(intents).containsExactly(CharacterLevelUpIntent.RetryClicked)
+    }
+
+    @Test
+    fun `terminal failure should not show retry`() {
+        // Given
+        composeTestRule.setContent {
+            AppTheme {
+                CharacterLevelUpRouteContent(
+                    state = CharacterLevelUpUiState.Failure("Character not found"),
+                    dispatch = {},
+                )
+            }
+        }
+
+        // Then
+        composeTestRule.onNodeWithText("Retry").assertDoesNotExist()
+    }
+}

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpRetryScreenTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpRetryScreenTest.kt
@@ -1,7 +1,6 @@
 package com.github.arhor.spellbindr.ui.feature.character.levelup
 
 import androidx.activity.ComponentActivity
-import androidx.compose.ui.test.assertDoesNotExist
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.performClick

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpRetryViewModelTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpRetryViewModelTest.kt
@@ -55,7 +55,7 @@ class CharacterLevelUpRetryViewModelTest {
             advanceUntilIdle()
             fixture.vm.dispatch(CharacterLevelUpIntent.ClassSelected("rogue"))
             advanceUntilIdle()
-            fixture.classes.value = Loadable.Failure(RuntimeException("temporary"))
+            fixture.classes.value = Loadable.Failure(cause = RuntimeException("temporary"))
             advanceUntilIdle()
             val failure = fixture.vm.uiState.value as CharacterLevelUpUiState.Failure
             assertThat(failure.canRetry).isTrue()
@@ -80,7 +80,7 @@ class CharacterLevelUpRetryViewModelTest {
             val fixture = createFixture(retrySucceeds = false)
             val collector = launch { fixture.vm.uiState.collect { } }
             advanceUntilIdle()
-            fixture.classes.value = Loadable.Failure(RuntimeException("first failure"))
+            fixture.classes.value = Loadable.Failure(cause = RuntimeException("first failure"))
             advanceUntilIdle()
 
             // When
@@ -143,7 +143,7 @@ class CharacterLevelUpRetryViewModelTest {
             classes.value = if (retrySucceeds) {
                 Loadable.Content(listOf(characterClass("fighter"), characterClass("rogue")))
             } else {
-                Loadable.Failure(RuntimeException("still unavailable"))
+                Loadable.Failure(cause = RuntimeException("still unavailable"))
             }
         }
 

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpRetryViewModelTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpRetryViewModelTest.kt
@@ -1,0 +1,235 @@
+package com.github.arhor.spellbindr.ui.feature.character.levelup
+
+import androidx.lifecycle.SavedStateHandle
+import com.github.arhor.spellbindr.MainDispatcherRule
+import com.github.arhor.spellbindr.domain.AssetBootstrapper
+import com.github.arhor.spellbindr.domain.model.AbilityScores
+import com.github.arhor.spellbindr.domain.model.ApplyLevelUpResult
+import com.github.arhor.spellbindr.domain.model.CharacterClass
+import com.github.arhor.spellbindr.domain.model.CharacterLevelRecord
+import com.github.arhor.spellbindr.domain.model.CharacterProgression
+import com.github.arhor.spellbindr.domain.model.CharacterSheet
+import com.github.arhor.spellbindr.domain.model.CharacterWithProgression
+import com.github.arhor.spellbindr.domain.model.HitPointGain
+import com.github.arhor.spellbindr.domain.model.LevelUpPlan
+import com.github.arhor.spellbindr.domain.model.LevelUpPreview
+import com.github.arhor.spellbindr.domain.model.LevelUpReferenceRules
+import com.github.arhor.spellbindr.domain.model.LevelUpRequirement
+import com.github.arhor.spellbindr.domain.model.LevelUpSnapshot
+import com.github.arhor.spellbindr.domain.model.Loadable
+import com.github.arhor.spellbindr.domain.model.ProgressionOrigin
+import com.github.arhor.spellbindr.domain.model.ProgressionState
+import com.github.arhor.spellbindr.domain.usecase.ApplyLevelUpUseCase
+import com.github.arhor.spellbindr.domain.usecase.CreateLevelUpPlanUseCase
+import com.github.arhor.spellbindr.domain.usecase.LoadCharacterWithProgressionUseCase
+import com.github.arhor.spellbindr.domain.usecase.ObserveAllCharacterClassesUseCase
+import com.github.arhor.spellbindr.domain.usecase.ObserveAllFeatsUseCase
+import com.github.arhor.spellbindr.domain.usecase.ObserveAllFeaturesUseCase
+import com.github.arhor.spellbindr.domain.usecase.ObserveAllLanguagesUseCase
+import com.github.arhor.spellbindr.domain.usecase.ObserveAllSpellsUseCase
+import com.github.arhor.spellbindr.domain.usecase.RebuildLevelUpPlanUseCase
+import com.google.common.truth.Truth.assertThat
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Rule
+import org.junit.Test
+
+class CharacterLevelUpRetryViewModelTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    @Test
+    fun `retry should restore the current step and preserve draft selections after reference data recovers`() =
+        runTest(mainDispatcherRule.dispatcher) {
+            // Given
+            val fixture = createFixture(retrySucceeds = true)
+            val collector = launch { fixture.vm.uiState.collect { } }
+            advanceUntilIdle()
+            fixture.vm.dispatch(CharacterLevelUpIntent.ClassSelected("rogue"))
+            advanceUntilIdle()
+            fixture.classes.value = Loadable.Failure(RuntimeException("temporary"))
+            advanceUntilIdle()
+            val failure = fixture.vm.uiState.value as CharacterLevelUpUiState.Failure
+            assertThat(failure.canRetry).isTrue()
+
+            // When
+            fixture.vm.dispatch(CharacterLevelUpIntent.RetryClicked)
+            advanceUntilIdle()
+
+            // Then
+            val content = fixture.vm.uiState.value as CharacterLevelUpUiState.Content
+            assertThat(content.step).isEqualTo(CharacterLevelUpStep.Class)
+            assertThat(content.plan.selectedClassId).isEqualTo("rogue")
+            assertThat(fixture.savedStateHandle.get<String>(DRAFT_KEY)).isNotNull()
+            coVerify(exactly = 1) { fixture.assetBootstrapper.retryFailedLoads() }
+            collector.cancel()
+        }
+
+    @Test
+    fun `retry should remain available when reference data fails repeatedly`() =
+        runTest(mainDispatcherRule.dispatcher) {
+            // Given
+            val fixture = createFixture(retrySucceeds = false)
+            val collector = launch { fixture.vm.uiState.collect { } }
+            advanceUntilIdle()
+            fixture.classes.value = Loadable.Failure(RuntimeException("first failure"))
+            advanceUntilIdle()
+
+            // When
+            fixture.vm.dispatch(CharacterLevelUpIntent.RetryClicked)
+            advanceUntilIdle()
+            val firstRetryFailure = fixture.vm.uiState.value as CharacterLevelUpUiState.Failure
+            fixture.vm.dispatch(CharacterLevelUpIntent.RetryClicked)
+            advanceUntilIdle()
+
+            // Then
+            assertThat(firstRetryFailure.canRetry).isTrue()
+            assertThat(fixture.vm.uiState.value).isInstanceOf(CharacterLevelUpUiState.Failure::class.java)
+            assertThat((fixture.vm.uiState.value as CharacterLevelUpUiState.Failure).canRetry).isTrue()
+            coVerify(exactly = 2) { fixture.assetBootstrapper.retryFailedLoads() }
+            collector.cancel()
+        }
+
+    private fun createFixture(retrySucceeds: Boolean): Fixture {
+        val classes = MutableStateFlow<Loadable<List<CharacterClass>>>(
+            Loadable.Content(listOf(characterClass("fighter"), characterClass("rogue"))),
+        )
+        val savedStateHandle = SavedStateHandle(mapOf(CHARACTER_ID_KEY to CHARACTER_ID))
+        val loadCharacter = mockk<LoadCharacterWithProgressionUseCase>()
+        val observeClasses = mockk<ObserveAllCharacterClassesUseCase>()
+        val observeFeatures = mockk<ObserveAllFeaturesUseCase>()
+        val observeFeats = mockk<ObserveAllFeatsUseCase>()
+        val observeSpells = mockk<ObserveAllSpellsUseCase>()
+        val observeLanguages = mockk<ObserveAllLanguagesUseCase>()
+        val assetBootstrapper = mockk<AssetBootstrapper>()
+        val createPlan = mockk<CreateLevelUpPlanUseCase>()
+        val rebuildPlan = mockk<RebuildLevelUpPlanUseCase>()
+        val applyLevelUp = mockk<ApplyLevelUpUseCase>()
+        val progression = progression()
+
+        every { loadCharacter(CHARACTER_ID) } returns flowOf(
+            CharacterWithProgression(
+                CharacterSheet(id = CHARACTER_ID, name = "Mira"),
+                ProgressionState.Managed(progression),
+            ),
+        )
+        every { observeClasses() } returns classes
+        every { observeFeatures() } returns flowOf(Loadable.Content(emptyList()))
+        every { observeFeats() } returns flowOf(Loadable.Content(emptyList()))
+        every { observeSpells() } returns flowOf(Loadable.Content(emptyList()))
+        every { observeLanguages() } returns flowOf(Loadable.Content(emptyList()))
+        every { createPlan(any()) } answers {
+            LevelUpPlan(
+                expectedTotalLevel = progression.totalLevel,
+                rulesetId = progression.rulesetId,
+                referenceDataVersion = progression.referenceDataVersion,
+                selectedClassId = "fighter",
+            )
+        }
+        every { rebuildPlan(any(), any(), any(), any()) } answers {
+            preview(thirdArg())
+        }
+        coEvery { applyLevelUp(any(), any(), any(), any()) } returns ApplyLevelUpResult.StaleState
+        coEvery { assetBootstrapper.retryFailedLoads() } coAnswers {
+            classes.value = Loadable.Loading
+            classes.value = if (retrySucceeds) {
+                Loadable.Content(listOf(characterClass("fighter"), characterClass("rogue")))
+            } else {
+                Loadable.Failure(RuntimeException("still unavailable"))
+            }
+        }
+
+        return Fixture(
+            vm = CharacterLevelUpViewModel(
+                loadCharacter,
+                observeClasses,
+                observeFeatures,
+                observeFeats,
+                observeSpells,
+                observeLanguages,
+                assetBootstrapper,
+                createPlan,
+                rebuildPlan,
+                applyLevelUp,
+                savedStateHandle,
+            ),
+            classes = classes,
+            assetBootstrapper = assetBootstrapper,
+            savedStateHandle = savedStateHandle,
+        )
+    }
+
+    private data class Fixture(
+        val vm: CharacterLevelUpViewModel,
+        val classes: MutableStateFlow<Loadable<List<CharacterClass>>>,
+        val assetBootstrapper: AssetBootstrapper,
+        val savedStateHandle: SavedStateHandle,
+    )
+
+    companion object {
+        private const val CHARACTER_ID = "character-1"
+        private const val CHARACTER_ID_KEY = "characterId"
+        private const val DRAFT_KEY = "character-level-up-draft"
+
+        private fun progression() = CharacterProgression(
+            rulesetId = CharacterProgression.SUPPORTED_RULESET_ID,
+            referenceDataVersion = LevelUpReferenceRules.referenceDataVersion,
+            origin = ProgressionOrigin.Guided,
+            levels = listOf(
+                CharacterLevelRecord(
+                    characterLevel = 1,
+                    classId = "fighter",
+                    classLevel = 1,
+                    hitPointGain = HitPointGain.Fixed(6),
+                ),
+            ),
+        )
+
+        private fun characterClass(id: String) = CharacterClass(
+            id = id,
+            name = id.replaceFirstChar(Char::titlecase),
+            hitDie = 10,
+            proficiencies = emptyList(),
+            proficiencyChoices = emptyList(),
+            savingThrows = emptyList(),
+            subclasses = emptyList(),
+            levels = emptyList(),
+        )
+
+        private fun preview(plan: LevelUpPlan): LevelUpPreview {
+            val before = LevelUpSnapshot(
+                totalLevel = plan.expectedTotalLevel,
+                classLevels = mapOf("fighter" to plan.expectedTotalLevel),
+                classDisplayName = "Fighter ${plan.expectedTotalLevel}",
+                proficiencyBonus = 2,
+                abilityScores = AbilityScores(),
+                maximumHitPoints = 10,
+                hitDicePools = emptyList(),
+                proficiencyIds = emptySet(),
+                savingThrowAbilityIds = emptySet(),
+                featureIds = emptySet(),
+                sharedCasterLevel = 0,
+                sharedSpellSlots = emptyMap(),
+            )
+            return LevelUpPreview(
+                before = before,
+                after = before.copy(totalLevel = before.totalLevel + 1),
+                requirements = listOf(
+                    LevelUpRequirement.ClassSelection(
+                        eligibleClassIds = listOf("fighter", "rogue"),
+                        selectedClassId = plan.selectedClassId,
+                    ),
+                ),
+                validations = emptyList(),
+            )
+        }
+    }
+}

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpViewModelTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpViewModelTest.kt
@@ -2,6 +2,7 @@ package com.github.arhor.spellbindr.ui.feature.character.levelup
 
 import androidx.lifecycle.SavedStateHandle
 import com.github.arhor.spellbindr.MainDispatcherRule
+import com.github.arhor.spellbindr.domain.AssetBootstrapper
 import com.github.arhor.spellbindr.domain.model.AbilityIds
 import com.github.arhor.spellbindr.domain.model.AbilityScoreDecision
 import com.github.arhor.spellbindr.domain.model.AbilityScores
@@ -419,6 +420,7 @@ class CharacterLevelUpViewModelTest {
         val observeFeats = mockk<ObserveAllFeatsUseCase>()
         val observeSpells = mockk<ObserveAllSpellsUseCase>()
         val observeLanguages = mockk<ObserveAllLanguagesUseCase>()
+        val assetBootstrapper = mockk<AssetBootstrapper>()
         val createPlan = mockk<CreateLevelUpPlanUseCase>()
         val rebuildPlan = mockk<RebuildLevelUpPlanUseCase>()
         val applyLevelUp = mockk<ApplyLevelUpUseCase>()
@@ -430,6 +432,7 @@ class CharacterLevelUpViewModelTest {
         every { observeFeats() } returns flowOf(Loadable.Content(emptyList()))
         every { observeSpells() } returns flowOf(Loadable.Content(emptyList()))
         every { observeLanguages() } returns flowOf(Loadable.Content(emptyList()))
+        coEvery { assetBootstrapper.retryFailedLoads() } returns Unit
         every { createPlan(any()) } answers {
             val source = firstArg<CharacterProgression>()
             LevelUpPlan(
@@ -456,6 +459,7 @@ class CharacterLevelUpViewModelTest {
                 observeFeats,
                 observeSpells,
                 observeLanguages,
+                assetBootstrapper,
                 createPlan,
                 rebuildPlan,
                 applyLevelUp,


### PR DESCRIPTION
Closes #168

## What changed
- add an explicit retry path for failed static asset loads
- mark level-up reference-data failures as retryable and show a visible Retry action
- keep the saved level-up draft intact while reference data reloads so a successful retry restores the appropriate step and selections
- leave repeated failures recoverable without crashing or clearing the draft

## Tests
- focused asset-bootstrap retry coverage
- focused ViewModel coverage for successful recovery, draft preservation, and repeated failure
- focused Robolectric Compose coverage for retry visibility and dispatch

## Validation
GitHub Actions is the authoritative validation for this project and will run on this pull request.