### PR TITLE
feat: show level-up gains in review

### DIFF
--- a/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpChangesReview.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpChangesReview.kt
@@ -1,0 +1,94 @@
+package com.github.arhor.spellbindr.ui.feature.character.levelup
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.github.arhor.spellbindr.domain.model.AbilityIds
+import com.github.arhor.spellbindr.domain.model.LevelUpChoiceCategory
+import com.github.arhor.spellbindr.domain.model.LevelUpRequirement
+import com.github.arhor.spellbindr.domain.model.Skill
+
+/** Shows only the permanent grants introduced by the pending level-up. */
+@Composable
+internal fun CharacterLevelUpChangesReview(state: CharacterLevelUpUiState.Content) {
+    val before = state.preview.before
+    val after = state.preview.after
+    val addedProficiencies = after.proficiencyIds - before.proficiencyIds
+    val addedSaves = after.savingThrowAbilityIds - before.savingThrowAbilityIds
+    val addedLanguages = after.languageIds - before.languageIds
+    val addedFeatures = after.featureIds - before.featureIds
+    val selectedOptions = state.preview.requirements
+        .filterIsInstance<LevelUpRequirement.ChoiceSelection>()
+        .flatMap { requirement ->
+            requirement.options.filter { it.id in requirement.selectedOptionIds }
+                .map { option -> requirement to option.label }
+        }
+    if (addedProficiencies.isEmpty() && addedSaves.isEmpty() && addedLanguages.isEmpty() &&
+        addedFeatures.isEmpty() && selectedOptions.isEmpty()
+    ) return
+
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = MaterialTheme.shapes.medium,
+        tonalElevation = 1.dp,
+    ) {
+        Column(modifier = Modifier.padding(12.dp), verticalArrangement = Arrangement.spacedBy(6.dp)) {
+            Text("New gains", style = MaterialTheme.typography.titleSmall)
+            ProficiencyGroup("Skills", addedProficiencies.filter { it.startsWith("skill-") }.map(::skillName))
+            ProficiencyGroup("Saving throws", addedSaves.map { it.uppercase() })
+            ProficiencyGroup("Armor", addedProficiencies.filter { it.startsWith("armor-") }.map(::idName))
+            ProficiencyGroup("Weapons", addedProficiencies.filter { it.startsWith("weapon-") }.map(::idName))
+            ProficiencyGroup("Tools", addedProficiencies.filter { it.startsWith("tool-") }.map(::idName))
+            ProficiencyGroup("Languages", addedLanguages.map(::idName))
+
+            val selectedClass = state.classes.firstOrNull { it.id == state.plan.selectedClassId }
+            val subclass = selectedClass?.subclasses?.firstOrNull {
+                it.id == state.plan.selections.subclassId
+            }
+            val subclassFeatureIds = subclass?.levels.orEmpty().flatMap { it.features }.toSet()
+            val featureNames = addedFeatures.map { id ->
+                val name = state.features.firstOrNull { it.id == id }?.name ?: idName(id)
+                when {
+                    id in subclassFeatureIds && subclass != null -> "$name (${subclass.name})"
+                    selectedClass != null -> "$name (${selectedClass.name})"
+                    else -> name
+                }
+            }
+            ProficiencyGroup("Class or subclass features", featureNames)
+            if (selectedOptions.isNotEmpty()) {
+                Text("Selected feature options", style = MaterialTheme.typography.labelLarge)
+                selectedOptions.forEach { (requirement, label) ->
+                    val kind = when (requirement.category) {
+                        LevelUpChoiceCategory.Feature -> "Feature"
+                        LevelUpChoiceCategory.Proficiency -> "Proficiency"
+                        LevelUpChoiceCategory.Feat -> "Feat"
+                    }
+                    Text("$label ($kind)")
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ProficiencyGroup(title: String, values: List<String>) {
+    if (values.isEmpty()) return
+    Text(title, style = MaterialTheme.typography.labelLarge)
+    values.distinct().sorted().forEach { Text(it) }
+}
+
+private fun skillName(id: String): String {
+    val skillId = id.removePrefix("skill-")
+    return Skill.entries.firstOrNull { it.name.equals(skillId.replace('-', '_'), ignoreCase = true) }
+        ?.displayName ?: idName(id)
+}
+
+private fun idName(id: String): String = id.substringAfter('-').replace('-', ' ')
+    .replaceFirstChar { it.uppercase() }

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpScreen.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpScreen.kt
@@ -259,6 +259,7 @@ private fun Content(state: CharacterLevelUpUiState.Content, dispatch: CharacterL
                 CharacterLevelUpClassProgressionReview(state)
                 CharacterLevelUpAbilityScoreReview(state)
                 CharacterLevelUpSpellChangesReview(state)
+                CharacterLevelUpChangesReview(state)
                 ReviewRow("Proficiency bonus", "+${state.preview.before.proficiencyBonus}", "+${state.preview.after.proficiencyBonus}")
                 CharacterLevelUpDurabilityReview(state)
                 CharacterLevelUpValidationReview(state, dispatch)

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpUiState.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpUiState.kt
@@ -62,6 +62,7 @@ sealed interface CharacterLevelUpUiState {
         val isSaving: Boolean = false,
         val staleMessage: String? = null,
         val persistenceMessage: String? = null,
+        val features: List<com.github.arhor.spellbindr.domain.model.Feature> = emptyList(),
     ) : CharacterLevelUpUiState {
         val isReview: Boolean get() = step == CharacterLevelUpStep.Review
         val canConfirm: Boolean get() = isReview && preview.canConfirm && !isSaving

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpViewModel.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpViewModel.kt
@@ -188,6 +188,7 @@ class CharacterLevelUpViewModel @Inject constructor(
                 restoredDraft?.isSaving == true,
                 restoredDraft?.staleMessage,
                 restoredDraft?.persistenceMessage,
+                source.reference.features,
             )
         }
         }

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpChangesReviewTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpChangesReviewTest.kt
@@ -1,0 +1,105 @@
+package com.github.arhor.spellbindr.ui.feature.character.levelup
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.arhor.spellbindr.domain.model.AbilityScores
+import com.github.arhor.spellbindr.domain.model.CharacterClass
+import com.github.arhor.spellbindr.domain.model.Choice
+import com.github.arhor.spellbindr.domain.model.Feature
+import com.github.arhor.spellbindr.domain.model.LevelUpChoiceCategory
+import com.github.arhor.spellbindr.domain.model.LevelUpChoiceOption
+import com.github.arhor.spellbindr.domain.model.LevelUpPlan
+import com.github.arhor.spellbindr.domain.model.LevelUpPreview
+import com.github.arhor.spellbindr.domain.model.LevelUpRequirement
+import com.github.arhor.spellbindr.domain.model.LevelUpSnapshot
+import com.github.arhor.spellbindr.ui.theme.AppTheme
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class CharacterLevelUpChangesReviewTest {
+    @get:Rule val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun `review shows only automatic additions grouped and selected feature option`() {
+        val before = snapshot(
+            proficiencyIds = setOf("skill-stealth"),
+            savingThrows = emptySet(),
+            languages = emptySet(),
+            features = setOf("existing"),
+        )
+        val after = before.copy(
+            proficiencyIds = before.proficiencyIds + setOf("skill-perception", "armor-shields", "weapon-martial"),
+            savingThrowAbilityIds = setOf("wisdom"),
+            languageIds = setOf("common"),
+            featureIds = before.featureIds + "second-wind",
+        )
+        val requirement = LevelUpRequirement.ChoiceSelection(
+            id = "second-wind:choice",
+            sourceId = "second-wind",
+            label = "Second Wind option",
+            choice = Choice.ProficiencyChoice(choose = 1, from = listOf("tool-thieves")),
+            selectedOptionIds = setOf("tool-thieves"),
+            category = LevelUpChoiceCategory.Feature,
+            options = listOf(LevelUpChoiceOption("tool-thieves", "Thieves' tools")),
+        )
+        val state = CharacterLevelUpUiState.Content(
+            characterName = "Hero",
+            plan = LevelUpPlan(2, "srd-5e-2014-v1", "test-v1", selectedClassId = "fighter"),
+            preview = LevelUpPreview(before, after, listOf(requirement), emptyList()),
+            classes = listOf(characterClass()),
+            feats = emptyList(),
+            spells = emptyList(),
+            steps = listOf(CharacterLevelUpStep.Review),
+            step = CharacterLevelUpStep.Review,
+            currentStepIndex = 0,
+            features = listOf(Feature("second-wind", "Second Wind", emptyList())),
+        )
+
+        composeTestRule.setContent { AppTheme { CharacterLevelUpScreen(state, {}) } }
+
+        composeTestRule.onNodeWithText("New gains").assertExists()
+        composeTestRule.onNodeWithText("Skills").assertExists()
+        composeTestRule.onNodeWithText("Perception").assertExists()
+        composeTestRule.onNodeWithText("Saving throws").assertExists()
+        composeTestRule.onNodeWithText("WISDOM").assertExists()
+        composeTestRule.onNodeWithText("Armor").assertExists()
+        composeTestRule.onNodeWithText("Shields").assertExists()
+        composeTestRule.onNodeWithText("Languages").assertExists()
+        composeTestRule.onNodeWithText("Common").assertExists()
+        composeTestRule.onNodeWithText("Class or subclass features").assertExists()
+        composeTestRule.onNodeWithText("Selected feature options").assertExists()
+        composeTestRule.onNodeWithText("Thieves' tools (Feature)").assertExists()
+        composeTestRule.onNodeWithText("Stealth").assertDoesNotExist()
+    }
+
+    private fun snapshot(
+        proficiencyIds: Set<String> = emptySet(),
+        savingThrows: Set<String> = emptySet(),
+        languages: Set<String> = emptySet(),
+        features: Set<String> = emptySet(),
+    ) = LevelUpSnapshot(
+        totalLevel = 1,
+        classLevels = mapOf("fighter" to 1),
+        classDisplayName = "Fighter 1",
+        proficiencyBonus = 2,
+        abilityScores = AbilityScores(),
+        maximumHitPoints = 10,
+        hitDicePools = emptyList(),
+        proficiencyIds = proficiencyIds,
+        savingThrowAbilityIds = savingThrows,
+        featureIds = features,
+        sharedCasterLevel = 0,
+        sharedSpellSlots = emptyMap(),
+        languageIds = languages,
+    )
+
+    private fun characterClass() = CharacterClass(
+        id = "fighter", name = "Fighter", hitDie = 10,
+        proficiencies = emptyList(), proficiencyChoices = emptyList(), savingThrows = emptyList(),
+        subclasses = emptyList(), levels = emptyList(),
+    )
+}


### PR DESCRIPTION
## Summary
- show only pending level-up proficiency, language, and feature additions grouped by category
- label class/subclass ownership and distinguish selected options
- add focused Robolectric Compose coverage

## Validation
- `./gradlew :app:testDebugUnitTest --tests '*CharacterLevelUpChangesReviewTest'`

Closes #161