### PR TITLE
feat: support Ritual Caster level-up choices

### DIFF
--- a/app/src/main/kotlin/com/github/arhor/spellbindr/domain/usecase/LevelUpProgressionEngine.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/domain/usecase/LevelUpProgressionEngine.kt
@@ -39,8 +39,8 @@ import com.github.arhor.spellbindr.domain.model.LevelUpValidationIssue
 import com.github.arhor.spellbindr.domain.model.LevelUpValidationSeverity
 import com.github.arhor.spellbindr.domain.model.ProficiencyChoiceSelection
 import com.github.arhor.spellbindr.domain.model.Prerequisite
-import com.github.arhor.spellbindr.domain.model.SpellLearningPolicy
 import com.github.arhor.spellbindr.domain.model.Spell
+import com.github.arhor.spellbindr.domain.model.SpellLearningPolicy
 import javax.inject.Inject
 
 /** Creates an empty, stale-safe one-level draft without inspecting a UI state. */
@@ -157,6 +157,7 @@ object LevelUpProgressionEngine {
         val persistedPlan = when (selectedFeat?.id) {
             MAGIC_INITIATE_ID -> plan.takeIf { magicInitiateIsSupported(referenceData) }?.withMagicInitiateSpellGrant() ?: plan
             SPELL_SNIPER_ID -> plan.takeIf { spellSniperIsSupported(referenceData) }?.withSpellSniperSpellGrant() ?: plan
+            RITUAL_CASTER_ID -> plan.takeIf { ritualCasterIsSupported(referenceData) }?.withRitualCasterSpellGrant() ?: plan
             else -> plan
         }
         return persistedPlan.toRecord(
@@ -404,9 +405,10 @@ object LevelUpProgressionEngine {
                     val deferredDecision = deferredFeatDecision(feat.id)
                         ?.takeUnless {
                             (feat.id == MAGIC_INITIATE_ID && magicInitiateIsSupported(data)) ||
-                                (feat.id == SPELL_SNIPER_ID && spellSniperIsSupported(data))
+                                (feat.id == SPELL_SNIPER_ID && spellSniperIsSupported(data)) ||
+                                (feat.id == RITUAL_CASTER_ID && ritualCasterIsSupported(data)) ||
+                                (feat.id == MARTIAL_ADEPT_ID && feat.maneuverChoice != null)
                         }
-                        ?.takeUnless { feat.id == MARTIAL_ADEPT_ID && feat.maneuverChoice != null }
                     if (deferredDecision != null) {
                         validations += blocking(
                             LevelUpValidationCode.UnsupportedFeatDecision,
@@ -493,6 +495,9 @@ object LevelUpProgressionEngine {
                     }
                     if (feat.id == SPELL_SNIPER_ID && spellSniperIsSupported(data)) {
                         validateSpellSniperSelections(selections, data, validations)
+                    }
+                    if (feat.id == RITUAL_CASTER_ID && ritualCasterIsSupported(data)) {
+                        validateRitualCasterSelections(selections, data, validations)
                     }
                     val afterFeat = applyAbilityDecision(abilities, selections, data)
                     if (AbilityIds.standardOrder.any { abilityScore(afterFeat, it) > 20 }) {
@@ -773,6 +778,9 @@ object LevelUpProgressionEngine {
                     }
                     if (feat.id == SPELL_SNIPER_ID && spellSniperIsSupported(referenceData)) {
                         addAll(spellSniperChoiceRequirements(referenceData, plan.selections.featChoices))
+                    }
+                    if (feat.id == RITUAL_CASTER_ID && ritualCasterIsSupported(referenceData)) {
+                        addAll(ritualCasterChoiceRequirements(referenceData, plan.selections.featChoices))
                     }
                 }
             }
@@ -1268,9 +1276,10 @@ object LevelUpProgressionEngine {
         val deferredDecision = deferredFeatDecision(feat.id)
             ?.takeUnless {
                 (feat.id == MAGIC_INITIATE_ID && magicInitiateIsSupported(data)) ||
-                    (feat.id == SPELL_SNIPER_ID && spellSniperIsSupported(data))
+                    (feat.id == SPELL_SNIPER_ID && spellSniperIsSupported(data)) ||
+                    (feat.id == RITUAL_CASTER_ID && ritualCasterIsSupported(data)) ||
+                    (feat.id == MARTIAL_ADEPT_ID && feat.maneuverChoice != null)
             }
-            ?.takeUnless { feat.id == MARTIAL_ADEPT_ID && feat.maneuverChoice != null }
         val reasons = buildList {
             if (!feat.repeatable && progression.levels.any { record ->
                     (record.abilityScoreDecision as? AbilityScoreDecision.Feat)?.featId == feat.id
@@ -1343,11 +1352,15 @@ object LevelUpProgressionEngine {
         val maneuverChoiceIsLegal = feat.maneuverChoice?.let { choice ->
             choice.choose <= choice.from.distinct().size
         } ?: true
-        val magicInitiateChoicesAreLegal = feat.id != MAGIC_INITIATE_ID || magicInitiateIsSupported(data)
-        val spellSniperChoicesAreLegal = feat.id != SPELL_SNIPER_ID || spellSniperIsSupported(data)
+        val spellChoiceIsLegal = when (feat.id) {
+            MAGIC_INITIATE_ID -> magicInitiateIsSupported(data)
+            SPELL_SNIPER_ID -> spellSniperIsSupported(data)
+            RITUAL_CASTER_ID -> ritualCasterIsSupported(data)
+            else -> true
+        }
         return abilityChoiceIsLegal && languageChoiceIsLegal && proficiencyChoiceIsLegal && damageTypeChoiceIsLegal &&
             maneuverChoiceIsLegal &&
-            magicInitiateChoicesAreLegal && spellSniperChoicesAreLegal
+            spellChoiceIsLegal
     }
 
     private fun legalFeatAbilityOptions(
@@ -1368,11 +1381,13 @@ object LevelUpProgressionEngine {
         .flatMap { it.abilities.entries }
         .fold(abilities) { scores, (ability, amount) -> updateAbility(scores, ability, amount) }
 
-    private fun activeFeatChoiceIds(feat: Feat): Set<String> = feat.ownedChoiceIds + when (feat.id) {
-        MAGIC_INITIATE_ID -> MAGIC_INITIATE_CHOICE_IDS
-        SPELL_SNIPER_ID -> SPELL_SNIPER_CHOICE_IDS
-        else -> emptySet()
-    }
+    private fun activeFeatChoiceIds(feat: Feat): Set<String> = feat.ownedChoiceIds +
+        when (feat.id) {
+            MAGIC_INITIATE_ID -> MAGIC_INITIATE_CHOICE_IDS
+            SPELL_SNIPER_ID -> SPELL_SNIPER_CHOICE_IDS
+            RITUAL_CASTER_ID -> RITUAL_CASTER_CHOICE_IDS
+            else -> emptySet()
+        }
 
     private fun magicInitiateIsSupported(data: LevelUpReferenceData): Boolean =
         magicInitiateClassIds(data).isNotEmpty()
@@ -1561,6 +1576,89 @@ object LevelUpProgressionEngine {
             spellChanges = selections.spellChanges.copy(
                 featureLearned = selections.spellChanges.featureLearned +
                     (SPELL_SNIPER_SPELL_GRANT_OWNER_ID to setOf(ClassSpellRef(classId, spellId))),
+            ),
+        ))
+    }
+
+    private fun ritualCasterIsSupported(data: LevelUpReferenceData): Boolean =
+        ritualCasterClassIds(data).any { ritualCasterSpellCandidates(data, it).size >= 2 }
+
+    private fun ritualCasterClassIds(data: LevelUpReferenceData): List<String> = RITUAL_CASTER_CLASS_IDS
+        .filter { classId -> classId in data.classesById && ritualCasterSpellCandidates(data, classId).size >= 2 }
+        .sorted()
+
+    private fun ritualCasterSpellCandidates(data: LevelUpReferenceData, classId: String) = data.spells.asSequence()
+        .filter { spell ->
+            spell.level == 1 && spell.ritual && classId in spell.classes.map { it.id }
+        }
+        .sortedWith(compareBy({ it.name }, { it.id }))
+        .toList()
+
+    private fun validateRitualCasterSelections(
+        selections: LevelUpSelections,
+        data: LevelUpReferenceData,
+        validations: MutableList<LevelUpValidationIssue>,
+    ) {
+        val classIds = ritualCasterClassIds(data)
+        validateChoice(
+            id = RITUAL_CASTER_CLASS_LIST_CHOICE_ID,
+            choice = Choice.OptionsArrayChoice(1, classIds),
+            selected = selections.featChoices[RITUAL_CASTER_CLASS_LIST_CHOICE_ID].orEmpty(),
+            label = "Ritual Caster spell list",
+            validations = validations,
+            legalOptionIds = classIds.toSet(),
+        )
+        val classId = selections.featChoices[RITUAL_CASTER_CLASS_LIST_CHOICE_ID]
+            ?.singleOrNull()?.takeIf { it in classIds } ?: return
+        val spellIds = ritualCasterSpellCandidates(data, classId).map { it.id }
+        validateChoice(
+            id = RITUAL_CASTER_SPELL_CHOICE_ID,
+            choice = Choice.OptionsArrayChoice(2, spellIds),
+            selected = selections.featChoices[RITUAL_CASTER_SPELL_CHOICE_ID].orEmpty(),
+            label = "Ritual Caster starting rituals",
+            validations = validations,
+            legalOptionIds = spellIds.toSet(),
+        )
+    }
+
+    private fun ritualCasterChoiceRequirements(
+        data: LevelUpReferenceData,
+        featChoices: Map<String, Set<String>>,
+    ): List<LevelUpRequirement.ChoiceSelection> = buildList {
+        val classIds = ritualCasterClassIds(data)
+        val classSelection = featChoices[RITUAL_CASTER_CLASS_LIST_CHOICE_ID].orEmpty()
+        add(LevelUpRequirement.ChoiceSelection(
+            id = RITUAL_CASTER_CLASS_LIST_CHOICE_ID,
+            sourceId = RITUAL_CASTER_ID,
+            label = "Ritual Caster spell list",
+            choice = Choice.OptionsArrayChoice(1, classIds),
+            selectedOptionIds = classSelection,
+            category = LevelUpChoiceCategory.Feat,
+            options = classIds.map { classId ->
+                LevelUpChoiceOption(classId, data.classesById[classId]?.name ?: classId)
+            },
+        ))
+        val classId = classSelection.singleOrNull()?.takeIf { it in classIds } ?: return@buildList
+        val spells = ritualCasterSpellCandidates(data, classId)
+        add(LevelUpRequirement.ChoiceSelection(
+            id = RITUAL_CASTER_SPELL_CHOICE_ID,
+            sourceId = RITUAL_CASTER_ID,
+            label = "Ritual Caster starting rituals",
+            choice = Choice.OptionsArrayChoice(2, spells.map { it.id }),
+            selectedOptionIds = featChoices[RITUAL_CASTER_SPELL_CHOICE_ID].orEmpty(),
+            category = LevelUpChoiceCategory.Feat,
+            options = spells.map { LevelUpChoiceOption(it.id, it.name) },
+        ))
+    }
+
+    private fun LevelUpPlan.withRitualCasterSpellGrant(): LevelUpPlan {
+        val classId = selections.featChoices[RITUAL_CASTER_CLASS_LIST_CHOICE_ID]?.singleOrNull() ?: return this
+        val grants = selections.featChoices[RITUAL_CASTER_SPELL_CHOICE_ID].orEmpty()
+            .mapTo(linkedSetOf()) { spellId -> ClassSpellRef(classId, spellId) }
+        return copy(selections = selections.copy(
+            spellChanges = selections.spellChanges.copy(
+                featureLearned = selections.spellChanges.featureLearned +
+                    (RITUAL_CASTER_SPELL_GRANT_OWNER_ID to grants),
             ),
         ))
     }
@@ -1762,6 +1860,15 @@ object LevelUpProgressionEngine {
     )
     private val SPELL_SNIPER_CLASS_IDS = setOf("bard", "cleric", "druid", "sorcerer", "warlock", "wizard")
     private val SPELL_SNIPER_CHOICE_IDS = setOf(SPELL_SNIPER_CLASS_LIST_CHOICE_ID, SPELL_SNIPER_CANTRIP_CHOICE_ID)
+    private const val RITUAL_CASTER_ID = "ritual-caster"
+    private const val RITUAL_CASTER_CLASS_LIST_CHOICE_ID = "ritual-caster:class-list"
+    private const val RITUAL_CASTER_SPELL_CHOICE_ID = "ritual-caster:starting-spells"
+    private const val RITUAL_CASTER_SPELL_GRANT_OWNER_ID = "feat:ritual-caster"
+    private val RITUAL_CASTER_CLASS_IDS = setOf("bard", "cleric", "druid", "sorcerer", "warlock", "wizard")
+    private val RITUAL_CASTER_CHOICE_IDS = setOf(
+        RITUAL_CASTER_CLASS_LIST_CHOICE_ID,
+        RITUAL_CASTER_SPELL_CHOICE_ID,
+    )
 
     private const val SAVING_THROW_PREFIX = "saving-throw-"
     private const val ADDITIONAL_MAGICAL_SECRETS = "additional-magical-secrets"

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/data/repository/CharacterLevelUpRepositoryIntegrationTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/data/repository/CharacterLevelUpRepositoryIntegrationTest.kt
@@ -505,6 +505,56 @@ class CharacterLevelUpRepositoryIntegrationTest {
         )
     }
 
+    @Test
+    fun `applyLevelUp should persist Ritual Caster spells with feat ownership`(): Unit = runBlocking {
+        val progression = CharacterProgression(
+            referenceDataVersion = REFERENCE_VERSION, origin = ProgressionOrigin.Guided,
+            levels = (1..3).map { level ->
+                CharacterLevelRecord(
+                    characterLevel = level,
+                    classId = "fighter",
+                    classLevel = level,
+                    hitPointGain = HitPointGain.Fixed(if (level == 1) 10 else 6),
+                )
+            },
+        )
+        val sheet = fighterSheet().copy(level = 3, className = "Fighter 3", maxHitPoints = 22, currentHitPoints = 22)
+        seed(sheet, progression)
+        val plan = LevelUpPlan(
+            expectedTotalLevel = 3, rulesetId = CharacterProgression.SUPPORTED_RULESET_ID,
+            referenceDataVersion = REFERENCE_VERSION, selectedClassId = "fighter",
+            selections = LevelUpSelections(
+                hitPointGain = HitPointGain.Fixed(6), abilityScoreDecision = AbilityScoreDecision.Feat("ritual-caster"),
+                featChoices = mapOf(
+                    "ritual-caster:class-list" to setOf("wizard"),
+                    "ritual-caster:starting-spells" to setOf("find-familiar", "identify"),
+                ),
+            ),
+        )
+        fun ritualSpell(id: String) = Spell(
+            id = id, name = id.replace('-', ' ').replaceFirstChar { it.uppercase() }, desc = emptyList(), level = 1,
+            range = "Self", ritual = true, school = EntityRef("divination"), duration = "Instantaneous",
+            castingTime = "1 minute", classes = listOf(EntityRef("wizard")), components = emptyList(),
+            concentration = false, source = "test",
+        )
+        val data = LevelUpReferenceData(
+            classes = listOf(characterClass("fighter", 10), characterClass("wizard", 6)), features = emptyList(),
+            feats = listOf(Feat("ritual-caster", "Ritual Caster", emptyList())),
+            spells = listOf(ritualSpell("find-familiar"), ritualSpell("identify")), referenceDataVersion = REFERENCE_VERSION,
+        )
+
+        val result = repository.applyLevelUp(CHARACTER_ID, 3, plan, data)
+        val stored = requireNotNull(dao.getCharacterWithProgression(CHARACTER_ID))
+        val storedSheet = requireNotNull(stored.character.manualSheet?.toDomain(CHARACTER_ID))
+        assertThat(result).isInstanceOf(ApplyLevelUpResult.Success::class.java)
+        assertThat(storedSheet.characterSpells.map { it.spellId }).containsAtLeast("find-familiar", "identify")
+        assertThat(storedSheet.managedProgression?.ownedSpellGrants.orEmpty().filter {
+            ":feature:feat:ritual-caster:" in it.ownerKey
+        }.map { it.spell }).containsExactly(
+            ClassSpellRef("wizard", "find-familiar"), ClassSpellRef("wizard", "identify"),
+        )
+    }
+
     private suspend fun seed(sheet: CharacterSheet, progression: CharacterProgression) {
         val character = CharacterEntity(
             id = CHARACTER_ID,

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/domain/usecase/LevelUpProgressionEngineMagicInitiateTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/domain/usecase/LevelUpProgressionEngineMagicInitiateTest.kt
@@ -5,6 +5,7 @@ import com.github.arhor.spellbindr.domain.model.CharacterClass
 import com.github.arhor.spellbindr.domain.model.CharacterLevelRecord
 import com.github.arhor.spellbindr.domain.model.CharacterProgression
 import com.github.arhor.spellbindr.domain.model.CharacterSheet
+import com.github.arhor.spellbindr.domain.model.ClassSpellRef
 import com.github.arhor.spellbindr.domain.model.ClassLevel
 import com.github.arhor.spellbindr.domain.model.EntityRef
 import com.github.arhor.spellbindr.domain.model.Feat
@@ -20,6 +21,47 @@ import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 
 class LevelUpProgressionEngineMagicInitiateTest {
+
+    @Test
+    fun `rebuild should expose only level one ritual spells for Ritual Caster`() {
+        val data = referenceData().copy(
+            feats = listOf(Feat("ritual-caster", "Ritual Caster", emptyList())),
+            spells = listOf(
+                spell("identify", "Identify", 1, "wizard", ritual = true),
+                spell("find-familiar", "Find Familiar", 1, "wizard", ritual = true),
+                spell("shield", "Shield", 1, "wizard"),
+                spell("arcane-lock", "Arcane Lock", 2, "wizard", ritual = true),
+            ),
+        )
+        val preview = LevelUpProgressionEngine.rebuild(
+            sheet(), progression(), planFor("ritual-caster", mapOf(
+                RITUAL_CLASS_LIST to setOf("wizard"),
+            )), data,
+        )
+        val choices = preview.requirements.filterIsInstance<LevelUpRequirement.ChoiceSelection>().associateBy { it.id }
+        assertThat(choices.getValue(RITUAL_SPELLS).options.map { it.id })
+            .containsExactly("find-familiar", "identify")
+    }
+
+    @Test
+    fun `recordFor should retain two Ritual Caster spells under feat owner`() {
+        val data = referenceData().copy(
+            feats = listOf(Feat("ritual-caster", "Ritual Caster", emptyList())),
+            spells = listOf(
+                spell("identify", "Identify", 1, "wizard", ritual = true),
+                spell("find-familiar", "Find Familiar", 1, "wizard", ritual = true),
+            ),
+        )
+        val plan = planFor("ritual-caster", mapOf(
+            RITUAL_CLASS_LIST to setOf("wizard"),
+            RITUAL_SPELLS to setOf("identify", "find-familiar"),
+        ))
+        val preview = LevelUpProgressionEngine.rebuild(sheet(), progression(), plan, data)
+        assertThat(preview.canConfirm).isTrue()
+        val record = LevelUpProgressionEngine.recordFor(plan, data.classesById.getValue("fighter"), 4, progression(), data, preview.validations)
+        assertThat(record.spellChanges.featureLearned.getValue("feat:ritual-caster"))
+            .containsExactly(ClassSpellRef("wizard", "identify"), ClassSpellRef("wizard", "find-familiar"))
+    }
 
     @Test
     fun `rebuild should filter Magic Initiate choices by selected class list and spell level`() {
@@ -152,6 +194,18 @@ class LevelUpProgressionEngineMagicInitiateTest {
         ),
     )
 
+    private fun planFor(featId: String, featChoices: Map<String, Set<String>>) = LevelUpPlan(
+        expectedTotalLevel = 3,
+        rulesetId = CharacterProgression.SUPPORTED_RULESET_ID,
+        referenceDataVersion = "test-v1",
+        selectedClassId = "fighter",
+        selections = LevelUpSelections(
+            hitPointGain = HitPointGain.Fixed(6),
+            abilityScoreDecision = AbilityScoreDecision.Feat(featId),
+            featChoices = featChoices,
+        ),
+    )
+
     private fun spellSniperPlan(featChoices: Map<String, Set<String>>) = plan(featChoices).copy(
         selections = plan(featChoices).selections.copy(abilityScoreDecision = AbilityScoreDecision.Feat("spell-sniper")),
     )
@@ -182,13 +236,20 @@ class LevelUpProgressionEngineMagicInitiateTest {
         levels = (1..20).map { level -> ClassLevel("$id-$level", level, emptyList()) },
     )
 
-    private fun spell(id: String, name: String, level: Int, classId: String, attackType: String? = null) = Spell(
+    private fun spell(
+        id: String,
+        name: String,
+        level: Int,
+        classId: String,
+        ritual: Boolean = false,
+        attackType: String? = null,
+    ) = Spell(
         id = id,
         name = name,
         desc = emptyList(),
         level = level,
         range = "Self",
-        ritual = false,
+        ritual = ritual,
         school = EntityRef("evocation"),
         duration = "Instantaneous",
         castingTime = "1 action",
@@ -205,5 +266,7 @@ class LevelUpProgressionEngineMagicInitiateTest {
         const val FIRST_LEVEL = "magic-initiate:first-level-spell"
         const val SPELL_SNIPER_CLASS_LIST = "spell-sniper:class-list"
         const val SPELL_SNIPER_CANTRIP = "spell-sniper:cantrip"
+        const val RITUAL_CLASS_LIST = "ritual-caster:class-list"
+        const val RITUAL_SPELLS = "ritual-caster:starting-spells"
     }
 }

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/RitualCasterLevelUpUiTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/ui/feature/character/levelup/RitualCasterLevelUpUiTest.kt
@@ -1,0 +1,89 @@
+package com.github.arhor.spellbindr.ui.feature.character.levelup
+
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.github.arhor.spellbindr.domain.model.AbilityScoreDecision
+import com.github.arhor.spellbindr.domain.model.AbilityScores
+import com.github.arhor.spellbindr.domain.model.Choice
+import com.github.arhor.spellbindr.domain.model.LevelUpChoiceCategory
+import com.github.arhor.spellbindr.domain.model.LevelUpChoiceOption
+import com.github.arhor.spellbindr.domain.model.LevelUpPlan
+import com.github.arhor.spellbindr.domain.model.LevelUpPreview
+import com.github.arhor.spellbindr.domain.model.LevelUpRequirement
+import com.github.arhor.spellbindr.domain.model.LevelUpSelections
+import com.github.arhor.spellbindr.domain.model.LevelUpSnapshot
+import com.github.arhor.spellbindr.domain.model.Feat
+import com.github.arhor.spellbindr.ui.theme.AppTheme
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class RitualCasterLevelUpUiTest {
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun `ability score step exposes legal ritual caster choices and dispatches selections`() {
+        val intents = mutableListOf<CharacterLevelUpIntent>()
+        setContent(state(CharacterLevelUpStep.AbilityScore), intents::add)
+
+        composeTestRule.onNodeWithText("Wizard").performScrollTo().performClick()
+        composeTestRule.onNodeWithText("Find Familiar").performScrollTo().performClick()
+        composeTestRule.onNodeWithText("Identify").performScrollTo().performClick()
+
+        assertThat(intents).containsAtLeast(
+            CharacterLevelUpIntent.ChoiceToggled("ritual-caster:class-list", "wizard", 1),
+            CharacterLevelUpIntent.ChoiceToggled("ritual-caster:starting-spells", "find-familiar", 2),
+            CharacterLevelUpIntent.ChoiceToggled("ritual-caster:starting-spells", "identify", 2),
+        )
+        composeTestRule.onNodeWithText("Shield").assertDoesNotExist()
+        composeTestRule.onNodeWithText("Arcane Lock").assertDoesNotExist()
+    }
+
+    private fun setContent(state: CharacterLevelUpUiState.Content, dispatch: CharacterLevelUpDispatch) {
+        composeTestRule.setContent { AppTheme { CharacterLevelUpScreen(state, dispatch) } }
+    }
+
+    private fun state(step: CharacterLevelUpStep): CharacterLevelUpUiState.Content {
+        val feat = Feat("ritual-caster", "Ritual Caster", emptyList())
+        val selections = LevelUpSelections(
+            abilityScoreDecision = AbilityScoreDecision.Feat(feat.id),
+            featChoices = mapOf(
+                "ritual-caster:class-list" to setOf("wizard"),
+                "ritual-caster:starting-spells" to emptySet(),
+            ),
+        )
+        val requirements = listOf(
+            LevelUpRequirement.AbilityScoreImprovement(
+                id = "fighter:4:asi", classId = "fighter", abilityPoints = 2, maximumAbilityScore = 20,
+                allowsFeat = true, eligibleFeatIds = listOf(feat.id), selectedDecision = selections.abilityScoreDecision,
+            ),
+            choice("ritual-caster:class-list", "Ritual Caster spell list", 1,
+                listOf(LevelUpChoiceOption("wizard", "Wizard")), setOf("wizard")),
+            choice("ritual-caster:starting-spells", "Ritual Caster starting rituals", 2,
+                listOf(LevelUpChoiceOption("find-familiar", "Find Familiar"), LevelUpChoiceOption("identify", "Identify")), emptySet()),
+        )
+        val snapshot = LevelUpSnapshot(
+            totalLevel = 3, classLevels = mapOf("fighter" to 3), classDisplayName = "Fighter 3", proficiencyBonus = 2,
+            abilityScores = AbilityScores(), maximumHitPoints = 24, hitDicePools = emptyList(), proficiencyIds = emptySet(),
+            savingThrowAbilityIds = emptySet(), featureIds = emptySet(), sharedCasterLevel = 0, sharedSpellSlots = emptyMap(),
+        )
+        return CharacterLevelUpUiState.Content(
+            characterName = "Test hero",
+            plan = LevelUpPlan(3, "srd-5e-2014-v1", "test-v1", "fighter", selections),
+            preview = LevelUpPreview(snapshot, snapshot.copy(totalLevel = 4), requirements, emptyList()),
+            classes = emptyList(), feats = listOf(feat), spells = emptyList(),
+            steps = listOf(CharacterLevelUpStep.AbilityScore, CharacterLevelUpStep.Review), step = step,
+            currentStepIndex = if (step == CharacterLevelUpStep.Review) 1 else 0,
+        )
+    }
+
+    private fun choice(id: String, label: String, choose: Int, options: List<LevelUpChoiceOption>, selected: Set<String>) =
+        LevelUpRequirement.ChoiceSelection(id, "ritual-caster", label, Choice.OptionsArrayChoice(choose, options.map { it.id }), selected, LevelUpChoiceCategory.Feat, options)
+}


### PR DESCRIPTION
## Summary
- add Ritual Caster class-list and starting ritual spell choices to level-up requirements
- filter candidates to legal level-1 ritual spells and enforce two distinct selections
- persist selected spells under stable `feat:ritual-caster` ownership
- add focused engine and persistence coverage

Closes #170

## Validation
- `./gradlew :app:compileDebugKotlin`
- `./gradlew :app:testDebugUnitTest --tests '*LevelUpProgressionEngineMagicInitiateTest'`