### PR TITLE
feat: support Martial Adept maneuver choices

### DIFF
--- a/app/src/main/assets/data/feats.json
+++ b/app/src/main/assets/data/feats.json
@@ -432,6 +432,16 @@
       "- You learn two maneuvers of your choice from among those available to the Battle Master archetype in the fighter class. If a maneuver you use requires your target to make a saving throw to resist the maneuver's effects, the saving throw DC equals 8 + your proficiency bonus + your Strength or Dexterity modifier (your choice).",
       "- If you already have a superiority dice, you gain one more; otherwise, you have one superiority die, which is a d6. This die is used to fuel your maneuvers. A superiority die is expended when you use it. You regain your expended superiority dice when you finish a short or long rest."
     ],
+    "maneuverChoice": {
+      "choose": 2,
+      "from": [
+        "ambush", "bait-and-switch", "brace", "commander's-strike", "commanding-presence",
+        "disarming-attack", "distracting-strike", "evasive-footwork", "feinting-attack",
+        "goading-attack", "lunging-attack", "maneuvering-attack", "menacing-attack",
+        "parry", "precision-attack", "pushing-attack", "rally", "riposte", "sweeping-attack",
+        "tactical-assessment", "trip-attack"
+      ]
+    },
     "prerequisites": []
   },
   {

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/data/repository/CharacterRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/data/repository/CharacterRepositoryImpl.kt
@@ -23,6 +23,7 @@ import com.github.arhor.spellbindr.domain.model.LevelUpValidationCode
 import com.github.arhor.spellbindr.domain.model.LevelUpValidationIssue
 import com.github.arhor.spellbindr.domain.model.LevelUpValidationSeverity
 import com.github.arhor.spellbindr.domain.model.ManagedProgressionSheetState
+import com.github.arhor.spellbindr.domain.model.ManagedResource
 import com.github.arhor.spellbindr.domain.model.ManagedSpellGrant
 import com.github.arhor.spellbindr.domain.model.ManagedSpellGrantType
 import com.github.arhor.spellbindr.domain.model.Loadable
@@ -355,6 +356,18 @@ class CharacterRepositoryImpl @Inject constructor(
                 spellcastingClassStats = after.calculateSpellcastingClassStats(referenceData.classes),
                 spellGrants = updatedSpellGrants.mapTo(linkedSetOf()) { it.spell },
                 ownedSpellGrants = updatedSpellGrants,
+                resources = after.resources.map { resource ->
+                    val prior = managedProgression?.resources.orEmpty().firstOrNull { it.id == resource.id }
+                    ManagedResource(
+                        ownerKey = "progression:feat:martial-adept",
+                        id = resource.id,
+                        name = resource.name,
+                        maximum = resource.maximum,
+                        recovery = resource.recovery,
+                        expended = prior?.expended.orZero().coerceIn(0, resource.maximum),
+                    )
+                },
+                featManeuvers = after.featManeuvers,
             ),
         )
     }

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/domain/model/CharacterSheet.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/domain/model/CharacterSheet.kt
@@ -118,6 +118,18 @@ data class ManagedProgressionSheetState(
     val spellGrants: Set<ClassSpellRef> = emptySet(),
     /** One entry per permanent progression owner; overlapping grants intentionally remain distinct. */
     val ownedSpellGrants: List<ManagedSpellGrant> = emptyList(),
+    val resources: List<ManagedResource> = emptyList(),
+    val featManeuvers: Map<String, Set<String>> = emptyMap(),
+)
+
+@Serializable
+data class ManagedResource(
+    val ownerKey: String,
+    val id: String,
+    val name: String,
+    val maximum: Int,
+    val recovery: ResourceRecovery = ResourceRecovery.ShortOrLongRest,
+    val expended: Int = 0,
 )
 
 @Serializable

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/domain/model/Feat.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/domain/model/Feat.kt
@@ -19,6 +19,8 @@ data class Feat(
     val languageChoice: Choice.ResourceListChoice? = null,
     val proficiencyChoice: Choice.OptionsArrayChoice? = null,
     val damageTypeChoice: Choice.OptionsArrayChoice? = null,
+    /** Choices owned by Martial Adept (and future maneuver-granting feats). */
+    val maneuverChoice: Choice.OptionsArrayChoice? = null,
     val correlatesAbilityAndSavingThrow: Boolean = false,
     val repeatable: Boolean = false,
 ) {
@@ -35,6 +37,9 @@ data class Feat(
     val damageTypeChoiceId: String?
         get() = damageTypeChoice?.let { "$id:damage-type" }
 
+    val maneuverChoiceId: String?
+        get() = maneuverChoice?.let { "$id:maneuvers" }
+
     val correlatedAbilitySavingThrowChoiceId: String?
         get() = takeIf { correlatesAbilityAndSavingThrow }?.let { "$id:ability-and-saving-throw" }
 
@@ -47,6 +52,7 @@ data class Feat(
                 languageChoiceId,
                 proficiencyChoiceId,
                 damageTypeChoiceId,
+                maneuverChoiceId,
             )
         }
 }

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/domain/model/LevelUpPlan.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/domain/model/LevelUpPlan.kt
@@ -241,7 +241,21 @@ data class LevelUpSnapshot(
     /** Pact Magic never contributes to the shared multiclass slot table. */
     val pactMagic: LevelUpPactMagicCapacity? = null,
     val languageIds: Set<String> = emptySet(),
+    /** Maneuvers selected by each feat owner, keyed by the stable feat id. */
+    val featManeuvers: Map<String, Set<String>> = emptyMap(),
+    val resources: List<LevelUpResource> = emptyList(),
 )
