### PR TITLE
feat: show spell slot changes in level-up review

### DIFF
--- a/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpClassProgressionReview.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpClassProgressionReview.kt
@@ -80,6 +80,7 @@ internal fun CharacterLevelUpClassProgressionReview(state: CharacterLevelUpUiSta
             MagicInitiateReview(state)
         }
     }
+    CharacterLevelUpSpellSlotReview(state)
 }
 
 @Composable

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpSpellSlotReview.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpSpellSlotReview.kt
@@ -1,0 +1,85 @@
+package com.github.arhor.spellbindr.ui.feature.character.levelup
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+@Composable
+internal fun CharacterLevelUpSpellSlotReview(state: CharacterLevelUpUiState.Content) {
+    val before = state.preview.before
+    val after = state.preview.after
+    val changedSharedSlots = (before.sharedSpellSlots.keys + after.sharedSpellSlots.keys)
+        .toSortedSet()
+        .filter { level -> before.sharedSpellSlots[level].orZero() != after.sharedSpellSlots[level].orZero() }
+    val pactCountChanged = before.pactMagic?.slots.orZero() != after.pactMagic?.slots.orZero()
+    val pactLevelChanged = before.pactMagic?.slotLevel != after.pactMagic?.slotLevel
+
+    if (changedSharedSlots.isEmpty() && !pactCountChanged && !pactLevelChanged) return
+
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = MaterialTheme.shapes.medium,
+        tonalElevation = 1.dp,
+    ) {
+        Column(
+            modifier = Modifier.padding(12.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Text("Spell slots", style = MaterialTheme.typography.titleSmall)
+            changedSharedSlots.forEach { level ->
+                SpellSlotReviewRow(
+                    label = "${level.ordinalLabel()} shared slots",
+                    before = before.sharedSpellSlots[level].orZero().toString(),
+                    after = after.sharedSpellSlots[level].orZero().toString(),
+                )
+            }
+            if (pactCountChanged || pactLevelChanged) {
+                Text("Pact Magic", style = MaterialTheme.typography.bodyMedium)
+                if (pactCountChanged) {
+                    SpellSlotReviewRow(
+                        label = "Pact Magic slots",
+                        before = before.pactMagic?.slots.orZero().toString(),
+                        after = after.pactMagic?.slots.orZero().toString(),
+                    )
+                }
+                if (pactLevelChanged) {
+                    SpellSlotReviewRow(
+                        label = "Pact Magic slot level",
+                        before = before.pactMagic?.slotLevel?.ordinalLabel() ?: "N/A",
+                        after = after.pactMagic?.slotLevel?.ordinalLabel() ?: "N/A",
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SpellSlotReviewRow(label: String, before: String, after: String) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Text(label)
+        Text("$before → $after")
+    }
+}
+
+private fun Int?.orZero(): Int = this ?: 0
+
+private fun Int.ordinalLabel(): String = when (this % 100) {
+    11, 12, 13 -> "${this}th-level"
+    else -> when (this % 10) {
+        1 -> "${this}st-level"
+        2 -> "${this}nd-level"
+        3 -> "${this}rd-level"
+        else -> "${this}th-level"
+    }
+}

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpClassProgressionReviewTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpClassProgressionReviewTest.kt
@@ -91,9 +91,94 @@ class CharacterLevelUpClassProgressionReviewTest {
         // Then
         composeTestRule.onNodeWithText("4 → 5").assertExists()
         composeTestRule.onNodeWithText("Wizard level").assertExists()
-        composeTestRule.onNodeWithText("1 → 2").assertExists()
+        assertThat(composeTestRule.onAllNodesWithText("1 → 2").fetchSemanticsNodes()).isNotEmpty()
         composeTestRule.onNodeWithText("Fighter 3 / Wizard 1 → Fighter 3 / Wizard 2").assertExists()
         composeTestRule.onNodeWithText("New subclass", substring = true).assertDoesNotExist()
+    }
+
+    @Test
+    fun `CharacterLevelUpScreen should show only changed shared spell slots for single-class level-up`() {
+        val wizard = characterClass("wizard", "Wizard")
+        setContent(
+            reviewState(
+                selectedClassId = wizard.id,
+                classes = listOf(wizard),
+                before = snapshot(
+                    totalLevel = 4,
+                    classLevels = mapOf(wizard.id to 4),
+                    classDisplayName = "Wizard 4",
+                    sharedSpellSlots = mapOf(1 to 4, 2 to 3),
+                ),
+                after = snapshot(
+                    totalLevel = 5,
+                    classLevels = mapOf(wizard.id to 5),
+                    classDisplayName = "Wizard 5",
+                    sharedSpellSlots = mapOf(1 to 4, 2 to 3, 3 to 2),
+                ),
+            ),
+        )
+
+        composeTestRule.onNodeWithText("Spell slots").assertExists()
+        composeTestRule.onNodeWithText("3rd-level shared slots").assertExists()
+        composeTestRule.onNodeWithText("1st-level shared slots").assertDoesNotExist()
+        composeTestRule.onNodeWithText("2nd-level shared slots").assertDoesNotExist()
+        composeTestRule.onNodeWithText("0 → 2").assertExists()
+    }
+
+    @Test
+    fun `CharacterLevelUpScreen should show changed shared spell slots for multiclass level-up`() {
+        val cleric = characterClass("cleric", "Cleric")
+        val wizard = characterClass("wizard", "Wizard")
+        setContent(
+            reviewState(
+                selectedClassId = wizard.id,
+                classes = listOf(cleric, wizard),
+                before = snapshot(
+                    totalLevel = 2,
+                    classLevels = mapOf(cleric.id to 1, wizard.id to 1),
+                    classDisplayName = "Cleric 1 / Wizard 1",
+                    sharedSpellSlots = mapOf(1 to 3),
+                ),
+                after = snapshot(
+                    totalLevel = 3,
+                    classLevels = mapOf(cleric.id to 1, wizard.id to 2),
+                    classDisplayName = "Cleric 1 / Wizard 2",
+                    sharedSpellSlots = mapOf(1 to 3, 2 to 2),
+                ),
+            ),
+        )
+
+        composeTestRule.onNodeWithText("2nd-level shared slots").assertExists()
+        composeTestRule.onNodeWithText("1st-level shared slots").assertDoesNotExist()
+        composeTestRule.onNodeWithText("0 → 2").assertExists()
+    }
+
+    @Test
+    fun `CharacterLevelUpScreen should show Pact Magic count and level separately`() {
+        val warlock = characterClass("warlock", "Warlock")
+        setContent(
+            reviewState(
+                selectedClassId = warlock.id,
+                classes = listOf(warlock),
+                before = snapshot(
+                    totalLevel = 1,
+                    classLevels = mapOf(warlock.id to 1),
+                    classDisplayName = "Warlock 1",
+                    pactMagic = com.github.arhor.spellbindr.domain.model.LevelUpPactMagicCapacity(1, 1),
+                ),
+                after = snapshot(
+                    totalLevel = 2,
+                    classLevels = mapOf(warlock.id to 2),
+                    classDisplayName = "Warlock 2",
+                    pactMagic = com.github.arhor.spellbindr.domain.model.LevelUpPactMagicCapacity(1, 2),
+                ),
+            ),
+        )
+
+        composeTestRule.onNodeWithText("Pact Magic").assertExists()
+        composeTestRule.onNodeWithText("Pact Magic slots").assertExists()
+        assertThat(composeTestRule.onAllNodesWithText("1 → 2").fetchSemanticsNodes()).isNotEmpty()
+        composeTestRule.onNodeWithText("Pact Magic slot level").assertDoesNotExist()
     }
 
     private fun setContent(state: CharacterLevelUpUiState.Content) {
@@ -141,6 +226,8 @@ class CharacterLevelUpClassProgressionReviewTest {
         totalLevel: Int,
         classLevels: Map<String, Int>,
         classDisplayName: String,
+        sharedSpellSlots: Map<Int, Int> = emptyMap(),
+        pactMagic: com.github.arhor.spellbindr.domain.model.LevelUpPactMagicCapacity? = null,
     ) = LevelUpSnapshot(
         totalLevel = totalLevel,
         classLevels = classLevels,
@@ -153,7 +240,8 @@ class CharacterLevelUpClassProgressionReviewTest {
         savingThrowAbilityIds = emptySet(),
         featureIds = emptySet(),
         sharedCasterLevel = 0,
-        sharedSpellSlots = emptyMap(),
+        sharedSpellSlots = sharedSpellSlots,
+        pactMagic = pactMagic,
     )
 
     private fun characterClass(id: String, name: String) = CharacterClass(


### PR DESCRIPTION
## Summary

- Show changed shared spell-slot capacities by slot level in the level-up review.
- Show Pact Magic slot count and slot level separately.
- Omit unchanged capacities.
- Add focused Robolectric-backed Compose coverage for single-class, multiclass, and warlock reviews.

Closes #163

## Validation

- `./gradlew :app:testDebugUnitTest --tests '*CharacterLevelUpClassProgressionReviewTest'`
- `./gradlew :app:testDebugUnitTest`