### PR TITLE
feat: require acknowledgement for manual hit points

### DIFF
--- a/app/src/main/kotlin/com/github/arhor/spellbindr/domain/model/LevelUpPlan.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/domain/model/LevelUpPlan.kt
@@ -58,6 +58,7 @@ enum class LevelUpValidationCode {
     InvalidChoice,
     HitPointGainRequired,
     InvalidHitPointGain,
+    ManualHitPointGainOverride,
     AbilityScoreDecisionRequired,
     InvalidAbilityScoreIncrease,
     FeatRequired,

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/domain/usecase/LevelUpProgressionEngine.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/domain/usecase/LevelUpProgressionEngine.kt
@@ -347,6 +347,15 @@ object LevelUpProgressionEngine {
             is HitPointGain.Manual -> gain.rolledValue >= 1
         }
         if (!isValid) validations += blocking(LevelUpValidationCode.InvalidHitPointGain, "The hit point gain is invalid.")
+        if (gain is HitPointGain.Manual && isValid) {
+            validations += LevelUpValidationIssue(
+                code = LevelUpValidationCode.ManualHitPointGainOverride,
+                message = "Manual hit point gain of ${gain.rolledValue} overrides the rules-derived fixed gain of " +
+                    "$expectedFixed or a rolled result from 1 to $hitDie.",
+                severity = LevelUpValidationSeverity.Overrideable,
+                findingId = "${LevelUpValidationCode.ManualHitPointGainOverride.name}:${gain.rolledValue}",
+            )
+        }
     }
 
     private fun validateAbilityDecision(

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/domain/usecase/LevelUpProgressionEngineCoreTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/domain/usecase/LevelUpProgressionEngineCoreTest.kt
@@ -13,12 +13,78 @@ import com.github.arhor.spellbindr.domain.model.LevelUpPlan
 import com.github.arhor.spellbindr.domain.model.LevelUpReferenceData
 import com.github.arhor.spellbindr.domain.model.LevelUpSelections
 import com.github.arhor.spellbindr.domain.model.LevelUpValidationCode
+import com.github.arhor.spellbindr.domain.model.LevelUpValidationSeverity
 import com.github.arhor.spellbindr.domain.model.MultiClassing
 import com.github.arhor.spellbindr.domain.model.ProgressionOrigin
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 
 class LevelUpProgressionEngineCoreTest {
+
+    @Test
+    fun `manual hit point gain is an overrideable finding tied to its value`() {
+        val manual = HitPointGain.Manual(14)
+        val preview = LevelUpProgressionEngine.rebuild(
+            CharacterSheet(id = "character", level = 1),
+            progression("fighter"),
+            plan(1, "fighter", manual),
+            referenceData(),
+        )
+
+        val finding = preview.validations.single { it.code == LevelUpValidationCode.ManualHitPointGainOverride }
+        assertThat(finding.severity).isEqualTo(LevelUpValidationSeverity.Overrideable)
+        assertThat(finding.message).contains("fixed gain of 6")
+        assertThat(finding.message).contains("rolled result from 1 to 10")
+        assertThat(finding.message).contains("14")
+        assertThat(finding.acknowledgementId).isEqualTo("ManualHitPointGainOverride:14")
+        assertThat(preview.canConfirm).isFalse()
+
+        val acknowledged = LevelUpProgressionEngine.rebuild(
+            CharacterSheet(id = "character", level = 1),
+            progression("fighter"),
+            plan(
+                1,
+                "fighter",
+                manual,
+                LevelUpSelections(
+                    hitPointGain = manual,
+                    acknowledgedIssueCodes = setOf(finding.acknowledgementId),
+                ),
+            ),
+            referenceData(),
+        )
+        assertThat(acknowledged.canConfirm).isTrue()
+
+        val edited = LevelUpProgressionEngine.rebuild(
+            CharacterSheet(id = "character", level = 1),
+            progression("fighter"),
+            plan(
+                1,
+                "fighter",
+                HitPointGain.Manual(15),
+                LevelUpSelections(
+                    hitPointGain = HitPointGain.Manual(15),
+                    acknowledgedIssueCodes = setOf(finding.acknowledgementId),
+                ),
+            ),
+            referenceData(),
+        )
+        assertThat(edited.canConfirm).isFalse()
+    }
+
+    @Test
+    fun `fixed and rolled hit point gains do not create an exception finding`() {
+        listOf(HitPointGain.Fixed(6), HitPointGain.Rolled(7)).forEach { gain ->
+            val preview = LevelUpProgressionEngine.rebuild(
+                CharacterSheet(id = "character", level = 1),
+                progression("fighter"),
+                plan(1, "fighter", gain),
+                referenceData(),
+            )
+            assertThat(preview.validations.map { it.code })
+                .doesNotContain(LevelUpValidationCode.ManualHitPointGainOverride)
+        }
+    }
 
     @Test
     fun `rebuild should derive the next level from ordered class history when returning to an earlier class`() {

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpValidationReviewTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpValidationReviewTest.kt
@@ -72,6 +72,19 @@ class CharacterLevelUpValidationReviewTest {
     }
 
     @Test
+    fun `manual hit point exception must be accepted before confirmation`() {
+        val exception = issue(
+            code = LevelUpValidationCode.ManualHitPointGainOverride,
+            message = "Manual hit point gain of 14 overrides the rules-derived fixed gain of 6 or a rolled result from 1 to 10.",
+            severity = LevelUpValidationSeverity.Overrideable,
+        )
+
+        setContent(reviewState(validations = listOf(exception)))
+        composeTestRule.onNodeWithText(exception.message).assertExists()
+        composeTestRule.onNodeWithText("Confirm level up").assertIsNotEnabled()
+    }
+
+    @Test
     fun `mixed review should keep blocking error outside accepted exceptions`() {
         val warning = issue(
             code = LevelUpValidationCode.ExperienceThreshold,


### PR DESCRIPTION
Closes #167

## What changed

- Add a value-specific overrideable validation finding for positive manual hit-point gains.
- Explain the fixed and rolled alternatives alongside the entered manual value.
- Require acknowledgement before confirmation; changing the manual value invalidates the previous acknowledgement.
- Keep fixed and rolled hit-point methods free of exception findings.
- Add focused engine and UI coverage.

## Validation

- `./gradlew :app:testDebugUnitTest --tests '*LevelUpProgressionEngineCoreTest'`
- `./gradlew :app:testDebugUnitTest --tests '*CharacterLevelUpValidationReviewTest'`