+
+@Serializable
+data class LevelUpResource(
+    val id: String,
+    val name: String,
+    val maximum: Int,
+    val recovery: ResourceRecovery = ResourceRecovery.ShortOrLongRest,
+)
+
+@Serializable
+enum class ResourceRecovery { ShortRest, LongRest, ShortOrLongRest }
 
 @Serializable
 data class LevelUpPactMagicCapacity(

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/domain/usecase/LevelUpProgressionEngine.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/domain/usecase/LevelUpProgressionEngine.kt
@@ -28,6 +28,7 @@ import com.github.arhor.spellbindr.domain.model.LevelUpPreview
 import com.github.arhor.spellbindr.domain.model.LevelUpReferenceData
 import com.github.arhor.spellbindr.domain.model.LevelUpReferenceRules
 import com.github.arhor.spellbindr.domain.model.LevelUpRequirement
+import com.github.arhor.spellbindr.domain.model.LevelUpResource
 import com.github.arhor.spellbindr.domain.model.LevelUpSelections
 import com.github.arhor.spellbindr.domain.model.LevelUpSnapshot
 import com.github.arhor.spellbindr.domain.model.LevelUpSpellOption
@@ -390,8 +391,8 @@ object LevelUpProgressionEngine {
                         )
                     }
                     val deferredDecision = deferredFeatDecision(feat.id)
-
                         ?.takeUnless { feat.id == MAGIC_INITIATE_ID && magicInitiateIsSupported(data) }
