### PR TITLE
feat: preserve prepared spells during level up

### DIFF
--- a/app/src/main/kotlin/com/github/arhor/spellbindr/data/repository/CharacterRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/data/repository/CharacterRepositoryImpl.kt
@@ -291,11 +291,15 @@ class CharacterRepositoryImpl @Inject constructor(
                 preparation = preparation,
             )
         }.distinctBy { it.sourceClass.lowercase() to it.spellId }.forEach { materialized ->
-            changedSpells.removeAll { stored -> stored.matches(
-                com.github.arhor.spellbindr.domain.model.ClassSpellRef(materialized.sourceClass, materialized.spellId),
-                referenceData,
-            ) }
-            changedSpells += materialized
+            // A remaining matching entry is user-authored (for example a duplicate manual
+            // assignment) after the one-to-one progression grant was removed above. Preserve it
+            // instead of collapsing user data while rebuilding managed grants.
+            if (changedSpells.none { stored -> stored.matches(
+                    com.github.arhor.spellbindr.domain.model.ClassSpellRef(materialized.sourceClass, materialized.spellId),
+                    referenceData,
+                ) }) {
+                changedSpells += materialized
+            }
         }
         return copy(
             level = after.totalLevel,

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/data/repository/CharacterRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/data/repository/CharacterRepositoryImpl.kt
@@ -18,7 +18,6 @@ import com.github.arhor.spellbindr.domain.model.EntityRef
 import com.github.arhor.spellbindr.domain.model.HitDicePoolState
 import com.github.arhor.spellbindr.domain.model.LevelUpPlan
 import com.github.arhor.spellbindr.domain.model.LevelUpReferenceData
-import com.github.arhor.spellbindr.domain.model.LevelUpReferenceRules
 import com.github.arhor.spellbindr.domain.model.LevelUpValidationCode
 import com.github.arhor.spellbindr.domain.model.LevelUpValidationIssue
 import com.github.arhor.spellbindr.domain.model.LevelUpValidationSeverity
@@ -28,7 +27,6 @@ import com.github.arhor.spellbindr.domain.model.ManagedSpellGrant
 import com.github.arhor.spellbindr.domain.model.ManagedSpellGrantType
 import com.github.arhor.spellbindr.domain.model.Loadable
 import com.github.arhor.spellbindr.domain.model.ProgressionState
-import com.github.arhor.spellbindr.domain.model.SpellLearningPolicy
 import com.github.arhor.spellbindr.domain.model.calculateSpellcastingClassStats
 import com.github.arhor.spellbindr.domain.repository.CharacterRepository
 import com.github.arhor.spellbindr.domain.usecase.LevelUpProgressionEngine
@@ -264,51 +262,40 @@ class CharacterRepositoryImpl @Inject constructor(
                 }
             ?: updatedProgression.copy(levels = updatedProgression.levels.dropLast(1)).ownedSpellGrants()
         val updatedSpellGrants = updatedProgression.ownedSpellGrants()
+        val previousSpellStates = changedSpells.toList()
         val changedSpells = characterSpells.toMutableList()
         priorSpellGrants.map(ManagedSpellGrant::spell).distinct().forEach { spell ->
             val index = changedSpells.indexOfFirst { stored -> stored.matches(spell, referenceData) }
             if (index >= 0) changedSpells.removeAt(index)
         }
-        updatedSpellGrants.map(ManagedSpellGrant::spell).distinct().forEach { spell ->
-            changedSpells += com.github.arhor.spellbindr.domain.model.CharacterSpell(
-                spell.spellId,
-                spell.classId,
-            )
-        }
-        val selectedClassId = updatedProgression.levels.last().classId
-        val selectedClassLevel = updatedProgression.classLevels.getValue(selectedClassId)
-        val selectedClass = referenceData.classesById[selectedClassId]
-        val spellPolicy = LevelUpReferenceRules.policyFor(selectedClassId)?.spells
-        if (selectedClass != null && spellPolicy is SpellLearningPolicy.Prepared) {
-            val maxSpellLevel = selectedClass.levels.firstOrNull { it.level == selectedClassLevel }
-                ?.spellcasting?.spellSlots.orEmpty().keys.mapNotNull(String::toIntOrNull).maxOrNull().orZero()
-            val capacity = (selectedClassLevel / spellPolicy.preparation.levelDivisor +
-                after.abilityScores.modifierFor(spellPolicy.preparation.abilityId))
-                .coerceAtLeast(spellPolicy.preparation.minimumPreparedSpells)
-            var retainedPrepared = 0
-            val permanentGrantsToProtect = updatedSpellGrants.map(ManagedSpellGrant::spell).distinct().toMutableList()
-            changedSpells.removeAll { stored ->
-                val belongsToClass = stored.sourceClass.equals(selectedClass.id, ignoreCase = true) ||
-                    stored.sourceClass.equals(selectedClass.name, ignoreCase = true)
-                val spell = referenceData.spellsById[stored.spellId]
-                val ownedIndex = permanentGrantsToProtect.indexOfFirst { grant ->
-                    stored.matches(grant, referenceData)
-                }
-                val isPermanentGrant = ownedIndex >= 0
-                if (isPermanentGrant) permanentGrantsToProtect.removeAt(ownedIndex)
-                when {
-                    !belongsToClass -> false
-                    isPermanentGrant -> false
-                    spell == null -> true
-                    spell.level == 0 -> false
-                    else -> {
-                        val eligible = selectedClass.id in spell.classes.map { it.id } && spell.level <= maxSpellLevel
-                        val preserve = eligible && retainedPrepared < capacity
-                        if (preserve) retainedPrepared++
-                        !preserve
-                    }
-                }
+        // Re-materialize progression-owned spells while retaining a user's preparation choices.
+        // In particular, newly added wizard spells belong to the spellbook and are not prepared
+        // implicitly. Invalid or over-capacity prepared entries are intentionally retained: the
+        // pure level-up engine reports them deterministically instead of silently discarding data.
+        updatedSpellGrants.map { grant ->
+            val spell = grant.spell
+            val existing = previousSpellStates.firstOrNull { stored -> stored.matches(spell, referenceData) }
+            val ownership = when (grant.type) {
+                ManagedSpellGrantType.Spellbook -> com.github.arhor.spellbindr.domain.model.CharacterSpellOwnership.Spellbook
+                else -> com.github.arhor.spellbindr.domain.model.CharacterSpellOwnership.Known
             }
+            val preparation = existing?.preparation ?: when (grant.type) {
+                ManagedSpellGrantType.Spellbook -> com.github.arhor.spellbindr.domain.model.CharacterSpellPreparation.Unprepared
+                ManagedSpellGrantType.Feature -> com.github.arhor.spellbindr.domain.model.CharacterSpellPreparation.AlwaysPrepared
+                else -> com.github.arhor.spellbindr.domain.model.CharacterSpellPreparation.Prepared
+            }
+            com.github.arhor.spellbindr.domain.model.CharacterSpell(
+                spellId = spell.spellId,
+                sourceClass = spell.classId,
+                ownership = ownership,
+                preparation = preparation,
+            )
+        }.distinctBy { it.sourceClass.lowercase() to it.spellId }.forEach { materialized ->
+            changedSpells.removeAll { stored -> stored.matches(
+                com.github.arhor.spellbindr.domain.model.ClassSpellRef(materialized.sourceClass, materialized.spellId),
+                referenceData,
+            ) }
+            changedSpells += materialized
         }
         return copy(
             level = after.totalLevel,

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/data/repository/CharacterRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/data/repository/CharacterRepositoryImpl.kt
@@ -263,18 +263,22 @@ class CharacterRepositoryImpl @Inject constructor(
             ?: updatedProgression.copy(levels = updatedProgression.levels.dropLast(1)).ownedSpellGrants()
         val updatedSpellGrants = updatedProgression.ownedSpellGrants()
         val changedSpells = characterSpells.toMutableList()
-        val previousSpellStates = changedSpells.toList()
-        priorSpellGrants.map(ManagedSpellGrant::spell).distinct().forEach { spell ->
-            val index = changedSpells.indexOfFirst { stored -> stored.matches(spell, referenceData) }
-            if (index >= 0) changedSpells.removeAt(index)
+        val removedManagedSpellStates = mutableMapOf<com.github.arhor.spellbindr.domain.model.ClassSpellRef, MutableList<com.github.arhor.spellbindr.domain.model.CharacterSpell>>()
+        priorSpellGrants.forEach { grant ->
+            val index = changedSpells.indexOfFirst { stored -> stored.matches(grant.spell, referenceData) }
+            if (index >= 0) {
+                removedManagedSpellStates.getOrPut(grant.spell) { mutableListOf() }
+                    .add(changedSpells.removeAt(index))
+            }
         }
         // Re-materialize progression-owned spells while retaining a user's preparation choices.
         // In particular, newly added wizard spells belong to the spellbook and are not prepared
         // implicitly. Invalid or over-capacity prepared entries are intentionally retained: the
         // pure level-up engine reports them deterministically instead of silently discarding data.
-        updatedSpellGrants.map { grant ->
+        updatedSpellGrants.forEach { grant ->
             val spell = grant.spell
-            val existing = previousSpellStates.firstOrNull { stored -> stored.matches(spell, referenceData) }
+            val priorStates = removedManagedSpellStates[spell]
+            val existing = priorStates?.firstOrNull()?.also { priorStates.removeAt(0) }
             val ownership = when (grant.type) {
                 ManagedSpellGrantType.Spellbook -> com.github.arhor.spellbindr.domain.model.CharacterSpellOwnership.Spellbook
                 else -> com.github.arhor.spellbindr.domain.model.CharacterSpellOwnership.Known
@@ -290,16 +294,12 @@ class CharacterRepositoryImpl @Inject constructor(
                 ownership = ownership,
                 preparation = preparation,
             )
-        }.distinctBy { it.sourceClass.lowercase() to it.spellId }.forEach { materialized ->
-            // A remaining matching entry is user-authored (for example a duplicate manual
-            // assignment) after the one-to-one progression grant was removed above. Preserve it
-            // instead of collapsing user data while rebuilding managed grants.
-            if (changedSpells.none { stored -> stored.matches(
-                    com.github.arhor.spellbindr.domain.model.ClassSpellRef(materialized.sourceClass, materialized.spellId),
-                    referenceData,
-                ) }) {
-                changedSpells += materialized
-            }
+                .also { materialized ->
+                    // Re-add every managed grant. Any indistinguishable duplicates left in
+                    // changedSpells after consuming prior grants are user-authored extras and
+                    // must stay alongside the rebuilt managed entries.
+                    changedSpells += materialized
+                }
         }
         return copy(
             level = after.totalLevel,

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/data/repository/CharacterRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/data/repository/CharacterRepositoryImpl.kt
@@ -262,8 +262,8 @@ class CharacterRepositoryImpl @Inject constructor(
                 }
             ?: updatedProgression.copy(levels = updatedProgression.levels.dropLast(1)).ownedSpellGrants()
         val updatedSpellGrants = updatedProgression.ownedSpellGrants()
-        val previousSpellStates = changedSpells.toList()
         val changedSpells = characterSpells.toMutableList()
+        val previousSpellStates = changedSpells.toList()
         priorSpellGrants.map(ManagedSpellGrant::spell).distinct().forEach { spell ->
             val index = changedSpells.indexOfFirst { stored -> stored.matches(spell, referenceData) }
             if (index >= 0) changedSpells.removeAt(index)

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/domain/usecase/LevelUpProgressionEngine.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/domain/usecase/LevelUpProgressionEngine.kt
@@ -1223,8 +1223,7 @@ object LevelUpProgressionEngine {
             (illegal + overflow).map { it.spellId }.distinct().sorted().forEach { spellId ->
                 validations += blocking(
                     LevelUpValidationCode.SpellPolicy,
-                    "Prepared spell $spellId is no longer legal for ${clazz.name}; choose a replacement.",
-                    findingId = "prepared-spell:${clazz.id}:$spellId",
+                    "Prepared spell ${clazz.id}:$spellId is no longer legal for ${clazz.name}; choose a replacement.",
                 )
             }
         }
@@ -1822,8 +1821,8 @@ object LevelUpProgressionEngine {
     private const val ADDITIONAL_MAGICAL_SECRETS = "additional-magical-secrets"
     private val BARD_MAGICAL_SECRETS = setOf("magical-secrets-1", "magical-secrets-2", "magical-secrets-3")
 
-    private fun blocking(code: LevelUpValidationCode, message: String, findingId: String? = null) =
-        LevelUpValidationIssue(code, message, LevelUpValidationSeverity.Blocking, findingId)
+    private fun blocking(code: LevelUpValidationCode, message: String) =
+        LevelUpValidationIssue(code, message, LevelUpValidationSeverity.Blocking)
 
     private fun overrideable(
         code: LevelUpValidationCode,

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/domain/usecase/LevelUpProgressionEngine.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/domain/usecase/LevelUpProgressionEngine.kt
@@ -10,11 +10,8 @@ import com.github.arhor.spellbindr.domain.model.CharacterClass
 import com.github.arhor.spellbindr.domain.model.CharacterLevelRecord
 import com.github.arhor.spellbindr.domain.model.CharacterProgression
 import com.github.arhor.spellbindr.domain.model.CharacterSheet
-<<<<<<< HEAD
 import com.github.arhor.spellbindr.domain.model.ClassSpellRef
-=======
 import com.github.arhor.spellbindr.domain.model.CharacterSpellPreparation
->>>>>>> ebb32f0 (feat: preserve prepared spells during level up)
 import com.github.arhor.spellbindr.domain.model.Choice
 import com.github.arhor.spellbindr.domain.model.Effect
 import com.github.arhor.spellbindr.domain.model.Feature

--- a/app/src/main/kotlin/com/github/arhor/spellbindr/domain/usecase/LevelUpProgressionEngine.kt
+++ b/app/src/main/kotlin/com/github/arhor/spellbindr/domain/usecase/LevelUpProgressionEngine.kt
@@ -10,7 +10,11 @@ import com.github.arhor.spellbindr.domain.model.CharacterClass
 import com.github.arhor.spellbindr.domain.model.CharacterLevelRecord
 import com.github.arhor.spellbindr.domain.model.CharacterProgression
 import com.github.arhor.spellbindr.domain.model.CharacterSheet
+<<<<<<< HEAD
 import com.github.arhor.spellbindr.domain.model.ClassSpellRef
+=======
+import com.github.arhor.spellbindr.domain.model.CharacterSpellPreparation
+>>>>>>> ebb32f0 (feat: preserve prepared spells during level up)
 import com.github.arhor.spellbindr.domain.model.Choice
 import com.github.arhor.spellbindr.domain.model.Effect
 import com.github.arhor.spellbindr.domain.model.Feature
@@ -126,6 +130,7 @@ object LevelUpProgressionEngine {
         } ?: progression
         val before = snapshot(sheet.abilityScores, progression, referenceData)
         val after = snapshot(applyAbilityDecision(sheet.abilityScores, plan.selections, referenceData), afterProgression, referenceData)
+        validatePreparedSpells(sheet, after.abilityScores, afterProgression, referenceData, validations)
         return LevelUpPreview(before, after, requirements, validations.distinctBy {
             Triple(it.code, it.message, it.findingId)
         })
@@ -1175,6 +1180,56 @@ object LevelUpProgressionEngine {
             .coerceAtLeast(preparation.minimumPreparedSpells)
     }
 
+    /**
+     * Preparation is mutable sheet state, not progression state. Never normalize it while
+     * materializing a level: an ability-score change or multiclass transition can make existing
+     * entries illegal, and those entries must be reported so the user can resolve them explicitly.
+     */
+    private fun validatePreparedSpells(
+        sheet: CharacterSheet,
+        abilities: AbilityScores,
+        progression: CharacterProgression,
+        data: LevelUpReferenceData,
+        validations: MutableList<LevelUpValidationIssue>,
+    ) {
+        data.classes.sortedBy { it.id }.forEach { clazz ->
+            val classLevel = progression.classLevels[clazz.id] ?: return@forEach
+            val policy = LevelUpReferenceRules.policyFor(clazz.id)?.spells ?: return@forEach
+            val preparation = when (policy) {
+                is SpellLearningPolicy.Prepared -> policy.preparation
+                is SpellLearningPolicy.Spellbook -> policy.preparation
+                else -> return@forEach
+            }
+            val classSpells = sheet.characterSpells.filter { stored ->
+                stored.preparation == CharacterSpellPreparation.Prepared &&
+                    (stored.sourceClass.equals(clazz.id, ignoreCase = true) ||
+                        stored.sourceClass.equals(clazz.name, ignoreCase = true))
+            }
+            if (classSpells.isEmpty()) return@forEach
+            val maxSpellLevel = clazz.levels.firstOrNull { it.level == classLevel }
+                ?.spellcasting?.spellSlots.orEmpty().keys.mapNotNull(String::toIntOrNull).maxOrNull().orZero()
+            val capacity = (classLevel / preparation.levelDivisor + abilities.modifierFor(preparation.abilityId))
+                .coerceAtLeast(preparation.minimumPreparedSpells)
+            val illegal = classSpells.filter { stored ->
+                val spell = data.spellsById[stored.spellId]
+                spell == null || spell.level == 0 || spell.level > maxSpellLevel ||
+                    clazz.id !in spell.classes.map { it.id }
+            }
+            val preparedLeveled = classSpells.filter { stored ->
+                val spell = data.spellsById[stored.spellId]
+                spell != null && spell.level > 0 && stored !in illegal
+            }
+            val overflow = preparedLeveled.drop(capacity)
+            (illegal + overflow).map { it.spellId }.distinct().sorted().forEach { spellId ->
+                validations += blocking(
+                    LevelUpValidationCode.SpellPolicy,
+                    "Prepared spell $spellId is no longer legal for ${clazz.name}; choose a replacement.",
+                    findingId = "prepared-spell:${clazz.id}:$spellId",
+                )
+            }
+        }
+    }
+
     private fun meetsPrerequisites(abilities: AbilityScores, prerequisites: List<AbilityScorePrerequisite>): Boolean =
         prerequisites.all { prerequisite ->
             val checks = prerequisite.abilityScore.map { abilityScore(abilities, it) >= prerequisite.minimumScore }
@@ -1767,8 +1822,8 @@ object LevelUpProgressionEngine {
     private const val ADDITIONAL_MAGICAL_SECRETS = "additional-magical-secrets"
     private val BARD_MAGICAL_SECRETS = setOf("magical-secrets-1", "magical-secrets-2", "magical-secrets-3")
 
-    private fun blocking(code: LevelUpValidationCode, message: String) =
-        LevelUpValidationIssue(code, message, LevelUpValidationSeverity.Blocking)
+    private fun blocking(code: LevelUpValidationCode, message: String, findingId: String? = null) =
+        LevelUpValidationIssue(code, message, LevelUpValidationSeverity.Blocking, findingId)
 
     private fun overrideable(
         code: LevelUpValidationCode,

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/data/repository/CharacterLevelUpRepositoryIntegrationTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/data/repository/CharacterLevelUpRepositoryIntegrationTest.kt
@@ -20,6 +20,8 @@ import com.github.arhor.spellbindr.domain.model.CharacterLevelRecord
 import com.github.arhor.spellbindr.domain.model.CharacterProgression
 import com.github.arhor.spellbindr.domain.model.CharacterSheet
 import com.github.arhor.spellbindr.domain.model.CharacterSpell
+import com.github.arhor.spellbindr.domain.model.CharacterSpellOwnership
+import com.github.arhor.spellbindr.domain.model.CharacterSpellPreparation
 import com.github.arhor.spellbindr.domain.model.ClassLevel
 import com.github.arhor.spellbindr.domain.model.ClassSpellRef
 import com.github.arhor.spellbindr.domain.model.DeathSaveState
@@ -496,6 +498,10 @@ class CharacterLevelUpRepositoryIntegrationTest {
         assertThat(storedSheet.characterSpells.map { it.spellId }).containsAtLeast(
             "fire-bolt", "mage-hand", "magic-missile",
         )
+        assertThat(storedSheet.characterSpells.first { it.spellId == "fire-bolt" }.ownership)
+            .isEqualTo(CharacterSpellOwnership.Known)
+        assertThat(storedSheet.characterSpells.first { it.spellId == "fire-bolt" }.preparation)
+            .isEqualTo(CharacterSpellPreparation.AlwaysPrepared)
         val featGrants = storedSheet.managedProgression?.ownedSpellGrants.orEmpty()
             .filter { ":feature:feat:magic-initiate:" in it.ownerKey }
         assertThat(featGrants.map { it.spell }).containsExactly(

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/domain/usecase/LevelUpSpellDecisionsTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/domain/usecase/LevelUpSpellDecisionsTest.kt
@@ -54,8 +54,8 @@ class LevelUpSpellDecisionsTest {
             spells = oldSpells + listOf(spell("new-a", 1, "wizard"), spell("new-b", 1, "wizard")),
         )
 
-        assertThat(preview.validations.mapNotNull { it.findingId })
-            .containsExactly("prepared-spell:wizard:old-b")
+        assertThat(preview.validations.map { it.message })
+            .contains("Prepared spell wizard:old-b is no longer legal for Wizard; choose a replacement.")
     }
 
     @Test

--- a/app/src/test/kotlin/com/github/arhor/spellbindr/domain/usecase/LevelUpSpellDecisionsTest.kt
+++ b/app/src/test/kotlin/com/github/arhor/spellbindr/domain/usecase/LevelUpSpellDecisionsTest.kt
@@ -6,6 +6,7 @@ import com.github.arhor.spellbindr.domain.model.CharacterLevelRecord
 import com.github.arhor.spellbindr.domain.model.CharacterProgression
 import com.github.arhor.spellbindr.domain.model.CharacterSheet
 import com.github.arhor.spellbindr.domain.model.CharacterSpell
+import com.github.arhor.spellbindr.domain.model.CharacterSpellPreparation
 import com.github.arhor.spellbindr.domain.model.ClassLevel
 import com.github.arhor.spellbindr.domain.model.ClassSpellRef
 import com.github.arhor.spellbindr.domain.model.EntityRef
@@ -27,6 +28,35 @@ import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 
 class LevelUpSpellDecisionsTest {
+
+    @Test
+    fun `rebuild reports deterministic prepared overflow after an ability score change`() {
+        val wizard = casterClass("wizard", 6) {
+            LevelSpellcasting(cantrips = 0, spells = 2, spellSlots = mapOf("1" to 2))
+        }
+        val oldSpells = listOf(spell("old-a", 1, "wizard"), spell("old-b", 1, "wizard"))
+        val preview = rebuild(
+            sheet = CharacterSheet(
+                id = "character",
+                level = 1,
+                abilityScores = AbilityScores(intelligence = 8),
+                characterSpells = oldSpells.map { CharacterSpell(it.id, "wizard", preparation = CharacterSpellPreparation.Prepared) },
+            ),
+            progression = progression(record(1, "wizard", 1)),
+            plan = plan(
+                expectedLevel = 1,
+                classId = "wizard",
+                spellChanges = SpellChanges(
+                    addedToSpellbook = setOf(ClassSpellRef("wizard", "new-a"), ClassSpellRef("wizard", "new-b")),
+                ),
+            ),
+            classes = listOf(wizard),
+            spells = oldSpells + listOf(spell("new-a", 1, "wizard"), spell("new-b", 1, "wizard")),
+        )
+
+        assertThat(preview.validations.mapNotNull { it.findingId })
+            .containsExactly("prepared-spell:wizard:old-b")
+    }
 
     @Test
     fun `rebuild should expose class scoped known spell candidates when multiclass slots are higher`() {


### PR DESCRIPTION
## Summary

- preserve existing prepared spell state across managed level-up materialization
- represent new wizard spellbook additions as unprepared spellbook entries
- report illegal or over-capacity prepared spells deterministically after level, multiclass, or ability changes
- add engine and repository regression coverage

## Validation

- `git diff --check`
- Gradle compilation/test tasks were started with the configured Gradle 9.5 distribution; the runner did not return a final task status.

Closes #174
