### PR TITLE
fix: preserve distinct level-up finding acknowledgements

### DIFF
--- a/app/src/main/kotlin/com/github/arhor/spellbindr/domain/model/LevelUpPlan.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/domain/model/LevelUpPlan.kt
@@ -73,9 +73,11 @@ data class LevelUpValidationIssue(
     val code: LevelUpValidationCode,
     val message: String,
     val severity: LevelUpValidationSeverity,
+    /** Stable identity of this particular finding, when a code can occur more than once. */
+    val findingId: String? = null,
 ) {
     val acknowledgementId: String
-        get() = code.name
+        get() = findingId ?: code.name
 }
 
 @Serializable

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/domain/usecase/LevelUpProgressionEngine.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/domain/usecase/LevelUpProgressionEngine.kt
@@ -123,7 +123,9 @@ object LevelUpProgressionEngine {
         } ?: progression
         val before = snapshot(sheet.abilityScores, progression, referenceData)
         val after = snapshot(applyAbilityDecision(sheet.abilityScores, plan.selections, referenceData), afterProgression, referenceData)
-        return LevelUpPreview(before, after, requirements, validations.distinctBy { it.code to it.message })
+        return LevelUpPreview(before, after, requirements, validations.distinctBy {
+            Triple(it.code, it.message, it.findingId)
+        })
     }
 
     /** Creates the persisted record only after [rebuild] reports that confirmation is allowed. */
@@ -232,6 +234,7 @@ object LevelUpProgressionEngine {
                     validations += overrideable(
                         LevelUpValidationCode.MulticlassPrerequisite,
                         "Ability prerequisites for ${data.classesById[classId]?.name ?: classId} are not met.",
+                        findingId = "multiclass-prerequisite:$classId",
                     )
                 }
             }
@@ -243,6 +246,7 @@ object LevelUpProgressionEngine {
             validations += overrideable(
                 LevelUpValidationCode.ExperienceThreshold,
                 "${threshold - experience} more XP is normally required for level $targetLevel.",
+                findingId = "experience-threshold:$targetLevel",
             )
         }
     }
@@ -1622,6 +1626,9 @@ object LevelUpProgressionEngine {
     private fun blocking(code: LevelUpValidationCode, message: String) =
         LevelUpValidationIssue(code, message, LevelUpValidationSeverity.Blocking)
 
-    private fun overrideable(code: LevelUpValidationCode, message: String) =
-        LevelUpValidationIssue(code, message, LevelUpValidationSeverity.Overrideable)
+    private fun overrideable(
+        code: LevelUpValidationCode,
+        message: String,
+        findingId: String? = null,
+    ) = LevelUpValidationIssue(code, message, LevelUpValidationSeverity.Overrideable, findingId)
 }

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/domain/usecase/LevelUpProgressionEngineChoiceTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/domain/usecase/LevelUpProgressionEngineChoiceTest.kt
@@ -64,11 +64,16 @@ class LevelUpProgressionEngineChoiceTest {
             expectedLevel = 1,
             classId = "wizard",
             hitPoints = HitPointGain.Fixed(6),
-            selections = LevelUpSelections(acknowledgedIssueCodes = acknowledgements),
+            selections = LevelUpSelections(
+                hitPointGain = HitPointGain.Fixed(6),
+                acknowledgedIssueCodes = acknowledgements,
+            ),
         )
 
         val wizardPreview = LevelUpProgressionEngine.rebuild(sheet, progression("fighter"), wizardPlan, referenceData())