+                        ?.takeUnless { feat.id == MARTIAL_ADEPT_ID && feat.maneuverChoice != null }
                     if (deferredDecision != null) {
                         validations += blocking(
                             LevelUpValidationCode.UnsupportedFeatDecision,
@@ -460,6 +461,17 @@ object LevelUpProgressionEngine {
                             label = feat.name,
                             validations = validations,
                             legalOptionIds = legalDamageTypes(feat, progression),
+                        )
+                    }
+                    feat.maneuverChoice?.let { choice ->
+                        val choiceId = feat.maneuverChoiceId.orEmpty()
+                        validateChoice(
+                            id = choiceId,
+                            choice = choice,
+                            selected = selections.featChoices[choiceId].orEmpty(),
+                            label = feat.name,
+                            validations = validations,
+                            legalOptionIds = choice.from.toSet(),
                         )
                     }
                     if (feat.id == MAGIC_INITIATE_ID && magicInitiateIsSupported(data)) {
@@ -789,6 +801,8 @@ object LevelUpProgressionEngine {
         val savingThrows = linkedSetOf<AbilityId>()
         val featureIds = linkedSetOf<String>()
         val languageIds = linkedSetOf<String>()
+        val featManeuvers = linkedMapOf<String, MutableSet<String>>()
+        var martialAdeptCount = 0
         progression.levels.forEachIndexed { index, record ->
             val clazz = classesById[record.classId] ?: return@forEachIndexed
             if (index == 0) {
@@ -825,6 +839,11 @@ object LevelUpProgressionEngine {
                 }
             }
             val feat = (record.abilityScoreDecision as? AbilityScoreDecision.Feat)?.featId?.let(data.featsById::get)
+            feat?.maneuverChoiceId?.let { choiceId ->
+                val selected = record.featChoices[choiceId].orEmpty()
+                if (selected.isNotEmpty()) featManeuvers.getOrPut(feat.id) { linkedSetOf() } += selected
+                if (feat.id == MARTIAL_ADEPT_ID) martialAdeptCount++
+            }
             feat?.effects?.filterIsInstance<Effect.AddProficienciesEffect>()
                 ?.flatMap { it.proficiencies }
                 ?.forEach { proficiencyId ->
@@ -890,6 +909,14 @@ object LevelUpProgressionEngine {
             sharedSpellSlots = LevelUpReferenceRules.sharedSpellSlots[sharedCasterLevel].orEmpty(),
             pactMagic = pactMagic,
             languageIds = languageIds,
+            featManeuvers = featManeuvers.mapValues { it.value.toSet() },
+            resources = if (martialAdeptCount > 0) listOf(
+                LevelUpResource(
+                    id = SUPERIORITY_DIE_RESOURCE_ID,
+                    name = "Superiority dice",
+                    maximum = martialAdeptCount,
+                ),
+            ) else emptyList(),
         )
     }
 
@@ -1219,8 +1246,8 @@ object LevelUpProgressionEngine {
         data: LevelUpReferenceData,
     ): LevelUpFeatEligibility {
         val deferredDecision = deferredFeatDecision(feat.id)
-
             ?.takeUnless { feat.id == MAGIC_INITIATE_ID && magicInitiateIsSupported(data) }
+            ?.takeUnless { feat.id == MARTIAL_ADEPT_ID && feat.maneuverChoice != null }
         val reasons = buildList {
             if (!feat.repeatable && progression.levels.any { record ->
                     (record.abilityScoreDecision as? AbilityScoreDecision.Feat)?.featId == feat.id
@@ -1290,8 +1317,12 @@ object LevelUpProgressionEngine {
         val damageTypeChoiceIsLegal = feat.damageTypeChoice?.let { choice ->
             choice.choose <= legalDamageTypes(feat, progression).size
         } ?: true
+        val maneuverChoiceIsLegal = feat.maneuverChoice?.let { choice ->
+            choice.choose <= choice.from.distinct().size
+        } ?: true
         val magicInitiateChoicesAreLegal = feat.id != MAGIC_INITIATE_ID || magicInitiateIsSupported(data)
         return abilityChoiceIsLegal && languageChoiceIsLegal && proficiencyChoiceIsLegal && damageTypeChoiceIsLegal &&
+            maneuverChoiceIsLegal &&
             magicInitiateChoicesAreLegal
     }
 
@@ -1608,6 +1639,8 @@ object LevelUpProgressionEngine {
     }
 
     private const val MAGIC_INITIATE_ID = "magic-initiate"
+    private const val MARTIAL_ADEPT_ID = "martial-adept"
+    private const val SUPERIORITY_DIE_RESOURCE_ID = "superiority-die"
     private const val MAGIC_INITIATE_CLASS_LIST_CHOICE_ID = "magic-initiate:class-list"
     private const val MAGIC_INITIATE_CANTRIP_CHOICE_ID = "magic-initiate:cantrips"
     private const val MAGIC_INITIATE_FIRST_LEVEL_SPELL_CHOICE_ID = "magic-initiate:first-level-spell"

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpClassProgressionReview.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/CharacterLevelUpClassProgressionReview.kt
@@ -78,9 +78,20 @@ internal fun CharacterLevelUpClassProgressionReview(state: CharacterLevelUpUiSta
                 }
             }
             MagicInitiateReview(state)
+            MartialAdeptReview(state)
         }
     }
     CharacterLevelUpSpellSlotReview(state)
+}
+
+@Composable
+private fun MartialAdeptReview(state: CharacterLevelUpUiState.Content) {
+    val maneuvers = state.preview.after.featManeuvers["martial-adept"].orEmpty()
+    val resource = state.preview.after.resources.firstOrNull { it.id == "superiority-die" }
+    if (maneuvers.isEmpty() && resource == null) return
+    Text("Martial Adept", style = MaterialTheme.typography.titleSmall)
+    if (maneuvers.isNotEmpty()) Text("Maneuvers: ${maneuvers.sorted().joinToString()}")
+    resource?.let { Text("${it.name}: ${it.maximum}d6 (recover on short or long rest)") }
 }
 
 @Composable


### PR DESCRIPTION
## Summary
- add two distinct legal Martial Adept maneuver choices with stable feat-owned persistence
- materialize selected maneuvers and superiority-die resource in managed progression previews and saved sheets
- show maneuver and resource changes in level-up review

## Validation
- `./gradlew :app:testDebugUnitTest --tests "*LevelUpProgressionEngine*" --no-daemon`

Closes #172