### PR TITLE
feat: show level-up review findings

### DIFF
--- a/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpScreen.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpScreen.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Button
-import androidx.compose.material3.Checkbox
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.MaterialTheme
@@ -37,7 +36,6 @@ import com.github.arhor.spellbindr.domain.model.HitPointGain
 import com.github.arhor.spellbindr.domain.model.LevelUpChoiceCategory
 import com.github.arhor.spellbindr.domain.model.LevelUpRequirement
 import com.github.arhor.spellbindr.domain.model.LevelUpSpellOption
-import com.github.arhor.spellbindr.domain.model.LevelUpValidationSeverity
 import com.github.arhor.spellbindr.domain.model.SpellChanges
 import com.github.arhor.spellbindr.domain.model.SpellReplacement
 
@@ -261,27 +259,9 @@ private fun Content(state: CharacterLevelUpUiState.Content, dispatch: CharacterL
                 CharacterLevelUpClassProgressionReview(state)
                 ReviewRow("Proficiency bonus", "+${state.preview.before.proficiencyBonus}", "+${state.preview.after.proficiencyBonus}")
                 CharacterLevelUpDurabilityReview(state)
-                state.preview.validations.forEach { issue ->
-                    when (issue.severity) {
-                        LevelUpValidationSeverity.Blocking -> WarningCard(issue.message)
-                        LevelUpValidationSeverity.Overrideable -> {
-                            val checked = issue.acknowledgementId in state.plan.selections.acknowledgedIssueCodes
-                            Row(verticalAlignment = Alignment.CenterVertically) {
-                                Checkbox(
-                                    checked = checked,
-                                    enabled = !state.isSaving,
-                                    onCheckedChange = {
-                                        dispatch(CharacterLevelUpIntent.AcknowledgementChanged(
-                                            issue.acknowledgementId,
-                                            it,
-                                        ))
-                                    },
-                                )
-                                Text(issue.message)
-                            }
-                        }
-                        LevelUpValidationSeverity.Informational -> InformationalCard(issue.message)
-                    }
+                CharacterLevelUpValidationReview(state, dispatch)
+                state.blockingIssues.forEach { issue ->
+                    WarningCard(issue.message)
                 }
             }
         }
@@ -522,7 +502,6 @@ private fun SpellChanges.toggleFeatureGrant(
 @Composable private fun ChoiceRow(label: String, selected: Boolean, onClick: () -> Unit) = Surface(onClick = onClick, modifier = Modifier.fillMaxWidth(), shape = MaterialTheme.shapes.medium) { Row(Modifier.padding(12.dp), verticalAlignment = Alignment.CenterVertically) { RadioButton(selected, onClick = onClick); Text(label) } }
 @Composable private fun SectionTitle(text: String) = Text(text, style = MaterialTheme.typography.titleSmall)
 @Composable private fun WarningCard(text: String) = Surface(color = MaterialTheme.colorScheme.errorContainer, shape = MaterialTheme.shapes.medium) { Text(text, Modifier.fillMaxWidth().padding(12.dp), color = MaterialTheme.colorScheme.onErrorContainer) }
-@Composable private fun InformationalCard(text: String) = Surface(color = MaterialTheme.colorScheme.surfaceVariant, shape = MaterialTheme.shapes.medium) { Text(text, Modifier.fillMaxWidth().padding(12.dp), color = MaterialTheme.colorScheme.onSurfaceVariant) }
 @Composable private fun ReviewRow(label: String, before: String, after: String) = Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) { Text(label); Text("$before → $after") }
 @Composable private fun MessagePane(text: String, modifier: Modifier) = Box(modifier.fillMaxSize().padding(32.dp), contentAlignment = Alignment.Center) { Text(text) }
 

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpValidationReview.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpValidationReview.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.weight
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpValidationReview.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpValidationReview.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -12,6 +13,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
 import com.github.arhor.spellbindr.domain.model.LevelUpValidationCode
 import com.github.arhor.spellbindr.domain.model.LevelUpValidationIssue