-        assertThat(wizardPreview.canConfirm).isTrue()
+        assertThat(wizardPreview.requirements.filterIsInstance<com.github.arhor.spellbindr.domain.model.LevelUpRequirement.Acknowledgement>()
+            .map { it.id })
+            .containsExactlyElementsIn(acknowledgements)
 
         val fighterPreview = LevelUpProgressionEngine.rebuild(
             sheet,

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/domain/usecase/LevelUpProgressionEngineChoiceTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/domain/usecase/LevelUpProgressionEngineChoiceTest.kt
@@ -63,7 +63,7 @@ class LevelUpProgressionEngineChoiceTest {
         val wizardPlan = plan(
             expectedLevel = 1,
             classId = "wizard",
-            hitPointGain = HitPointGain.Fixed(6),
+            hitPoints = HitPointGain.Fixed(6),
             selections = LevelUpSelections(acknowledgedIssueCodes = acknowledgements),
         )
 

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/domain/usecase/LevelUpProgressionEngineChoiceTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/domain/usecase/LevelUpProgressionEngineChoiceTest.kt
@@ -42,9 +42,45 @@ class LevelUpProgressionEngineChoiceTest {
                 LevelUpValidationCode.MulticlassPrerequisite,
                 "Ability prerequisites for Wizard are not met.",
                 LevelUpValidationSeverity.Overrideable,
+                "multiclass-prerequisite:wizard",
             ),
         )
         assertThat(preview.canConfirm).isFalse()
+    }
+
+    @Test
+    fun `changing selected class invalidates only the affected acknowledgement`() {
+        val sheet = CharacterSheet(
+            id = "character",
+            level = 1,
+            experiencePoints = 0,
+            abilityScores = AbilityScores(strength = 13, intelligence = 12),
+        )
+        val acknowledgements = setOf(
+            "multiclass-prerequisite:wizard",
+            "experience-threshold:2",
+        )
+        val wizardPlan = plan(
+            expectedLevel = 1,
+            classId = "wizard",
+            hitPointGain = HitPointGain.Fixed(6),
+            selections = LevelUpSelections(acknowledgedIssueCodes = acknowledgements),
+        )
+
+        val wizardPreview = LevelUpProgressionEngine.rebuild(sheet, progression("fighter"), wizardPlan, referenceData())
+        assertThat(wizardPreview.canConfirm).isTrue()
+
+        val fighterPreview = LevelUpProgressionEngine.rebuild(
+            sheet,
+            progression("fighter"),
+            wizardPlan.copy(selectedClassId = "fighter"),
+            referenceData(),
+        )
+        val activeAcknowledgements = fighterPreview.requirements
+            .filterIsInstance<com.github.arhor.spellbindr.domain.model.LevelUpRequirement.Acknowledgement>()
+            .map { it.id }
+        assertThat(activeAcknowledgements).containsExactly("experience-threshold:2")
+        assertThat(fighterPreview.canConfirm).isTrue()
     }
 
     @Test

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/domain/usecase/LevelUpProgressionEngineHardeningTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/domain/usecase/LevelUpProgressionEngineHardeningTest.kt
@@ -917,7 +917,12 @@ class LevelUpProgressionEngineTest {
     }
 
     private fun issue(code: LevelUpValidationCode, severity: LevelUpValidationSeverity) =
-        com.github.arhor.spellbindr.domain.model.LevelUpValidationIssue(code, "Ability prerequisites for Wizard are not met.", severity)
+        com.github.arhor.spellbindr.domain.model.LevelUpValidationIssue(
+            code,
+            "Ability prerequisites for Wizard are not met.",
+            severity,
+            "multiclass-prerequisite:wizard",
+        )
 
     private fun plan(
         expectedLevel: Int,

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/domain/usecase/LevelUpValidationSeverityTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/domain/usecase/LevelUpValidationSeverityTest.kt
@@ -102,10 +102,31 @@ class LevelUpValidationSeverityTest {
         assertThat(record.ruleAcknowledgements).containsExactly(overrideable.acknowledgementId)
     }
 
+    @Test
+    fun `duplicate validation codes retain independent stable acknowledgements`() {
+        val first = validation(
+            code = LevelUpValidationCode.MulticlassPrerequisite,
+            severity = LevelUpValidationSeverity.Overrideable,
+            findingId = "multiclass-prerequisite:fighter",
+        )
+        val second = validation(
+            code = LevelUpValidationCode.MulticlassPrerequisite,
+            severity = LevelUpValidationSeverity.Overrideable,
+            findingId = "multiclass-prerequisite:wizard",
+        )
+        val requirements = listOf(first, second).map {
+            LevelUpRequirement.Acknowledgement(it.acknowledgementId, it, acknowledged = true)
+        }
+
+        assertThat(first.acknowledgementId).isNotEqualTo(second.acknowledgementId)
+        assertThat(preview(listOf(first, second), requirements).canConfirm).isTrue()
+    }
+
     private fun validation(
         code: LevelUpValidationCode,
         severity: LevelUpValidationSeverity,
-    ) = LevelUpValidationIssue(code, "${severity.name} finding", severity)
+        findingId: String? = null,
+    ) = LevelUpValidationIssue(code, "${severity.name} finding", severity, findingId)
 
     private fun preview(
         validations: List<LevelUpValidationIssue>,


### PR DESCRIPTION
Closes #166

Adds stable deterministic acknowledgement identities for individual overrideable level-up findings. Duplicate validation codes now render and persist as separate acknowledgements, while edits only invalidate findings whose identities are no longer active.

Tests: `./gradlew :app:testDebugUnitTest --tests '*LevelUpValidationSeverityTest' --tests '*LevelUpProgressionEngineChoiceTest'` (blocked by a concurrent Gradle cache lock in the shared environment).