### PR TITLE
feat: show ability score changes in level-up review

### DIFF
--- a/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpAbilityScoreReview.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpAbilityScoreReview.kt
@@ -1,0 +1,70 @@
+package com.github.arhor.spellbindr.ui.feature.character.levelup
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.github.arhor.spellbindr.domain.model.AbilityIds
+import com.github.arhor.spellbindr.domain.model.AbilityScores
+import com.github.arhor.spellbindr.domain.model.displayName
+
+/** Shows only the ability scores whose values changed in the level-up preview. */
+@Composable
+internal fun CharacterLevelUpAbilityScoreReview(state: CharacterLevelUpUiState.Content) {
+    val before = state.preview.before.abilityScores
+    val after = state.preview.after.abilityScores
+    val changes = AbilityIds.standardOrder.mapNotNull { abilityId ->
+        val beforeScore = before.scoreForReview(abilityId)
+        val afterScore = after.scoreForReview(abilityId)
+        if (beforeScore == afterScore) {
+            null
+        } else {
+            AbilityScoreReviewChange(
+                abilityId = abilityId,
+                beforeScore = beforeScore,
+                afterScore = afterScore,
+                beforeModifier = before.modifierFor(abilityId),
+                afterModifier = after.modifierFor(abilityId),
+            )
+        }
+    }
+    if (changes.isEmpty()) return
+
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        Text("Ability scores", style = MaterialTheme.typography.titleSmall)
+        changes.forEach { change ->
+            Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+                Text(change.abilityId.displayName())
+                Text(
+                    "${change.beforeScore} (${change.beforeModifier.asModifier()}) → " +
+                        "${change.afterScore} (${change.afterModifier.asModifier()})",
+                )
+            }
+        }
+    }
+}
+
+private data class AbilityScoreReviewChange(
+    val abilityId: String,
+    val beforeScore: Int,
+    val afterScore: Int,
+    val beforeModifier: Int,
+    val afterModifier: Int,
+)
+
+private fun AbilityScores.scoreForReview(abilityId: String): Int = when (abilityId) {
+    AbilityIds.STR -> strength
+    AbilityIds.DEX -> dexterity
+    AbilityIds.CON -> constitution
+    AbilityIds.INT -> intelligence
+    AbilityIds.WIS -> wisdom
+    AbilityIds.CHA -> charisma
+    else -> error("Unknown ability id: $abilityId")
+}
+
+private fun Int.asModifier(): String = if (this >= 0) "+$this" else toString()

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpScreen.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpScreen.kt
@@ -257,6 +257,7 @@ private fun Content(state: CharacterLevelUpUiState.Content, dispatch: CharacterL
                 }
                 state.persistenceMessage?.let { WarningCard(it) }
                 CharacterLevelUpClassProgressionReview(state)
+                CharacterLevelUpAbilityScoreReview(state)
                 ReviewRow("Proficiency bonus", "+${state.preview.before.proficiencyBonus}", "+${state.preview.after.proficiencyBonus}")
                 CharacterLevelUpDurabilityReview(state)
                 CharacterLevelUpValidationReview(state, dispatch)

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpAbilityScoreReviewTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpAbilityScoreReviewTest.kt
@@ -1,0 +1,81 @@
+package com.github.arhor.spellbindr.ui.feature.character.levelup
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.arhor.spellbindr.domain.model.AbilityScores
+import com.github.arhor.spellbindr.domain.model.CharacterClass
+import com.github.arhor.spellbindr.domain.model.LevelUpPlan
+import com.github.arhor.spellbindr.domain.model.LevelUpPreview
+import com.github.arhor.spellbindr.domain.model.LevelUpSelections
+import com.github.arhor.spellbindr.domain.model.LevelUpSnapshot
+import com.github.arhor.spellbindr.ui.theme.AppTheme
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class CharacterLevelUpAbilityScoreReviewTest {
+
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun `review shows changed ability score and modifiers`() {
+        setContent(state(before = AbilityScores(strength = 15), after = AbilityScores(strength = 17)))
+
+        composeTestRule.onNodeWithText("Ability scores").assertExists()
+        composeTestRule.onNodeWithText("Strength").assertExists()
+        composeTestRule.onNodeWithText("15 (+2) → 17 (+3)").assertExists()
+        composeTestRule.onNodeWithText("Dexterity").assertDoesNotExist()
+    }
+
+    @Test
+    fun `review shows ability change produced by a feat`() {
+        setContent(state(before = AbilityScores(wisdom = 12), after = AbilityScores(wisdom = 13)))
+
+        composeTestRule.onNodeWithText("Wisdom").assertExists()
+        composeTestRule.onNodeWithText("12 (+1) → 13 (+1)").assertExists()
+    }
+
+    @Test
+    fun `review omits ability section when no scores changed`() {
+        setContent(state(before = AbilityScores(dexterity = 14), after = AbilityScores(dexterity = 14)))
+
+        composeTestRule.onNodeWithText("Ability scores").assertDoesNotExist()
+    }
+
+    private fun setContent(state: CharacterLevelUpUiState.Content) {
+        composeTestRule.setContent {
+            AppTheme { CharacterLevelUpScreen(state = state, dispatch = {}) }
+        }
+    }
+
+    private fun state(before: AbilityScores, after: AbilityScores) = CharacterLevelUpUiState.Content(
+        characterName = "Test hero",
+        plan = LevelUpPlan(1, "srd-5e-2014-v1", "test-v1", selections = LevelUpSelections()),
+        preview = LevelUpPreview(snapshot(before), snapshot(after), emptyList(), emptyList()),
+        classes = emptyList<CharacterClass>(),
+        feats = emptyList(),
+        spells = emptyList(),
+        steps = listOf(CharacterLevelUpStep.Review),
+        step = CharacterLevelUpStep.Review,
+        currentStepIndex = 0,
+    )
+
+    private fun snapshot(abilityScores: AbilityScores) = LevelUpSnapshot(
+        totalLevel = 1,
+        classLevels = emptyMap(),
+        classDisplayName = "Fighter 1",
+        proficiencyBonus = 2,
+        abilityScores = abilityScores,
+        maximumHitPoints = 1,
+        hitDicePools = emptyList(),
+        proficiencyIds = emptySet(),
+        savingThrowAbilityIds = emptySet(),
+        featureIds = emptySet(),
+        sharedCasterLevel = 0,
+        sharedSpellSlots = emptyMap(),
+    )
+}


### PR DESCRIPTION
Closes #160

## Summary
- show changed ability scores with before/after values and modifiers during level-up review
- omit the section when no ability scores changed
- add focused Compose/Robolectric coverage for ASI-style, feat-style, and no-change previews

## Validation
- ./gradlew :app:testDebugUnitTest --tests '*CharacterLevelUpAbilityScoreReviewTest' --stacktrace