@@ -84,15 +86,23 @@ private fun RuleExceptionFinding(
         shape = MaterialTheme.shapes.small,
     ) {
         Row(
-            modifier = Modifier.padding(12.dp),
+            modifier = Modifier
+                .fillMaxWidth()
+                .toggleable(
+                    value = accepted,
+                    enabled = !state.isSaving,
+                    role = Role.Checkbox,
+                    onValueChange = {
+                        dispatch(CharacterLevelUpIntent.AcknowledgementChanged(issue.acknowledgementId, it))
+                    },
+                )
+                .padding(12.dp),
             verticalAlignment = Alignment.Top,
         ) {
             Checkbox(
                 checked = accepted,
                 enabled = !state.isSaving,
-                onCheckedChange = {
-                    dispatch(CharacterLevelUpIntent.AcknowledgementChanged(issue.acknowledgementId, it))
-                },
+                onCheckedChange = null,
             )
             Column(
                 modifier = Modifier.weight(1f),

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpValidationReview.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpValidationReview.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.unit.dp
 import com.github.arhor.spellbindr.domain.model.LevelUpValidationCode
 import com.github.arhor.spellbindr.domain.model.LevelUpValidationIssue
@@ -103,6 +104,7 @@ private fun RuleExceptionFinding(
                 checked = accepted,
                 enabled = !state.isSaving,
                 onCheckedChange = null,
+                modifier = Modifier.clearAndSetSemantics {},
             )
             Column(
                 modifier = Modifier.weight(1f),

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpValidationReview.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpValidationReview.kt
@@ -1,0 +1,128 @@
+package com.github.arhor.spellbindr.ui.feature.character.levelup
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.weight
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.github.arhor.spellbindr.domain.model.LevelUpValidationCode
+import com.github.arhor.spellbindr.domain.model.LevelUpValidationIssue
+import com.github.arhor.spellbindr.domain.model.LevelUpValidationSeverity
+
+@Composable
+internal fun CharacterLevelUpValidationReview(
+    state: CharacterLevelUpUiState.Content,
+    dispatch: CharacterLevelUpDispatch,
+) {
+    val findings = state.preview.validations.filter { issue ->
+        issue.severity == LevelUpValidationSeverity.Informational ||
+            issue.severity == LevelUpValidationSeverity.Overrideable
+    }
+    if (findings.isEmpty()) return
+
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = MaterialTheme.shapes.medium,
+        tonalElevation = 1.dp,
+    ) {
+        Column(
+            modifier = Modifier.padding(12.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            Text("Review findings", style = MaterialTheme.typography.titleSmall)
+            findings.forEach { issue ->
+                when (issue.severity) {
+                    LevelUpValidationSeverity.Informational -> InformationalFinding(issue)
+                    LevelUpValidationSeverity.Overrideable -> RuleExceptionFinding(state, issue, dispatch)
+                    LevelUpValidationSeverity.Blocking -> Unit
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun InformationalFinding(issue: LevelUpValidationIssue) {
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        color = MaterialTheme.colorScheme.surfaceVariant,
+        shape = MaterialTheme.shapes.small,
+    ) {
+        Column(
+            modifier = Modifier.padding(12.dp),
+            verticalArrangement = Arrangement.spacedBy(4.dp),
+        ) {
+            Text("Warning", style = MaterialTheme.typography.labelLarge)
+            Text(issue.message)
+            Text(
+                "No action required.",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+    }
+}
+
+@Composable
+private fun RuleExceptionFinding(
+    state: CharacterLevelUpUiState.Content,
+    issue: LevelUpValidationIssue,
+    dispatch: CharacterLevelUpDispatch,
+) {
+    val accepted = issue.acknowledgementId in state.plan.selections.acknowledgedIssueCodes
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        color = MaterialTheme.colorScheme.secondaryContainer,
+        shape = MaterialTheme.shapes.small,
+    ) {
+        Row(
+            modifier = Modifier.padding(12.dp),
+            verticalAlignment = Alignment.Top,
+        ) {
+            Checkbox(
+                checked = accepted,
+                enabled = !state.isSaving,
+                onCheckedChange = {
+                    dispatch(CharacterLevelUpIntent.AcknowledgementChanged(issue.acknowledgementId, it))
+                },
+            )
+            Column(
+                modifier = Modifier.weight(1f),
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
+                Text(
+                    if (accepted) "Accepted rule exception" else "Rule exception",
+                    style = MaterialTheme.typography.labelLarge,
+                )
+                Text(issue.message)
+                Text(
+                    issue.reviewContext(state),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSecondaryContainer,
+                )
+            }
+        }
+    }
+}
+
+private fun LevelUpValidationIssue.reviewContext(state: CharacterLevelUpUiState.Content): String = when (code) {
+    LevelUpValidationCode.MulticlassPrerequisite -> "Class choice: ${state.selectedClassLabel()}"
+    LevelUpValidationCode.ExperienceThreshold -> "Target level: ${state.preview.after.totalLevel}"
+    else -> "Level-up choice: ${state.selectedClassLabel()} · level ${state.preview.after.totalLevel}"
+}
+
+private fun CharacterLevelUpUiState.Content.selectedClassLabel(): String {
+    val selectedClassId = plan.selectedClassId
+    return classes.firstOrNull { it.id == selectedClassId }?.name
+        ?: selectedClassId
+        ?: preview.after.classDisplayName
+}

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpValidationReview.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpValidationReview.kt
@@ -1,12 +1,14 @@
 package com.github.arhor.spellbindr.ui.feature.character.levelup
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.selection.toggleable
-import androidx.compose.material3.Checkbox
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -14,7 +16,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.Role
-import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.unit.dp
 import com.github.arhor.spellbindr.domain.model.LevelUpValidationCode
 import com.github.arhor.spellbindr.domain.model.LevelUpValidationIssue
@@ -98,14 +99,10 @@ private fun RuleExceptionFinding(
                     },
                 )
                 .padding(12.dp),
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
             verticalAlignment = Alignment.Top,
         ) {
-            Checkbox(
-                checked = accepted,
-                enabled = !state.isSaving,
-                onCheckedChange = null,
-                modifier = Modifier.clearAndSetSemantics {},
-            )
+            ExceptionCheckIndicator(accepted)
             Column(
                 modifier = Modifier.weight(1f),
                 verticalArrangement = Arrangement.spacedBy(4.dp),
@@ -119,6 +116,26 @@ private fun RuleExceptionFinding(
                     issue.reviewContext(state),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSecondaryContainer,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ExceptionCheckIndicator(accepted: Boolean) {
+    Surface(
+        modifier = Modifier.size(24.dp),
+        shape = MaterialTheme.shapes.extraSmall,
+        color = if (accepted) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.surface,
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outline),
+    ) {
+        Box(contentAlignment = Alignment.Center) {
+            if (accepted) {
+                Text(
+                    "✓",
+                    color = MaterialTheme.colorScheme.onPrimary,
+                    style = MaterialTheme.typography.labelLarge,
                 )
             }
         }

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpScreenTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpScreenTest.kt
@@ -569,7 +569,7 @@ class CharacterLevelUpScreenTest {
         setContent(reviewState(validations = listOf(issue)), intents::add)
 
         // When
-        composeTestRule.onAllNodes(isToggleable())[0].performClick()
+        composeTestRule.onAllNodes(isToggleable())[0].performScrollTo().performClick()
 
         // Then
         assertThat(intents).contains(

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpValidationReviewTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpValidationReviewTest.kt
@@ -1,0 +1,192 @@
+package com.github.arhor.spellbindr.ui.feature.character.levelup
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.isToggleable
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.arhor.spellbindr.domain.model.AbilityScores
+import com.github.arhor.spellbindr.domain.model.CharacterClass
+import com.github.arhor.spellbindr.domain.model.LevelUpPlan
+import com.github.arhor.spellbindr.domain.model.LevelUpPreview
+import com.github.arhor.spellbindr.domain.model.LevelUpRequirement
+import com.github.arhor.spellbindr.domain.model.LevelUpSelections
+import com.github.arhor.spellbindr.domain.model.LevelUpSnapshot
+import com.github.arhor.spellbindr.domain.model.LevelUpValidationCode
+import com.github.arhor.spellbindr.domain.model.LevelUpValidationIssue
+import com.github.arhor.spellbindr.domain.model.LevelUpValidationSeverity
+import com.github.arhor.spellbindr.ui.theme.AppTheme
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class CharacterLevelUpValidationReviewTest {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun `warning only review should show passive finding and keep confirmation enabled`() {
+        val warning = issue(
+            code = LevelUpValidationCode.ExperienceThreshold,
+            message = "Level-up timing is unusual.",
+            severity = LevelUpValidationSeverity.Informational,
+        )
+
+        setContent(reviewState(validations = listOf(warning)))
+
+        composeTestRule.onNodeWithText("Review findings").assertExists()
+        composeTestRule.onNodeWithText("Warning").assertExists()
+        composeTestRule.onNodeWithText(warning.message).assertExists()
+        composeTestRule.onNodeWithText("No action required.").assertExists()
+        composeTestRule.onNodeWithText("Confirm level up").assertIsEnabled()
+        assertThat(composeTestRule.onAllNodes(isToggleable()).fetchSemanticsNodes()).isEmpty()
+    }
+
+    @Test
+    fun `accepted exception only review should identify affected class choice`() {
+        val exception = issue(
+            code = LevelUpValidationCode.MulticlassPrerequisite,
+            message = "Ability prerequisites for Fighter are not met.",
+            severity = LevelUpValidationSeverity.Overrideable,
+        )
+
+        setContent(
+            reviewState(
+                validations = listOf(exception),
+                acceptedIssueCodes = setOf(exception.acknowledgementId),
+            ),
+        )
+
+        composeTestRule.onNodeWithText("Review findings").assertExists()
+        composeTestRule.onNodeWithText("Accepted rule exception").assertExists()
+        composeTestRule.onNodeWithText(exception.message).assertExists()
+        composeTestRule.onNodeWithText("Class choice: Fighter").assertExists()
+        composeTestRule.onNodeWithText("Confirm level up").assertIsEnabled()
+        assertThat(composeTestRule.onAllNodes(isToggleable()).fetchSemanticsNodes()).hasSize(1)
+    }
+
+    @Test
+    fun `mixed review should keep blocking error outside accepted exceptions`() {
+        val warning = issue(
+            code = LevelUpValidationCode.ExperienceThreshold,
+            message = "Level-up timing is unusual.",
+            severity = LevelUpValidationSeverity.Informational,
+        )
+        val exception = issue(
+            code = LevelUpValidationCode.MulticlassPrerequisite,
+            message = "Ability prerequisites for Fighter are not met.",
+            severity = LevelUpValidationSeverity.Overrideable,
+        )
+        val blocking = issue(
+            code = LevelUpValidationCode.ChoiceRequired,
+            message = "Choose a class to level up.",
+            severity = LevelUpValidationSeverity.Blocking,
+        )
+
+        setContent(
+            reviewState(
+                validations = listOf(warning, exception, blocking),
+                acceptedIssueCodes = setOf(exception.acknowledgementId),
+            ),
+        )
+
+        composeTestRule.onNodeWithText(warning.message).assertExists()
+        composeTestRule.onNodeWithText(exception.message).assertExists()
+        composeTestRule.onNodeWithText(blocking.message).assertExists()
+        composeTestRule.onAllNodesWithText("Accepted rule exception").assertCountEquals(1)
+        composeTestRule.onNodeWithText("Confirm level up").assertIsNotEnabled()
+        assertThat(composeTestRule.onAllNodes(isToggleable()).fetchSemanticsNodes()).hasSize(1)
+    }
+
+    @Test
+    fun `review findings section should be omitted when there are no warning or exception findings`() {
+        setContent(reviewState(validations = emptyList()))
+
+        composeTestRule.onNodeWithText("Review findings").assertDoesNotExist()
+    }
+
+    private fun setContent(state: CharacterLevelUpUiState.Content) {
+        composeTestRule.setContent {
+            AppTheme {
+                CharacterLevelUpScreen(state = state, dispatch = {})
+            }
+        }
+    }
+
+    private fun reviewState(
+        validations: List<LevelUpValidationIssue>,
+        acceptedIssueCodes: Set<String> = emptySet(),
+    ): CharacterLevelUpUiState.Content {
+        val before = snapshot()
+        val acknowledgements = validations
+            .filter { it.severity == LevelUpValidationSeverity.Overrideable }
+            .map { issue ->
+                LevelUpRequirement.Acknowledgement(
+                    id = issue.acknowledgementId,
+                    issue = issue,
+                    acknowledged = issue.acknowledgementId in acceptedIssueCodes,
+                )
+            }
+        return CharacterLevelUpUiState.Content(
+            characterName = "Test hero",
+            plan = LevelUpPlan(
+                expectedTotalLevel = before.totalLevel,
+                rulesetId = "srd-5e-2014-v1",
+                referenceDataVersion = "test-v1",
+                selectedClassId = "fighter",
+                selections = LevelUpSelections(acknowledgedIssueCodes = acceptedIssueCodes),
+            ),
+            preview = LevelUpPreview(
+                before = before,
+                after = before.copy(totalLevel = before.totalLevel + 1),
+                requirements = acknowledgements,
+                validations = validations,
+            ),
+            classes = listOf(characterClass()),
+            feats = emptyList(),
+            spells = emptyList(),
+            steps = listOf(CharacterLevelUpStep.Class, CharacterLevelUpStep.Review),
+            step = CharacterLevelUpStep.Review,
+            currentStepIndex = 1,
+        )
+    }
+
+    private fun issue(
+        code: LevelUpValidationCode,
+        message: String,
+        severity: LevelUpValidationSeverity,
+    ) = LevelUpValidationIssue(code, message, severity)
+
+    private fun snapshot() = LevelUpSnapshot(
+        totalLevel = 3,
+        classLevels = mapOf("fighter" to 3),
+        classDisplayName = "Fighter 3",
+        proficiencyBonus = 2,
+        abilityScores = AbilityScores(),
+        maximumHitPoints = 24,
+        hitDicePools = emptyList(),
+        proficiencyIds = emptySet(),
+        savingThrowAbilityIds = emptySet(),
+        featureIds = emptySet(),
+        sharedCasterLevel = 0,
+        sharedSpellSlots = emptyMap(),
+    )
+
+    private fun characterClass() = CharacterClass(
+        id = "fighter",
+        name = "Fighter",
+        hitDie = 10,
+        proficiencies = emptyList(),
+        proficiencyChoices = emptyList(),
+        savingThrows = emptyList(),
+        subclasses = emptyList(),
+        levels = emptyList(),
+    )
+}

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpValidationReviewTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpValidationReviewTest.kt
@@ -1,7 +1,6 @@
 package com.github.arhor.spellbindr.ui.feature.character.levelup
 
 import androidx.activity.ComponentActivity
-import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.isToggleable
@@ -100,7 +99,9 @@ class CharacterLevelUpValidationReviewTest {
         composeTestRule.onNodeWithText(warning.message).assertExists()
         composeTestRule.onNodeWithText(exception.message).assertExists()
         composeTestRule.onNodeWithText(blocking.message).assertExists()
-        composeTestRule.onAllNodesWithText("Accepted rule exception").assertCountEquals(1)
+        assertThat(
+            composeTestRule.onAllNodesWithText("Accepted rule exception").fetchSemanticsNodes(),
+        ).hasSize(1)
         composeTestRule.onNodeWithText("Confirm level up").assertIsNotEnabled()
         assertThat(composeTestRule.onAllNodes(isToggleable()).fetchSemanticsNodes()).hasSize(1)
     }


### PR DESCRIPTION
Closes #164

## What changed
- add a dedicated review findings section for informational warnings and rule exceptions
- keep informational warnings passive while accepted exceptions remain explicit and actionable
- show affected class or target-level context for overrideable findings
- keep blocking validations outside the accepted-exception section
- omit the section when there are no warning or exception findings
- add focused Robolectric coverage for warning-only, exception-only, mixed, and empty cases

## Validation
- GitHub Actions run #389 passed `lintDebug`, unit/Robolectric tests, `assembleRelease`, and debug APK assembly.