### PR TITLE
Recalculate spell save DC and spell attack bonus after level-up

### DIFF
--- a/app/src/main/kotlin/com/github/arhor/spellbindr/data/repository/CharacterRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/data/repository/CharacterRepositoryImpl.kt
@@ -28,6 +28,7 @@ import com.github.arhor.spellbindr.domain.model.ManagedSpellGrantType
 import com.github.arhor.spellbindr.domain.model.Loadable
 import com.github.arhor.spellbindr.domain.model.ProgressionState
 import com.github.arhor.spellbindr.domain.model.SpellLearningPolicy
+import com.github.arhor.spellbindr.domain.model.calculateSpellcastingClassStats
 import com.github.arhor.spellbindr.domain.repository.CharacterRepository
 import com.github.arhor.spellbindr.domain.usecase.LevelUpProgressionEngine
 import com.github.arhor.spellbindr.utils.asLoadableFlow
@@ -351,6 +352,7 @@ class CharacterRepositoryImpl @Inject constructor(
                 savingThrowAbilityIds = after.savingThrowAbilityIds,
                 featureIds = after.featureIds,
                 languageIds = after.languageIds,
+                spellcastingClassStats = after.calculateSpellcastingClassStats(referenceData.classes),
                 spellGrants = updatedSpellGrants.mapTo(linkedSetOf()) { it.spell },
                 ownedSpellGrants = updatedSpellGrants,
             ),

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/domain/model/CharacterSheet.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/domain/model/CharacterSheet.kt
@@ -112,6 +112,8 @@ data class ManagedProgressionSheetState(
     val savingThrowAbilityIds: Set<AbilityId> = emptySet(),
     val featureIds: Set<String> = emptySet(),
     val languageIds: Set<String> = emptySet(),
+    /** Class-owned spellcasting values materialized from the latest managed progression state. */
+    val spellcastingClassStats: Map<String, SpellcastingClassStats> = emptyMap(),
     /** Legacy aggregate retained so older snapshots remain decodable. New writes also populate [ownedSpellGrants]. */
     val spellGrants: Set<ClassSpellRef> = emptySet(),
     /** One entry per permanent progression owner; overlapping grants intentionally remain distinct. */

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/domain/model/SpellcastingClassStats.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/domain/model/SpellcastingClassStats.kt
@@ -1,0 +1,36 @@
+package com.github.arhor.spellbindr.domain.model
+
+import kotlinx.serialization.Serializable
+
+/** Derived spellcasting values owned by one character class. */
+@Serializable
+data class SpellcastingClassStats(
+    val abilityId: AbilityId,
+    val spellSaveDc: Int,
+    val spellAttackBonus: Int,
+)
+
+/**
+ * Calculates per-class spellcasting values from a level-up snapshot.
+ *
+ * Multiclass characters intentionally keep one entry per spellcasting class so different casting abilities never
+ * bleed into one another. Classes are included only after their configured spellcasting acquisition level.
+ */
+fun LevelUpSnapshot.calculateSpellcastingClassStats(
+    classes: List<CharacterClass>,
+): Map<String, SpellcastingClassStats> {
+    val classesById = classes.associateBy(CharacterClass::id)
+    return classLevels.toSortedMap().mapNotNull { (classId, classLevel) ->
+        val spellcasting = classesById[classId]?.spellcasting ?: return@mapNotNull null
+        if (classLevel < spellcasting.level) return@mapNotNull null
+        val abilityId = spellcasting.spellcastingAbility.id.trim().lowercase()
+            .takeIf { it in AbilityIds.standardOrder }
+            ?: return@mapNotNull null
+        val abilityModifier = abilityScores.modifierFor(abilityId)
+        classId to SpellcastingClassStats(
+            abilityId = abilityId,
+            spellSaveDc = 8 + proficiencyBonus + abilityModifier,
+            spellAttackBonus = proficiencyBonus + abilityModifier,
+        )
+    }.toMap(linkedMapOf())
+}

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpClassProgressionReview.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpClassProgressionReview.kt
@@ -12,6 +12,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.github.arhor.spellbindr.domain.model.LevelUpRequirement
+import com.github.arhor.spellbindr.domain.model.SpellcastingClassStats
+import com.github.arhor.spellbindr.domain.model.calculateSpellcastingClassStats
 
 @Composable
 internal fun CharacterLevelUpClassProgressionReview(state: CharacterLevelUpUiState.Content) {
@@ -21,6 +23,8 @@ internal fun CharacterLevelUpClassProgressionReview(state: CharacterLevelUpUiSta
     val selectedClassName = selectedClassId?.let { classId ->
         state.classes.firstOrNull { it.id == classId }?.name ?: classId
     }
+    val beforeSpellcasting = before.calculateSpellcastingClassStats(state.classes)
+    val afterSpellcasting = after.calculateSpellcastingClassStats(state.classes)
 
     Surface(
         modifier = Modifier.fillMaxWidth(),
@@ -52,6 +56,27 @@ internal fun CharacterLevelUpClassProgressionReview(state: CharacterLevelUpUiSta
             selectedSubclassName(state, selectedClassId)?.let { subclassName ->
                 Text("New subclass: $subclassName", style = MaterialTheme.typography.bodyMedium)
             }
+            val spellcastingClassIds = (beforeSpellcasting.keys + afterSpellcasting.keys).toSortedSet()
+            if (spellcastingClassIds.isNotEmpty()) {
+                Text("Spellcasting", style = MaterialTheme.typography.titleSmall)
+                spellcastingClassIds.forEach { classId ->
+                    val className = state.classes.firstOrNull { it.id == classId }?.name ?: classId
+                    val beforeStats = beforeSpellcasting[classId]
+                    val afterStats = afterSpellcasting[classId]
+                    val ability = (afterStats ?: beforeStats)?.abilityId?.uppercase()
+                    val labelPrefix = ability?.let { "$className ($it)" } ?: className
+                    ClassProgressionReviewRow(
+                        label = "$labelPrefix spell save DC",
+                        before = beforeStats?.spellSaveDc?.toString().orMissing(),
+                        after = afterStats?.spellSaveDc?.toString().orMissing(),
+                    )
+                    ClassProgressionReviewRow(
+                        label = "$labelPrefix spell attack",
+                        before = beforeStats.formatAttackBonus(),
+                        after = afterStats.formatAttackBonus(),
+                    )
+                }
+            }
         }
     }
 }
@@ -78,5 +103,11 @@ private fun selectedSubclassName(
     val selectedSubclassId = requirement.selectedSubclassId ?: return null
     return requirement.options.firstOrNull { it.id == selectedSubclassId }?.label ?: selectedSubclassId
 }
+
+private fun SpellcastingClassStats?.formatAttackBonus(): String = this?.spellAttackBonus?.let { bonus ->
+    if (bonus >= 0) "+$bonus" else bonus.toString()
+} ?: "N/A"
+
+private fun String?.orMissing(): String = this ?: "N/A"
 
 private fun Int?.orZero(): Int = this ?: 0

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/sheet/CharacterSheetSpellCastingMappers.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/sheet/CharacterSheetSpellCastingMappers.kt
@@ -59,11 +59,17 @@ internal fun CharacterSheet.toSpellsState(
     val spellsBySource = spellEntries.groupBy { it.sourceKey }
     val classModels = spellsBySource
         .map { (sourceKey, spells) ->
-            val abilityId = spellcastingClasses.resolveSpellcastingAbility(sourceKey)
+            val spellcastingClass = spellcastingClasses.resolveSpellcastingClass(sourceKey)
+            val materializedStats = spellcastingClass?.id?.let { classId ->
+                managedProgression?.spellcastingClassStats?.get(classId)
+            }
+            val abilityId = materializedStats?.abilityId ?: spellcastingClass.resolveSpellcastingAbility()
             val abilityLabel = abilityId?.abbreviation()
             val abilityModifier = abilityId?.let(abilityScores::modifierFor)
-            val spellAttack = abilityModifier?.let { proficiencyBonus + it }
-            val spellDc = abilityModifier?.let { 8 + proficiencyBonus + it }
+            val spellAttack = materializedStats?.spellAttackBonus
+                ?: abilityModifier?.let { proficiencyBonus + it }
+            val spellDc = materializedStats?.spellSaveDc
+                ?: abilityModifier?.let { 8 + proficiencyBonus + it }
 
             val spellsByLevel = spells.groupBy { it.level }
             val spellLevels = buildList {
@@ -92,9 +98,7 @@ internal fun CharacterSheet.toSpellsState(
             val displayName = if (sourceKey == UNASSIGNED_SOURCE_KEY) {
                 ""
             } else {
-                spellcastingClasses.firstOrNull { clazz ->
-                    normalizeSourceKey(clazz.id) == sourceKey || normalizeSourceKey(clazz.name) == sourceKey
-                }?.name ?: spells.firstOrNull()?.sourceLabel?.ifBlank { null }
+                spellcastingClass?.name ?: spells.firstOrNull()?.sourceLabel?.ifBlank { null }
                 ?: formatSourceLabel(sourceKey)
             }
 
@@ -221,11 +225,14 @@ internal fun buildCastSlotOptions(
     }
 }
 
-private fun List<CharacterClass>.resolveSpellcastingAbility(sourceKey: String): AbilityId? {
-    val normalizedKey = sourceKey.trim().lowercase(Locale.ROOT)
-    val clazz = firstOrNull { it.id.equals(normalizedKey, ignoreCase = true) }
+private fun List<CharacterClass>.resolveSpellcastingClass(sourceKey: String): CharacterClass? {
+    val normalizedKey = normalizeSourceKey(sourceKey)
+    return firstOrNull { normalizeSourceKey(it.id) == normalizedKey }
         ?: firstOrNull { normalizeSourceKey(it.name) == normalizedKey }
-    val abilityId = clazz?.spellcasting?.spellcastingAbility?.id
+}
+
+private fun CharacterClass?.resolveSpellcastingAbility(): AbilityId? {
+    val abilityId = this?.spellcasting?.spellcastingAbility?.id
     return abilityId?.trim()?.lowercase(Locale.ROOT)?.takeIf { it in AbilityIds.standardOrder }
 }
 

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/data/repository/CharacterLevelUpSpellcastingStatsIntegrationTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/data/repository/CharacterLevelUpSpellcastingStatsIntegrationTest.kt
@@ -1,0 +1,210 @@
+package com.github.arhor.spellbindr.data.repository
+
+import androidx.room.Room
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.github.arhor.spellbindr.data.local.database.CharacterProgressionJsonCodec
+import com.github.arhor.spellbindr.data.local.database.SpellbindrDatabase
+import com.github.arhor.spellbindr.data.local.database.converter.CharacterSheetConverter
+import com.github.arhor.spellbindr.data.local.database.converter.EntityRefConverter
+import com.github.arhor.spellbindr.data.local.database.dao.CharacterDao
+import com.github.arhor.spellbindr.data.local.database.entity.CharacterEntity
+import com.github.arhor.spellbindr.data.mapper.toDomain
+import com.github.arhor.spellbindr.data.mapper.toEntity
+import com.github.arhor.spellbindr.data.mapper.toSnapshot
+import com.github.arhor.spellbindr.domain.model.AbilityIds
+import com.github.arhor.spellbindr.domain.model.AbilityScores
+import com.github.arhor.spellbindr.domain.model.ApplyLevelUpResult
+import com.github.arhor.spellbindr.domain.model.CharacterClass
+import com.github.arhor.spellbindr.domain.model.CharacterLevelRecord
+import com.github.arhor.spellbindr.domain.model.CharacterProgression
+import com.github.arhor.spellbindr.domain.model.CharacterSheet
+import com.github.arhor.spellbindr.domain.model.ClassLevel
+import com.github.arhor.spellbindr.domain.model.EntityRef
+import com.github.arhor.spellbindr.domain.model.HitPointGain
+import com.github.arhor.spellbindr.domain.model.LevelUpPlan
+import com.github.arhor.spellbindr.domain.model.LevelUpReferenceData
+import com.github.arhor.spellbindr.domain.model.LevelUpSelections
+import com.github.arhor.spellbindr.domain.model.MultiClassing
+import com.github.arhor.spellbindr.domain.model.ProgressionOrigin
+import com.github.arhor.spellbindr.domain.model.ProgressionState
+import com.github.arhor.spellbindr.domain.model.Spellcasting
+import com.github.arhor.spellbindr.domain.model.calculateSpellcastingClassStats
+import com.github.arhor.spellbindr.domain.usecase.LevelUpProgressionEngine
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class CharacterLevelUpSpellcastingStatsIntegrationTest {
+
+    private lateinit var database: SpellbindrDatabase
+    private lateinit var dao: CharacterDao
+    private lateinit var codec: CharacterProgressionJsonCodec
+    private lateinit var repository: CharacterRepositoryImpl
+
+    @Before
+    fun setUp() {
+        val json = Json {
+            ignoreUnknownKeys = true
+            classDiscriminator = "type"
+        }
+        database = Room.inMemoryDatabaseBuilder(
+            InstrumentationRegistry.getInstrumentation().targetContext,
+            SpellbindrDatabase::class.java,
+        )
+            .addTypeConverter(CharacterSheetConverter(json))
+            .addTypeConverter(EntityRefConverter(json))
+            .allowMainThreadQueries()
+            .build()
+        dao = database.characterDao()
+        codec = CharacterProgressionJsonCodec(json)
+        repository = CharacterRepositoryImpl(dao, codec, database)
+    }
+
+    @After
+    fun tearDown() {
+        database.close()
+    }
+
+    @Test
+    fun `apply level up should persist single class stats from resulting preview`() = runBlocking {
+        val arcanist = casterClass("arcanist", AbilityIds.INT, hitDie = 6)
+        val data = LevelUpReferenceData(
+            classes = listOf(arcanist),
+            features = emptyList(),
+            referenceDataVersion = REFERENCE_VERSION,
+        )
+        val progression = progression("arcanist", "arcanist", "arcanist", "arcanist")
+        val sheet = CharacterSheet(
+            id = CHARACTER_ID,
+            name = "Aster",
+            level = 4,
+            className = "Arcanist 4",
+            abilityScores = AbilityScores(intelligence = 16),
+        )
+        val plan = plan(expectedLevel = 4, selectedClassId = "arcanist", hitPointGain = 4)
+        seed(sheet, progression)
+        val preview = LevelUpProgressionEngine.rebuild(sheet, progression, plan, data)
+        val expectedStats = preview.after.calculateSpellcastingClassStats(data.classes)
+
+        val result = repository.applyLevelUp(CHARACTER_ID, 4, plan, data)
+        val stored = requireNotNull(dao.getCharacterWithProgression(CHARACTER_ID))
+            .character.manualSheet?.toDomain(CHARACTER_ID)
+
+        assertThat(result).isInstanceOf(ApplyLevelUpResult.Success::class.java)
+        requireNotNull(stored)
+        assertThat(expectedStats.getValue("arcanist").spellSaveDc).isEqualTo(14)
+        assertThat(expectedStats.getValue("arcanist").spellAttackBonus).isEqualTo(6)
+        assertThat(stored.managedProgression?.spellcastingClassStats).isEqualTo(expectedStats)
+        assertThat((result as ApplyLevelUpResult.Success).sheet.managedProgression?.spellcastingClassStats)
+            .isEqualTo(expectedStats)
+    }
+
+    @Test
+    fun `apply level up should persist separate multiclass spellcasting stats`() = runBlocking {
+        val arcanist = casterClass("arcanist", AbilityIds.INT, hitDie = 6)
+        val priest = casterClass("priest", AbilityIds.WIS, hitDie = 8)
+        val guardian = characterClass("guardian", hitDie = 10)
+        val data = LevelUpReferenceData(
+            classes = listOf(arcanist, priest, guardian),
+            features = emptyList(),
+            referenceDataVersion = REFERENCE_VERSION,
+        )
+        val progression = progression("arcanist", "priest", "guardian", "guardian")
+        val sheet = CharacterSheet(
+            id = CHARACTER_ID,
+            name = "Tamsin",
+            level = 4,
+            className = "Arcanist 1 / Priest 1 / Guardian 2",
+            abilityScores = AbilityScores(intelligence = 16, wisdom = 14),
+        )
+        val plan = plan(expectedLevel = 4, selectedClassId = "guardian", hitPointGain = 6)
+        seed(sheet, progression)
+        val preview = LevelUpProgressionEngine.rebuild(sheet, progression, plan, data)
+        val expectedStats = preview.after.calculateSpellcastingClassStats(data.classes)
+
+        val result = repository.applyLevelUp(CHARACTER_ID, 4, plan, data)
+        val stored = requireNotNull(dao.getCharacterWithProgression(CHARACTER_ID))
+            .character.manualSheet?.toDomain(CHARACTER_ID)
+
+        assertThat(result).isInstanceOf(ApplyLevelUpResult.Success::class.java)
+        requireNotNull(stored)
+        assertThat(expectedStats.keys).containsExactly("arcanist", "priest")
+        assertThat(expectedStats.getValue("arcanist").spellSaveDc).isEqualTo(14)
+        assertThat(expectedStats.getValue("arcanist").spellAttackBonus).isEqualTo(6)
+        assertThat(expectedStats.getValue("priest").spellSaveDc).isEqualTo(13)
+        assertThat(expectedStats.getValue("priest").spellAttackBonus).isEqualTo(5)
+        assertThat(stored.managedProgression?.spellcastingClassStats).isEqualTo(expectedStats)
+    }
+
+    private suspend fun seed(sheet: CharacterSheet, progression: CharacterProgression) {
+        dao.saveCharacterWithProgression(
+            character = CharacterEntity(
+                id = CHARACTER_ID,
+                name = sheet.name,
+                classes = progression.classLevels.mapKeys { EntityRef(it.key) },
+                manualSheet = sheet.toSnapshot(),
+            ),
+            progression = ProgressionState.Managed(progression).toEntity(CHARACTER_ID, codec),
+        )
+    }
+
+    private fun plan(
+        expectedLevel: Int,
+        selectedClassId: String,
+        hitPointGain: Int,
+    ): LevelUpPlan = LevelUpPlan(
+        expectedTotalLevel = expectedLevel,
+        rulesetId = CharacterProgression.SUPPORTED_RULESET_ID,
+        referenceDataVersion = REFERENCE_VERSION,
+        selectedClassId = selectedClassId,
+        selections = LevelUpSelections(hitPointGain = HitPointGain.Fixed(hitPointGain)),
+    )
+
+    private fun progression(vararg classIds: String): CharacterProgression = CharacterProgression(
+        referenceDataVersion = REFERENCE_VERSION,
+        origin = ProgressionOrigin.Guided,
+        levels = classIds.mapIndexed { index, classId ->
+            CharacterLevelRecord(
+                characterLevel = index + 1,
+                classId = classId,
+                classLevel = classIds.take(index + 1).count { it == classId },
+                hitPointGain = HitPointGain.Fixed(6),
+            )
+        },
+    )
+
+    private fun casterClass(
+        id: String,
+        abilityId: String,
+        hitDie: Int,
+    ): CharacterClass = characterClass(id, hitDie).copy(
+        spellcasting = Spellcasting(
+            info = emptyList(),
+            level = 1,
+            spellcastingAbility = EntityRef(abilityId),
+        ),
+    )
+
+    private fun characterClass(id: String, hitDie: Int): CharacterClass = CharacterClass(
+        id = id,
+        name = id.replaceFirstChar { it.uppercase() },
+        multiClassing = MultiClassing(),
+        hitDie = hitDie,
+        proficiencies = emptyList(),
+        proficiencyChoices = emptyList(),
+        savingThrows = emptyList(),
+        subclasses = emptyList(),
+        levels = (1..20).map { level -> ClassLevel("$id-$level", level, emptyList()) },
+    )
+
+    private companion object {
+        private const val CHARACTER_ID = "spellcasting-level-up"
+        private const val REFERENCE_VERSION = "test-v1"
+    }
+}

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/domain/usecase/LevelUpSpellcastingDerivedStatsTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/domain/usecase/LevelUpSpellcastingDerivedStatsTest.kt
@@ -1,0 +1,193 @@
+package com.github.arhor.spellbindr.domain.usecase
+
+import com.github.arhor.spellbindr.domain.model.AbilityIds
+import com.github.arhor.spellbindr.domain.model.AbilityScoreDecision
+import com.github.arhor.spellbindr.domain.model.AbilityScores
+import com.github.arhor.spellbindr.domain.model.CharacterClass
+import com.github.arhor.spellbindr.domain.model.CharacterLevelRecord
+import com.github.arhor.spellbindr.domain.model.CharacterProgression
+import com.github.arhor.spellbindr.domain.model.CharacterSheet
+import com.github.arhor.spellbindr.domain.model.ClassLevel
+import com.github.arhor.spellbindr.domain.model.ClassSpellRef
+import com.github.arhor.spellbindr.domain.model.EntityRef
+import com.github.arhor.spellbindr.domain.model.HitPointGain
+import com.github.arhor.spellbindr.domain.model.LevelSpellcasting
+import com.github.arhor.spellbindr.domain.model.LevelUpPlan
+import com.github.arhor.spellbindr.domain.model.LevelUpReferenceData
+import com.github.arhor.spellbindr.domain.model.LevelUpSelections
+import com.github.arhor.spellbindr.domain.model.MultiClassing
+import com.github.arhor.spellbindr.domain.model.ProgressionOrigin
+import com.github.arhor.spellbindr.domain.model.Spell
+import com.github.arhor.spellbindr.domain.model.SpellChanges
+import com.github.arhor.spellbindr.domain.model.Spellcasting
+import com.github.arhor.spellbindr.domain.model.calculateSpellcastingClassStats
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class LevelUpSpellcastingDerivedStatsTest {
+
+    @Test
+    fun `rebuild should update spell save dc and attack when proficiency bonus increases`() {
+        val progression = progression("wizard", "wizard", "wizard", "wizard")
+        val sheet = CharacterSheet(
+            id = "character",
+            level = 4,
+            abilityScores = AbilityScores(intelligence = 16),
+        )
+        val data = referenceData()
+        val preview = LevelUpProgressionEngine.rebuild(
+            sheet = sheet,
+            progression = progression,
+            plan = wizardPlan(
+                expectedLevel = 4,
+                addedSpellIds = setOf("shield", "magic-missile"),
+            ),
+            referenceData = data,
+        )
+
+        assertThat(preview.canConfirm).isTrue()
+        val before = preview.before.calculateSpellcastingClassStats(data.classes).getValue("wizard")
+        val after = preview.after.calculateSpellcastingClassStats(data.classes).getValue("wizard")
+        assertThat(before.abilityId).isEqualTo(AbilityIds.INT)
+        assertThat(before.spellSaveDc).isEqualTo(13)
+        assertThat(before.spellAttackBonus).isEqualTo(5)
+        assertThat(after.spellSaveDc).isEqualTo(14)
+        assertThat(after.spellAttackBonus).isEqualTo(6)
+    }
+
+    @Test
+    fun `rebuild should keep multiclass spellcasting abilities separate when one ability changes`() {
+        val progression = progression("wizard", "cleric", "wizard", "wizard")
+        val sheet = CharacterSheet(
+            id = "character",
+            level = 4,
+            abilityScores = AbilityScores(intelligence = 16, wisdom = 14),
+        )
+        val data = referenceData()
+        val preview = LevelUpProgressionEngine.rebuild(
+            sheet = sheet,
+            progression = progression,
+            plan = wizardPlan(
+                expectedLevel = 4,
+                addedSpellIds = setOf("shield", "magic-missile"),
+                abilityScoreDecision = AbilityScoreDecision.Increase(mapOf(AbilityIds.INT to 2)),
+            ),
+            referenceData = data,
+        )
+
+        assertThat(preview.canConfirm).isTrue()
+        val before = preview.before.calculateSpellcastingClassStats(data.classes)
+        val after = preview.after.calculateSpellcastingClassStats(data.classes)
+
+        assertThat(before.getValue("wizard").abilityId).isEqualTo(AbilityIds.INT)
+        assertThat(before.getValue("cleric").abilityId).isEqualTo(AbilityIds.WIS)
+        assertThat(before.getValue("wizard").spellSaveDc).isEqualTo(13)
+        assertThat(before.getValue("wizard").spellAttackBonus).isEqualTo(5)
+        assertThat(before.getValue("cleric").spellSaveDc).isEqualTo(12)
+        assertThat(before.getValue("cleric").spellAttackBonus).isEqualTo(4)
+
+        assertThat(after.getValue("wizard").spellSaveDc).isEqualTo(15)
+        assertThat(after.getValue("wizard").spellAttackBonus).isEqualTo(7)
+        assertThat(after.getValue("cleric").spellSaveDc).isEqualTo(13)
+        assertThat(after.getValue("cleric").spellAttackBonus).isEqualTo(5)
+    }
+
+    private fun wizardPlan(
+        expectedLevel: Int,
+        addedSpellIds: Set<String>,
+        abilityScoreDecision: AbilityScoreDecision? = null,
+    ): LevelUpPlan = LevelUpPlan(
+        expectedTotalLevel = expectedLevel,
+        rulesetId = CharacterProgression.SUPPORTED_RULESET_ID,
+        referenceDataVersion = REFERENCE_VERSION,
+        selectedClassId = "wizard",
+        selections = LevelUpSelections(
+            hitPointGain = HitPointGain.Fixed(4),
+            abilityScoreDecision = abilityScoreDecision,
+            spellChanges = SpellChanges(
+                addedToSpellbook = addedSpellIds.mapTo(linkedSetOf()) { spellId ->
+                    ClassSpellRef("wizard", spellId)
+                },
+            ),
+        ),
+    )
+
+    private fun progression(vararg classIds: String): CharacterProgression = CharacterProgression(
+        referenceDataVersion = REFERENCE_VERSION,
+        origin = ProgressionOrigin.Guided,
+        levels = classIds.mapIndexed { index, classId ->
+            CharacterLevelRecord(
+                characterLevel = index + 1,
+                classId = classId,
+                classLevel = classIds.take(index + 1).count { it == classId },
+                hitPointGain = HitPointGain.Fixed(if (index == 0) 6 else 4),
+            )
+        },
+    )
+
+    private fun referenceData(): LevelUpReferenceData = LevelUpReferenceData(
+        classes = listOf(
+            casterClass("wizard", AbilityIds.INT, includeLevelSpellcasting = true),
+            casterClass("cleric", AbilityIds.WIS),
+        ),
+        features = emptyList(),
+        spells = listOf("shield", "magic-missile").map(::wizardSpell),
+        referenceDataVersion = REFERENCE_VERSION,
+    )
+
+    private fun casterClass(
+        id: String,
+        abilityId: String,
+        includeLevelSpellcasting: Boolean = false,
+    ): CharacterClass = CharacterClass(
+        id = id,
+        name = id.replaceFirstChar { it.uppercase() },
+        multiClassing = MultiClassing(),
+        hitDie = 6,
+        proficiencies = emptyList(),
+        proficiencyChoices = emptyList(),
+        savingThrows = emptyList(),
+        spellcasting = Spellcasting(
+            info = emptyList(),
+            level = 1,
+            spellcastingAbility = EntityRef(abilityId),
+        ),
+        subclasses = emptyList(),
+        levels = (1..20).map { level ->
+            ClassLevel(
+                id = "$id-$level",
+                level = level,
+                features = emptyList(),
+                spellcasting = if (includeLevelSpellcasting) {
+                    LevelSpellcasting(
+                        cantrips = 0,
+                        spells = 0,
+                        spellSlots = mapOf("1" to 2),
+                    )
+                } else {
+                    null
+                },
+            )
+        },
+    )
+
+    private fun wizardSpell(id: String): Spell = Spell(
+        id = id,
+        name = id,
+        desc = emptyList(),
+        level = 1,
+        range = "Self",
+        ritual = false,
+        school = EntityRef("abjuration"),
+        duration = "Instantaneous",
+        castingTime = "1 action",
+        classes = listOf(EntityRef("wizard")),
+        components = emptyList(),
+        concentration = false,
+        source = "test",
+    )
+
+    private companion object {
+        private const val REFERENCE_VERSION = "test-v1"
+    }
+}

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/character/sheet/SpellsTabSpellcastingStatsTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/character/sheet/SpellsTabSpellcastingStatsTest.kt
@@ -1,0 +1,77 @@
+package com.github.arhor.spellbindr.ui.feature.character.sheet
+
+import com.github.arhor.spellbindr.domain.model.AbilityIds
+import com.github.arhor.spellbindr.domain.model.AbilityScores
+import com.github.arhor.spellbindr.domain.model.CharacterClass
+import com.github.arhor.spellbindr.domain.model.CharacterSheet
+import com.github.arhor.spellbindr.domain.model.CharacterSpell
+import com.github.arhor.spellbindr.domain.model.EntityRef
+import com.github.arhor.spellbindr.domain.model.ManagedProgressionSheetState
+import com.github.arhor.spellbindr.domain.model.Spellcasting
+import com.github.arhor.spellbindr.domain.model.SpellcastingClassStats
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class SpellsTabSpellcastingStatsTest {
+
+    @Test
+    fun `toSpellsState should display materialized managed spellcasting stats`() {
+        val wizard = wizardClass()
+        val sheet = CharacterSheet(
+            id = "character",
+            proficiencyBonus = 2,
+            abilityScores = AbilityScores(intelligence = 10),
+            characterSpells = listOf(CharacterSpell("shield", "Wizard")),
+            managedProgression = ManagedProgressionSheetState(
+                spellcastingClassStats = mapOf(
+                    "wizard" to SpellcastingClassStats(
+                        abilityId = AbilityIds.INT,
+                        spellSaveDc = 15,
+                        spellAttackBonus = 7,
+                    ),
+                ),
+            ),
+        )
+
+        val state = sheet.toSpellsState(allSpells = emptyList(), spellcastingClasses = listOf(wizard))
+
+        val spellcasting = state.spellcastingClasses.single()
+        assertThat(spellcasting.spellcastingAbility).isEqualTo("INT")
+        assertThat(spellcasting.spellSaveDc).isEqualTo(15)
+        assertThat(spellcasting.spellAttackBonus).isEqualTo(7)
+    }
+
+    @Test
+    fun `toSpellsState should retain derived fallback for unmanaged sheets`() {
+        val wizard = wizardClass()
+        val sheet = CharacterSheet(
+            id = "character",
+            proficiencyBonus = 3,
+            abilityScores = AbilityScores(intelligence = 16),
+            characterSpells = listOf(CharacterSpell("shield", "wizard")),
+        )
+
+        val state = sheet.toSpellsState(allSpells = emptyList(), spellcastingClasses = listOf(wizard))
+
+        val spellcasting = state.spellcastingClasses.single()
+        assertThat(spellcasting.spellcastingAbility).isEqualTo("INT")
+        assertThat(spellcasting.spellSaveDc).isEqualTo(14)
+        assertThat(spellcasting.spellAttackBonus).isEqualTo(6)
+    }
+
+    private fun wizardClass(): CharacterClass = CharacterClass(
+        id = "wizard",
+        name = "Wizard",
+        hitDie = 6,
+        proficiencies = emptyList(),
+        proficiencyChoices = emptyList(),
+        savingThrows = emptyList(),
+        spellcasting = Spellcasting(
+            info = emptyList(),
+            level = 1,
+            spellcastingAbility = EntityRef(AbilityIds.INT),
+        ),
+        subclasses = emptyList(),
+        levels = emptyList(),
+    )
+}


### PR DESCRIPTION
## Summary

- derive spell save DC and spell attack bonus per spellcasting class from the level-up snapshot's proficiency bonus and class casting ability
- materialize those values into managed character sheet state and use them on the Spells tab, while retaining the legacy/unmanaged fallback calculation
- show per-class spellcasting values in the level-up review so preview and persisted values use the same calculation
- add focused single-class, multiclass, persistence, and sheet-mapper coverage under `src/test`

## Validation

- GitHub Actions Build #393 passed: lint, unit tests, `testDebugUnitTest`, release assembly, and debug APK assembly
- no `androidTest` coverage added; new tests stay under the project's Robolectric-first `src/test` strategy

Closes #175