### PR TITLE
feat: add Compose UI design skill harness

### DIFF
--- a/.codex/skills/design-compose-ui/SKILL.md
+++ b/.codex/skills/design-compose-ui/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: design-compose-ui
+description: >-
+  Design, critique, refine, or visually verify Spellbindr Android UI built with Jetpack Compose and Material 3. Use
+  for new screens, focused visual polish, screenshot matching or review, image-led composition, visual hierarchy,
+  spacing, typography, color, shape, density, motion, accessibility, adaptive layouts, or UI design-system work.
+  Do not use for Compose changes limited to state, navigation, business logic, performance, or tests with no visual
+  or interaction-design decision.
+---
+
+# Design Compose UI
+
+Produce focused, product-specific UI work that preserves behavior and is judged from rendered evidence.
+
+## Load the relevant context
+
+1. Read repository instructions and the target feature's route, screen, state, components, previews, and tests.
+2. Read [Spellbindr visual language](references/spellbindr-visual-language.md) for every task.
+3. Read [Compose design guidance](references/compose-design-guidance.md) when designing or changing UI.
+4. Read [Visual verification](references/visual-verification.md) before planning rendered checks or reviewing an image.
+5. Read `docs/mvi-dispatch-contract.md` when a change touches feature entry points, dispatch, effects, or navigation.
+6. Read [Provenance and maintenance](references/provenance.md) only when updating this skill or importing guidance.
+
+Do not load unrelated references. Treat the running UI and repository source as more authoritative than this skill when
+they disagree; call out the mismatch and update the skill if the repository's intentional design language changed.
+
+## Classify the task
+
+- **Critique**: inspect the render first; report strengths and prioritized problems before proposing edits.
+- **Focused refinement**: identify the smallest coherent correction and preserve behavior, navigation, state, and
+  identity.
+- **New UI**: establish the user job, hierarchy, states, visual direction, reuse plan, and verification matrix before
+  code.
+- **Image-led UI**: make artwork structurally important; keep controls legible without burying the image under cards or
+  copy.
+- **Reference match**: reproduce the reference state and dimensions, compare renders, and iterate from observed
+  differences.
+
+If no render is available, inspect the code but label visual conclusions as hypotheses. Do not claim polish from source
+inspection alone.
+
+## Form the design intent
+
+Write a compact internal brief before editing:
+
+- user job and primary action;
+- ordered information hierarchy;
+- one product-specific visual idea or existing signature to preserve;
+- existing theme roles and components to reuse;
+- clutter to remove or combine;
+- loading, empty, error, disabled, and selected states that matter;
+- compact, large-font, and wider-window behavior;
+- accessibility contract;
+- exact preview and screenshot checks.
+
+Prefer subtraction. Every label, chip, divider, container, instruction, icon, and animation must communicate hierarchy,
+state, action, grouping, or product character. Remove it when it does none of those jobs.
+
+## Critique before changing
+
+Evaluate in this order:
+
+1. User job and action clarity.
+2. Hierarchy and reading path.
+3. Content density and redundant explanation.
+4. Composition, spacing rhythm, alignment, and grouping.
+5. Typography, color-role pairing, shape, elevation, imagery, and motion.
+6. Touch, TalkBack semantics, contrast, font scaling, system insets, and adaptive behavior.
+7. Consistency with nearby Spellbindr UI.
+
+Separate findings into:
+
+- **UX problem**: the structure, priority, copy, state, or interaction is wrong.
+- **Implementation problem**: the intended design is sound but the Compose code, modifier order, semantics, or sizing is
+  wrong.
+
+For each material finding, cite visible or source evidence, state user impact, and propose a bounded correction.
+Preserve what already works. Do not turn a focused request into a broad redesign.
+
+## Implement idiomatically
+
+- Keep route-owned navigation and dispatch-based screen APIs intact.
+- Prefer existing components and `MaterialTheme` roles. Introduce a reusable component only for a repeated semantic
+  pattern.
+- Hoist interaction state and callbacks; keep previews deterministic and free of Android runtime dependencies.
+- Use semantic Material/Foundation controls before low-level gesture handling. Add custom semantics only when defaults do
+  not express the action, role, value, state, or traversal correctly.
+- Keep decorative imagery and icons out of the semantics tree; describe meaningful imagery by purpose, not appearance.
+- Use scalable text styles and allow content to reflow. Avoid fixed heights around text and actions.
+- Make layout decisions from available window space, not device names or orientation checks.
+- Use motion to explain state or spatial continuity. Keep it nonessential and provide a reduced-motion path.
+- Preserve MVI behavior and existing tests unless the requested UX intentionally changes them.
+
+## Verify from rendered output
+
+1. Add or update a dedicated `@PreviewTest` in `app/src/screenshotTest/kotlin` for the exact state.
+2. Include the standard compact render plus only the risk-relevant variants: dark/light, large font, narrow height, wider
+   window, RTL, or state variants.
+3. Wrap the preview with `ScreenshotHarness`.
+4. Generate and export PNGs with the repository commands in [Visual verification](references/visual-verification.md).
+5. Inspect the PNG. Compare hierarchy, clipping, alignment, density, contrast, touch affordance, and reference
+   differences.
+6. Apply one batched correction pass, render again, and re-inspect. Continue only when a concrete defect remains.
+7. Run the narrowest screenshot validation, Compose/UI test, compile, and lint checks proportional to the change.
+
+Never update a reference image merely to make a failure pass. Review the actual/reference/diff first and state why the
+new rendering is intentional. Screenshot checks complement, but do not replace, semantics tests and human judgment.
+
+## Hand off the result
+
+Report:
+
+- the design outcome and what was deliberately preserved or removed;
+- files and behavior changed;
+- rendered variants inspected and concrete visual observations;
+- deterministic checks run and their results;
+- known tradeoffs or remaining human-design decisions.
+
+Do not use vague conclusions such as "cleaner" or "more modern" without naming the observable change.

--- a/.codex/skills/design-compose-ui/agents/openai.yaml
+++ b/.codex/skills/design-compose-ui/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Compose UI Designer"
+  short_description: "Design and verify polished Spellbindr Compose UI"
+  default_prompt: "Use $design-compose-ui to critique and refine this Spellbindr Compose interface, then verify the rendered result."

--- a/.codex/skills/design-compose-ui/references/compose-design-guidance.md
+++ b/.codex/skills/design-compose-ui/references/compose-design-guidance.md
@@ -1,0 +1,101 @@
+# Compose design guidance
+
+## Contents
+
+1. Hierarchy and composition
+2. Material roles and product identity
+3. Adaptive layout and system UI
+4. Accessibility contract
+5. Motion and interaction
+6. Compose implementation review
+7. Sources
+
+## Hierarchy and composition
+
+Start with the user's next decision or action. Make the primary content visually dominant through position, scale,
+contrast, or available area. Use no more than one dominant emphasis in a compact viewport.
+
+- Establish a spacing rhythm from repeated values already present nearby. Treat exceptions as design decisions.
+- Use alignment and whitespace as the first grouping tools; containers and dividers are secondary tools.
+- Keep action labels specific and consistent across control, confirmation, and error states.
+- Avoid equal visual weight for title, metadata, instruction, primary action, and secondary action.
+- Preserve real content during design. Placeholder copy hides wrapping, density, and empty-state failures.
+- Spend visual character in one or two places. Let the rest of the composition support them quietly.
+
+For image-led composition, decide whether the image is content, identity, or decoration. Content and identity imagery need
+meaningful space and deliberate cropping. Place legible text over a localized gradient or separate surface; avoid a
+large opaque card that reduces the image to a background strip.
+
+## Material roles and product identity
+
+Material 3 is the component and semantic-token foundation, not the complete product identity.
+
+- Pair container and content roles (`primary`/`onPrimary`, `surface`/`onSurface`) instead of selecting colors by eye.
+- Use typography roles for meaning. Do not encode hierarchy solely with arbitrary `fontSize` or weight.
+- Use theme shapes and tonal surface differences consistently. Add shadow only when separation from a busy layer requires it.
+- Prefer explicit product schemes when they are intentional. Dynamic color is an option, not a universal requirement.
+- Keep contrast valid in every supported scheme and state, including disabled content and image overlays.
+
+## Adaptive layout and system UI
+
+Design for the current window, which can resize independently of the physical device.
+
+- Branch on window size classes or measured constraints when the composition must change.
+- Reflow before shrinking. Allow text to wrap, actions to stack, grids to change columns, and supporting panes to move.
+- Constrain readable content width on expansive windows; do not stretch paragraphs and forms edge to edge.
+- Keep critical content away from folds, hinges, display cutouts, and occlusion regions.
+- Consume `Scaffold` padding and deliberate `WindowInsets`; verify status bar, navigation bar, IME, and gesture navigation.
+- Test at least one compact width and every size class whose composition differs. Use a large-font preview when text can
+  influence geometry.
+
+## Accessibility contract
+
+Define accessibility as behavior, not a final checklist.
+
+- Prefer Material and Foundation controls because they supply interaction and semantics defaults.
+- Keep effective touch targets at least 48 dp even when visual glyphs are smaller.
+- Provide an accessible name for interactive icons. Use `contentDescription = null` for purely decorative icons or images.
+- Express selection, toggle, range, progress, error, and disabled state through semantics and visible cues; never color alone.
+- Merge descendants only when a group should be announced as one action. Clear semantics only when replacing them with a
+  complete equivalent.
+- Keep traversal order aligned with the visual reading path. Recheck sheets, dialogs, pagers, and custom layouts.
+- Use `sp` and scalable Material type. Avoid fixed-height text containers and truncating critical instructions or actions.
+- Verify contrast with a tool when values are uncertain. Screenshot inspection cannot prove a ratio.
+- Add Compose semantics assertions for critical custom controls; use automated accessibility checks when instrumentation
+  infrastructure supports them, then perform TalkBack/manual review for behavior automation cannot judge.
+
+## Motion and interaction
+
+Motion should explain cause, state change, or spatial relationship.
+
+- Prefer one coordinated transition over unrelated animation on every element.
+- Keep the task possible with animation disabled or reduced.
+- Avoid infinite ambient motion near reading or input unless the user explicitly requested it and it can be paused.
+- Preserve input and scroll state across recomposition and configuration changes when users expect continuity.
+- Use whole-surface semantics and click handling for rows and cards; avoid competing nested targets without clear need.
+- Make loading, pressed, selected, success, and failure feedback distinguishable without relying only on color or motion.
+
+## Compose implementation review
+
+Check implementation details only after the UX and composition are sound:
+
+- modifier order matches intended hit area, clipping, drawing, padding, and semantics;
+- state is hoisted to the owning layer and transient UI state uses the appropriate saveability;
+- lazy items have stable keys when identity matters;
+- preview inputs are stable, representative, and deterministic;
+- strings shown to users follow repository localization practice rather than a new ad hoc mechanism;
+- custom Canvas or pointer-input code is justified over semantic components;
+- adaptive branches preserve the same state and actions;
+- tests assert behavior and semantics while screenshots assert pixels.
+
+## Sources
+
+Use current official documentation when an API or recommendation may have changed:
+
+- [Accessibility in Jetpack Compose](https://developer.android.com/develop/ui/compose/accessibility)
+- [Compose semantics](https://developer.android.com/develop/ui/compose/accessibility/semantics)
+- [Compose accessibility API defaults](https://developer.android.com/develop/ui/compose/accessibility/api-defaults)
+- [Build adaptive apps](https://developer.android.com/develop/ui/compose/build-adaptive-apps)
+- [Support different display sizes](https://developer.android.com/develop/adaptive-apps/guides/support-different-display-sizes)
+- [Canonical adaptive layouts](https://developer.android.com/develop/adaptive-apps/guides/canonical-layouts)
+- [Compose preview screenshot testing](https://developer.android.com/studio/preview/compose-screenshot-testing)

--- a/.codex/skills/design-compose-ui/references/provenance.md
+++ b/.codex/skills/design-compose-ui/references/provenance.md
@@ -1,0 +1,34 @@
+# Provenance and maintenance
+
+This skill is original repository-local guidance informed by public skills and official Android documentation. It does
+not vendor executable code, third-party assets, or substantial copied passages.
+
+Conceptual influences:
+
+- Anthropic `frontend-design` (Apache-2.0): subject-grounded visual direction, restraint, deliberate hierarchy, and
+  screenshot-based critique. Web/CSS/DOM guidance was not carried over.
+- `wshobson/agents` `mobile-android-design` (MIT): Compose, Material 3, adaptive-layout, preview, and touch-target coverage.
+- `mdrmuhaimin/agentic-skills` `mobile-ui-ux-designer` (MIT): user-goal-first briefs, state completeness, accessibility
+  contracts, and rendered verification. Its large cross-platform output template was not adopted.
+- `aldefy/compose-skill` (MIT, with Apache-2.0 AndroidX source excerpts): progressive Compose references and
+  source-grounded implementation checks. No upstream source excerpts are included here.
+- `hamen/material-3-skill` (MIT): Compose-oriented Material role and audit concepts. Cross-platform web/Flutter material
+  and volatile API claims were excluded.
+- `android/skills` and developer.android.com (Apache-2.0/content license as applicable): official open-skill conventions
+  and current Android technical guidance.
+
+See `docs/compose-ui-design-skill-research.md` for the evaluated versions, links, limitations, and decision record.
+
+## Maintenance
+
+Review this skill when any of these change:
+
+- `AppTheme`, color, typography, or shape roles;
+- shared UI components or feature-entry architecture;
+- AGP screenshot plugin tasks, paths, or `ScreenshotHarness`;
+- supported Android window/form-factor policy;
+- Compose Material 3, adaptive, or accessibility APIs used by the app.
+
+Prefer updating repository-specific references over importing a broad upstream skill. Re-check upstream sources and
+licenses before copying any new material. Pin or record a commit when vendoring content; review instructions and scripts
+for network access, shell execution, credential requests, and prompt-injection behavior before installation.

--- a/.codex/skills/design-compose-ui/references/spellbindr-visual-language.md
+++ b/.codex/skills/design-compose-ui/references/spellbindr-visual-language.md
@@ -1,0 +1,68 @@
+# Spellbindr visual language
+
+Use this repository map before designing. Inspect the current files because this reference records a baseline, not an
+immutable specification.
+
+## Product character
+
+Spellbindr is a compact D&D 5e companion. Its established identity is warm parchment and gold in light mode, deep
+blue-black surfaces and muted gold in dark mode, with restrained violet and ember accents. Rounded surfaces, occasional
+fantasy geometry, and character artwork provide personality. Dense rules data should remain scannable and operational;
+fantasy atmosphere must not obstruct play.
+
+Preserve these traits:
+
+- warm gold as the primary emphasis, not a generic purple-gradient treatment;
+- violet as a supporting selection or secondary role and ember for limited tertiary emphasis;
+- high-radius Material surfaces plus purposeful custom shapes where they encode game character;
+- typography hierarchy built from `MaterialTheme.typography`, with semibold display/headline roles and readable body text;
+- artwork as a focal layer where the content warrants it, especially guided character creation;
+- concise interface copy and visible game state rather than explanatory cards around every control.
+
+## Source map
+
+| Concern | Source of truth |
+|---|---|
+| Theme entry | `app/src/main/kotlin/com/github/arhor/spellbindr/ui/theme/AppTheme.kt` |
+| Color roles | `app/src/main/kotlin/com/github/arhor/spellbindr/ui/theme/AppColorScheme.kt` |
+| Type roles | `app/src/main/kotlin/com/github/arhor/spellbindr/ui/theme/AppTypography.kt` |
+| Shape roles | `app/src/main/kotlin/com/github/arhor/spellbindr/ui/theme/AppShapes.kt` |
+| Shared chrome and primitives | `app/src/main/kotlin/com/github/arhor/spellbindr/ui/components/` |
+| Feature UI | `app/src/main/kotlin/com/github/arhor/spellbindr/ui/feature/` |
+| Image-led precedent | `ui/feature/character/guided/components/race/` |
+| Screenshot previews | `app/src/screenshotTest/kotlin/com/github/arhor/spellbindr/ui/` |
+| Screenshot wrapper | `app/src/screenshotTest/kotlin/com/github/arhor/spellbindr/ui/screenshot/ScreenshotHarness.kt` |
+| Export helper | `run/export-preview-screenshot.sh` |
+| MVI entry contract | `docs/mvi-dispatch-contract.md` |
+
+## Reuse before invention
+
+Search shared components and the target feature before introducing another card, row, picker, top bar, bottom bar,
+loading state, error state, or selected indicator. Reuse means preserving semantics and visual rhythm, not forcing every
+new concept into an unrelated component.
+
+Examples worth inspecting include `AppTopBar`, `AppBottomBar`, `SelectableGrid`, `SelectedIndicator`, `InlineTextField`,
+`InlineNumberField`, `LoadingIndicator`, and `ErrorMessage`. Feature-local patterns are intentionally local when their
+meaning is specific to dice, spells, the character sheet, guided creation, or level-up.
+
+## Current layout and accessibility evidence
+
+The repository already uses:
+
+- `@PreviewLightDark` and explicit screenshot preview sizes;
+- `fontScale` screenshot variants;
+- Material/Foundation semantics plus custom `stateDescription`, `customActions`, and `Role` where necessary;
+- `minimumInteractiveComponentSize()` for compact custom controls;
+- reduced-motion behavior for externally driven pager changes;
+- full-bleed race artwork with a gradient readability scrim and concise overlay content.
+
+Extend those patterns rather than resetting the product to baseline Material samples.
+
+## Design boundaries
+
+- Do not replace the static brand schemes with dynamic wallpaper color without an explicit product decision.
+- Do not hardcode a new palette inside feature composables. Add or use semantic theme roles.
+- Do not use nested opaque cards merely to group every heading and value.
+- Do not add chips for static metadata when aligned text, type hierarchy, or spacing communicates the same relation.
+- Do not hide primary play actions behind decorative motion or imagery.
+- Do not alter Route/Intent/Effect ownership to simplify a visual implementation.

--- a/.codex/skills/design-compose-ui/references/visual-verification.md
+++ b/.codex/skills/design-compose-ui/references/visual-verification.md
@@ -1,0 +1,85 @@
+# Visual verification
+
+## Choose evidence by risk
+
+| Risk | Render or check |
+|---|---|
+| Hierarchy, spacing, shape, imagery | Screenshot preview at the target state and size |
+| Theme roles and contrast | Light and dark renders; calculate uncertain contrast ratios |
+| Wrapping and action reachability | `fontScale` preview, usually 1.3 or higher when risk warrants |
+| Compact-height overflow or IME | Short-height preview plus device/instrumentation check for runtime insets |
+| Adaptive composition | Explicit compact and wider-window previews around actual layout transitions |
+| RTL or directional controls | RTL preview and semantic review |
+| Interaction and state | Compose UI/instrumentation test; screenshots for key stable states |
+| Visual regression | `validateDebugScreenshotTest` against reviewed reference images |
+
+Do not multiply previews mechanically. Select variants that could falsify the design.
+
+## Create the preview
+
+Place dedicated exported previews under `app/src/screenshotTest/kotlin` near the owning feature. Each preview requires:
+
+```kotlin
+@PreviewTest
+@Preview(widthDp = 360, heightDp = 640)
+@Composable
+fun Feature_State_Screenshot() {
+    ScreenshotHarness {
+        FeatureScreen(...)
+    }
+}
+```
+
+Use the real `ScreenshotHarness`, theme, state model, and representative content. Keep callbacks deterministic. Add
+`uiMode`, `fontScale`, locale, or a different width/height only when it exercises a design risk.
+
+## Generate and export
+
+Generate a filtered reference:
+
+```text
+./gradlew :app:updateDebugScreenshotTest --tests '*Feature_State_Screenshot*'
+```
+
+Export the newly generated PNGs:
+
+```text
+run/export-preview-screenshot.sh --module :app --tests '*Feature_State_Screenshot*'
+```
+
+If Gradle already ran or the script cannot invoke it:
+
+```text
+run/export-preview-screenshot.sh --module :app --tests '*Feature_State_Screenshot*' --skip-gradle
+```
+
+Validate reviewed baselines:
+
+```text
+./gradlew :app:validateDebugScreenshotTest --tests '*Feature_State_Screenshot*'
+```
+
+The HTML diff report is under `app/build/reports/screenshotTest/preview/debug/`.
+
+## Inspect and compare
+
+Review the full image before zooming into details:
+
+1. Is the user job and primary action obvious at first glance?
+2. Does the reading path match importance?
+3. Is the density intentional, with redundant copy and containers removed?
+4. Are groups expressed consistently through alignment, spacing, surface, and type?
+5. Do artwork, text, and controls compete or cooperate?
+6. Are content and actions clipped, crowded, or unreachable in risk variants?
+7. Do disabled, selected, loading, empty, and error states remain understandable?
+
+For reference matching, list concrete deltas: bounding position, padding, line wrapping, type role/weight, color role,
+corner shape, crop, icon geometry, and missing/extra elements. Batch related corrections. Re-render before declaring a match.
+
+## Verification boundaries
+
+- A passing screenshot test proves similarity to an approved raster, not usability or accessibility.
+- Host-rendered previews do not exercise runtime system bars, IME, TalkBack traversal, gestures, or lifecycle behavior.
+- Pixel diffs can change after rendering-tool or font upgrades. Review the report before accepting a new baseline.
+- Reference PNGs are gitignored in this repository; the preview source and documented verification commands are the durable
+  review artifacts. Exported PNGs can be shared during review without committing generated build output.

--- a/docs/compose-ui-design-skill-research.md
+++ b/docs/compose-ui-design-skill-research.md
@@ -1,0 +1,165 @@
+# Android and Compose UI design skill research
+
+Date: 2026-08-11
+Issue: [#150](https://github.com/arhor/spellbindr/issues/150)
+
+## Decision
+
+Use the repository-local `$design-compose-ui` skill in `.codex/skills/design-compose-ui` as a layered harness:
+
+1. a short critique/design/implementation/verification workflow;
+2. a required Spellbindr visual-language reference;
+3. focused Compose, accessibility, adaptive-layout, and screenshot-verification references;
+4. a provenance and maintenance record.
+
+Do not install any reviewed public skill unchanged. The strongest general-design candidates remain web-oriented or too
+broad, while the Android-aware candidates emphasize API correctness and baseline Material patterns more than design
+judgment, product identity, critique, and rendered iteration. Combining whole upstream skills would duplicate guidance,
+increase activation/context cost, and introduce conflicting assumptions. The local harness instead uses original,
+repository-specific instructions informed by their strongest concepts and current official Android guidance.
+
+## Repository needs
+
+The repository inspection covered the theme, shared components, representative feature screens, image-led race carousel,
+previews, screenshot source set, export helper, and MVI contract.
+
+Spellbindr already has a recognizable language: parchment/gold and blue-black/gold schemes, violet and ember supporting
+roles, rounded and occasional fantasy-geometric shapes, semibold hierarchy, dense game data, and character artwork. It
+also has useful implementation precedents: `MaterialTheme` roles, feature-local components, explicit semantics, 48 dp
+touch support, reduced-motion pager behavior, light/dark previews, font-scale previews, and AGP screenshot tests.
+
+The missing capability was therefore not “teach Compose from zero.” It was a reliable workflow that makes an agent:
+
+- read and preserve the existing identity before proposing a visual direction;
+- critique hierarchy and clutter before editing;
+- distinguish UX structure from Compose implementation defects;
+- prefer focused subtraction over container/chip/copy accumulation;
+- preserve route/screen behavior and MVI ownership;
+- render the exact state, inspect it, and iterate from evidence.
+
+## Sources and candidate inventory
+
+Sources were reviewed at their default branches on 2026-08-11. Repository counts are volatile, weak discovery signals;
+they are not treated as proof that a skill regularly improves real tasks.
+
+### Serious candidates
+
+| Candidate | Concrete behavior | Evidence and activity | Limitation for Spellbindr | License |
+|---|---|---|---|---|
+| [Anthropic `frontend-design`](https://github.com/anthropics/skills/blob/main/skills/frontend-design/SKILL.md) | Grounds a visual direction in subject matter; plans palette/type/layout/signature; critiques generic defaults; encourages restraint and screenshots | High-visibility upstream with recent repository activity. Community reports are mixed: [positive experience](https://www.reddit.com/r/ClaudeAI/comments/1oxn1gj/frontenddesign_skill_is_so_amazing/), [an eval-driven rewrite](https://www.reddit.com/r/ClaudeAI/comments/1q7rnpk/i_rewrote_anthropics_frontenddesign_skill_and/), and [reported disappointment](https://www.reddit.com/r/ClaudeCode/comments/1q9mkx9/anyone_else_struggling_with_the_official/) | Web hero/page framing, font-pairing expectations, CSS concerns, hover/focus language, and “aesthetic risk” can conflict with a compact native product and an established theme | Apache-2.0 in its bundled `LICENSE.txt` |
+| [`mobile-android-design`](https://github.com/wshobson/agents/tree/main/plugins/ui-design/skills/mobile-android-design) | Supplies Material 3/Compose examples, adaptive layout, theme roles, state hoisting, previews, accessibility, and 48 dp targets | Large, actively maintained parent collection; registry install count is only a popularity signal | Mostly baseline component recipes. Its generic card example is exactly the template tendency this issue wants to resist; little critique or rendered iteration | MIT |
+| [`mobile-ui-ux-designer`](https://github.com/mdrmuhaimin/agentic-skills/blob/main/codex/mobile-ui-ux-designer/skill.md) | User-goal-first brief, hierarchy, state model, responsive plan, platform conventions, accessibility contract, tokens, and rendered-verification gates | Concrete and comprehensive, but the repository showed only an initial commit and one skill-add commit; independent usage evidence was not found | Roughly 43 KB/700+ lines, cross-platform, template-heavy output, placeholders, and web/iOS/Flutter branching create high context cost | MIT stated in skill |
+| [`compose-expert`](https://github.com/aldefy/compose-skill) | Progressive references for state, modifiers, performance, animation, navigation, design-to-code, and source-backed API checks | Recent claim-verification commits, releases/install paths, and hundreds of public stars; a [developer discussion](https://www.reddit.com/r/androiddev/comments/1rripih/i_built_an_agent_skill_that_gives_ai_tools/) provides interest, not independent outcome proof | Strong engineering harness, but broad triggers and a large reference surface; visual taste, product-specific critique, and screenshot iteration are secondary | MIT; vendored AndroidX excerpts Apache-2.0 |
+| [`material-3`](https://github.com/hamen/material-3-skill) | Material token/component reference, Compose mappings, adaptive layout, and a 10-category audit | Recent packaging fixes and versioned releases show maintenance; limited independent real-world evidence | Mixes Compose, Flutter, and substantial web content; compliance scoring can reward generic Material conformity over product identity; volatile Expressive/API claims need current verification | MIT |
+| [Google `android/skills`](https://github.com/android/skills) | Official, narrowly scoped Android workflows grounded in developer.android.com and the open Agent Skills format | Frequent releases/updates and official ownership; the repository explicitly says it does not prioritize basic Compose practices | No general visual-design/critique skill matching this issue. Current skills complement rather than replace the harness | Apache-2.0 |
+| [`ui-ux-pro-max`](https://github.com/nextlevelbuilder/ui-ux-pro-max-skill) | Searchable design data, stack-specific rules, design-system persistence, and recent Jetpack Compose support | Versioned releases, CLI, many stack adapters, and community posts; install/popularity signals are not measured task outcomes | Large generated/data-driven package, broad stack surface, external CLI/update path, and insufficient evidence that its Compose adapter preserves a repository's identity | MIT |
+| [`impeccable`](https://github.com/pbakaus/impeccable) | Product-context capture, critique, audit, polish, anti-pattern detection, bounded screenshot passes, and design-system documentation | High public visibility and active packaging; feedback is primarily web-oriented | Explicitly frontend/browser focused, includes executable hooks/CLI and many commands, and uses an intentionally maximal design-director stance unsuited to automatic activation for focused native changes | Apache-2.0 |
+
+### Considered but not shortlisted
+
+- [`fixing-accessibility`](https://github.com/ibelick/ui-skills/tree/main/skills/fixing-accessibility): useful audit ordering,
+  but HTML/ARIA/keyboard specific; official Compose semantics guidance is safer.
+- [`iOS-Design-Agent-Skill`](https://github.com/vermont42/iOS-Design-Agent-Skill): demonstrates a thoughtful native port of
+  frontend-design and validates the adaptation strategy, but SwiftUI/HIG details do not transfer directly.
+- [`expo-ui`](https://github.com/expo/skills/tree/main/plugins/expo/skills/expo-ui): its “Jetpack Compose” target is Expo's
+  React bridge, not a native Kotlin Compose application.
+- Figma-to-Compose skills: useful only with a Figma/MCP source and do not solve critique, product identity, or verification.
+- Screenshot-critique and web accessibility micro-skills: narrow supplements, but browser automation and DOM assumptions
+  duplicate or conflict with the existing Compose screenshot workflow.
+
+## Comparison matrix
+
+Scores are 1 (poor) through 5 (strong) for this repository's goal, based on inspected instructions rather than marketing.
+“Evidence” rates maintenance plus independent outcome evidence; most skills score modestly because public outcome data is
+sparse.
+
+| Candidate | Design specificity | Compose / M3 | Critique | Existing identity | A11y / adaptive | Render loop | Activation / context | Evidence | Adaptation |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| frontend-design | 5 | 1 | 4 | 3 | 2 | 3 | 5 | 3 | 2 |
+| mobile-android-design | 2 | 4 | 1 | 2 | 4 | 2 | 4 | 2 | 3 |
+| mobile-ui-ux-designer | 4 | 3 | 4 | 4 | 5 | 4 | 1 | 1 | 2 |
+| compose-expert | 2 | 5 | 2 | 3 | 4 | 3 | 2 | 3 | 3 |
+| material-3 | 3 | 4 | 3 | 2 | 4 | 2 | 2 | 2 | 3 |
+| android/skills | 1 | 5 | 1 | 3 | 4 | 1 | 5 | 4 | 2 |
+| ui-ux-pro-max | 4 | 3 | 3 | 3 | 3 | 2 | 1 | 2 | 2 |
+| impeccable | 5 | 1 | 5 | 5 | 4 | 5 | 1 | 3 | 1 |
+| local layered harness | 5 | 5 | 5 | 5 | 5 | 5 | 5 | 2 | 5 |
+
+Operational criteria:
+
+| Candidate | Codex portability | License / provenance | Supply-chain surface | Overlap risk |
+|---|---|---|---|---|
+| frontend-design | Standard skill file | Clear Apache-2.0 | Markdown only if copied | Medium: generic design layer |
+| mobile-android-design | Standard skill + reference | Clear MIT parent license | Markdown only if copied | High: generic Compose guidance |
+| mobile-ui-ux-designer | Compatible frontmatter with extra fields | MIT stated; small provenance trail | Single large instruction file | High: workflow and accessibility |
+| compose-expert | Codex install documented | MIT plus Apache excerpts identified | Large copied/submodule reference set | High: implementation expertise |
+| material-3 | Codex/manual install documented | MIT and source list | Plugin/package plus cross-stack refs | High: Material implementation |
+| android/skills | Open standard and Android CLI | Official Apache-2.0 | CLI-managed remote updates if installed | Low: narrow official workflows |
+| ui-ux-pro-max | Codex adapter and CLI | MIT | npm/CLI, release archives, generated data | High: broad design database |
+| impeccable | Codex skill packaging | Apache-2.0 | Node CLI and optional hooks | High: critique/audit/polish |
+| local layered harness | Native `.codex/skills` | Original text with source record | No executables or network dependency | Controlled within four references |
+
+## Research questions answered
+
+1. **Which skills exist?** The inventory above covers high-signal general design, native mobile, Android/Compose, Material,
+   accessibility, critique, and screenshot-oriented options across official, vendor, and community repositories.
+2. **Which are maintained or reused?** Android/skills, Anthropic skills, wshobson/agents, compose-skill, Impeccable, and
+   ui-ux-pro-max show recent maintenance. Stars, forks, downloads, and install counts establish visibility only. Independent
+   outcome reports are scarce and mixed, especially for frontend-design.
+3. **What do they add beyond “beautiful”?** Subject grounding and restraint; user-goal/state contracts; Android component
+   and adaptive rules; source-backed Compose implementation; token audits; screenshot iteration; or deterministic hooks.
+4. **Which are Codex-compatible?** All shortlisted instruction sets can be read by Codex; several ship standard skill
+   folders. Plugin commands, hooks, and other-agent metadata are not automatically portable and were excluded.
+5. **Are any Android/Compose-aware?** Yes: mobile-android-design, compose-expert, material-3, ui-ux-pro-max's Compose
+   adapter, and Android's official focused skills. None alone covers product-specific visual critique plus rendered iteration.
+6. **What transfers from web?** Subject grounding, explicit hierarchy, one memorable idea, disciplined typography and
+   color, meaningful structure, concise copy, restraint, self-critique, and screenshot review.
+7. **What must be replaced?** DOM/CSS selectors, browser frameworks, hover, web breakpoints, page heroes, web font loading,
+   ARIA recipes, viewport assumptions, and browser screenshot tools become Compose semantics, Material roles, touch,
+   window size classes, system insets/IME, previews, instrumentation, and AGP screenshot tests.
+8. **One or several skills?** One narrowly triggered skill with progressive references. Multiple broad skills would
+   activate together, conflict, and repeat context.
+9. **How does it use repository context?** It requires the theme, nearby UI/components, feature entry contract, exact state,
+   `ScreenshotHarness`, filtered screenshot generation, exported PNG inspection, and a bounded correction pass.
+10. **Which deterministic checks help?** Screenshot validation/diff reports, filtered previews at risk variants, Compose
+    semantics/UI tests, automated accessibility checks where device infrastructure exists, compilation, lint, and contrast
+    calculation. None replaces human judgment.
+11. **What are the risks?** Skill instructions are code-adjacent supply-chain inputs. Risks include prompt injection,
+    overbroad activation, hidden shell/network steps, stale APIs, unpinned remote updates, license loss, and architectural
+    pattern bleed. The local skill contains no scripts, network dependency, or copied source, and records provenance.
+12. **What gaps remain?** A model cannot prove taste, cultural fit, readability, or delight. Host previews cannot validate
+    TalkBack, runtime insets, IME, gestures, lifecycle, or device rendering. Human product/design and accessibility review
+    remains necessary for high-impact changes.
+
+## Why the harness is concise
+
+The activation description names both positive UI triggers and negative boundaries so ordinary Compose logic work does not
+load it. The core file contains the invariant workflow. Repository identity, detailed Compose design rules, verification,
+and provenance are one reference level deep. There are no personas, generic output templates, bundled assets, or scripts.
+
+## Security, provenance, and maintenance
+
+Agent skills can alter tool use and generated code, so popularity is not a trust boundary. Before vendoring a future skill:
+
+1. inspect every instruction, script, asset, hook, manifest, and dependency;
+2. verify repository ownership, license, and attribution requirements;
+3. pin or record a reviewed commit and avoid unreviewed auto-updates;
+4. reject unexpected credential, network, destructive-shell, or unrelated tool instructions;
+5. test activation precision and task behavior against local scenarios;
+6. compare new guidance with repository architecture and current official APIs.
+
+Maintain the local harness when the theme, shared components, MVI contract, screenshot plugin, supported window policy, or
+Compose accessibility/adaptive APIs change. Re-run the scenarios in
+`docs/compose-ui-design-skill-validation.md`, the skill validator, and the relevant Gradle checks.
+
+## Official technical references
+
+- [Android skills overview](https://developer.android.com/tools/agents/android-skills)
+- [Accessibility in Jetpack Compose](https://developer.android.com/develop/ui/compose/accessibility)
+- [Compose semantics](https://developer.android.com/develop/ui/compose/accessibility/semantics)
+- [Compose accessibility API defaults](https://developer.android.com/develop/ui/compose/accessibility/api-defaults)
+- [Build adaptive apps](https://developer.android.com/develop/ui/compose/build-adaptive-apps)
+- [Support different display sizes](https://developer.android.com/develop/adaptive-apps/guides/support-different-display-sizes)
+- [Canonical adaptive layouts](https://developer.android.com/develop/adaptive-apps/guides/canonical-layouts)
+- [Compose preview screenshot testing](https://developer.android.com/studio/preview/compose-screenshot-testing)
+- [Agent-skill semantic supply-chain research](https://arxiv.org/abs/2605.11418)

--- a/docs/compose-ui-design-skill-validation.md
+++ b/docs/compose-ui-design-skill-validation.md
@@ -1,0 +1,169 @@
+# Compose UI design skill validation
+
+Date: 2026-08-11
+
+## Method
+
+The `$design-compose-ui` harness was walked through against repository-native artifacts without committing experimental
+product changes. Each scenario records the context the skill routes to, the expected actionable output, and whether that
+behavior is represented in the skill. Existing PNGs were visually inspected for the critique scenario. Source, preview,
+and test artifacts were used where a live interaction or new product requirement was intentionally absent.
+
+This is a scenario/dry-run evaluation, not evidence that prompt text alone guarantees design quality. Deterministic skill
+validation and repository checks are recorded at the end.
+
+## 1. Existing-screen critique
+
+**Prompt shape:** “Critique the character-sheet Spells tab and prioritize focused improvements.”
+
+**Artifacts:**
+
+- `SpellsTabScreenshotPreviews.kt`
+- existing light screenshot `SpellsTab_Screenshot_8953c3c2_0.png`
+- spell-tab components under `ui/feature/character/sheet/components/tabs/spells/`
+
+**Observed harness behavior:** It classifies the task as critique, loads the product language and visual-verification
+reference, requires the render before conclusions, and separates UX from implementation.
+
+**Sample output:**
+
+1. P1 UX: spell-slot controls consume most of the first viewport through repeated nested surfaces and repeated Use/Restore
+   controls, delaying the spell list and “Add spells” action. First test a more compact slot composition while preserving
+   per-level state and 48 dp actions.
+2. P2 UX: the Level 4 `0/0` surface carries the same container emphasis as actionable levels despite offering no action.
+   Reduce or omit that inactive group if the rules/product requirement allows it.
+3. Preserve: the tab hierarchy, gold/violet palette, clear used/available slot distinction, disabled-state visibility,
+   class grouping, and direct cast affordances already fit the product.
+4. Implementation follow-up: inspect modifier hit areas and semantics before changing pixels; do not infer accessibility
+   failure from the screenshot alone.
+
+**Result:** Pass. The output is prioritized, evidence-based, and bounded; it does not propose a wholesale redesign.
+
+## 2. Focused refinement
+
+**Prompt shape:** “Refine the guided race selection without changing navigation, selection behavior, or state.”
+
+**Artifacts:** `RaceCarousel.kt`, `RaceCarouselPage.kt`, `RaceSummaryPanel.kt`, `RaceArtwork.kt`, and
+`RaceCarouselScreenshotPreviews.kt`.
+
+**Observed harness behavior:** It requires behavior and component inspection before edits, names state/navigation as
+preservation boundaries, identifies image-led precedent, and selects only risk-relevant preview variants.
+
+**Refinement plan produced:**
+
+- preserve pager selection, subrace selection, details dialog, custom TalkBack previous/next actions, selected state,
+  reduced-motion external page changes, and artwork mapping;
+- critique only overlay density, summary hierarchy, scrim balance, arrow prominence, and pagination legibility;
+- verify selected and unselected states at 360×640 plus the existing 1.3 font-scale preview;
+- change a shared component only if the pattern repeats outside race selection.
+
+**Result:** Pass. The harness prevents visual polish from leaking into MVI or pager behavior.
+
+## 3. New-screen design
+
+**Prompt shape:** “Add a feat-details screen that fits Spellbindr.”
+
+**Context route:** Theme and nearby compendium details/list screens, shared chrome, MVI dispatch contract, Compose guidance,
+and screenshot verification.
+
+**Compact brief produced:**
+
+- user job: understand a feat's benefits and prerequisites, then return to the prior compendium context;
+- hierarchy: feat name → eligibility/prerequisites → mechanical effects → rules description/source;
+- signature: restrained fantasy-rulebook treatment using the existing gold hierarchy and shape language, not a generic
+  hero-gradient/card dashboard;
+- reuse: `AppTopBar`, theme roles, existing compendium detail spacing and loading/error patterns;
+- states: loading, missing feat/error, long prerequisite list, long rules text;
+- adaptive behavior: readable constrained column on wide windows, reflowing metadata at large font, system inset handling;
+- verification: standard compact, 1.3 font scale with long content, and dark theme.
+
+**Result:** Pass as a design/implementation plan. Limitation: final hierarchy and copy require an actual feature contract;
+the skill correctly does not invent actions or data.
+
+## 4. Image-led composition
+
+**Prompt shape:** “Design race selection around the artwork instead of putting it behind a card.”
+
+**Artifact:** The existing `RaceCarouselPage` provides a real solution: full-size `RaceArtwork`, a localized vertical
+gradient scrim, and bottom-aligned summary/actions.
+
+**Observed harness behavior:** The skill identifies imagery as identity/content, protects crop and visual area, asks whether
+overlay elements communicate state/action, and explicitly rejects burying art under a large opaque card.
+
+**Result:** Pass. The local product reference gives a concrete repository precedent instead of generic image-card advice.
+
+## 5. Adaptive and accessible UI
+
+**Prompt shape:** “Make this selection UI work with large text, TalkBack, and wider windows.”
+
+**Evidence:**
+
+- `RaceCarousel_NoSelectionLargeFont_Screenshot` uses `fontScale = 1.3f`;
+- `RaceCarouselPage` exposes radio-button role, selected state, position, summary, and custom previous/next actions;
+- `RaceCarouselPagination` provides a page-position description;
+- Compose guidance covers 48 dp targets, semantic defaults, reflow, window-based decisions, insets, contrast, and
+  instrumentation limits.
+
+**Expected check plan:** compact default + compact large font + a width around the actual layout transition; semantics
+assertions for role/state/custom actions; device review for TalkBack traversal and runtime insets if implementation changes.
+
+**Result:** Pass. The harness does not treat a screenshot as proof of TalkBack behavior and avoids device-name/orientation
+breakpoints.
+
+## 6. Visual verification
+
+**Prompt shape:** “Match a supplied screenshot and show the result.”
+
+**Observed harness behavior:** It requires an exact-state `@PreviewTest`, `ScreenshotHarness`, explicit size when relevant,
+filtered generation/export, direct PNG inspection, concrete delta reporting, a batched correction pass, and validation
+against reviewed baselines.
+
+**Repository commands selected:**
+
+```text
+./gradlew :app:updateDebugScreenshotTest --tests '*Target_Screenshot*'
+run/export-preview-screenshot.sh --module :app --tests '*Target_Screenshot*'
+./gradlew :app:validateDebugScreenshotTest --tests '*Target_Screenshot*'
+```
+
+**Result:** Pass. The workflow matches the repository's configured AGP screenshot source set and calls out host-preview
+limits. It forbids blindly accepting changed references.
+
+## Activation tests
+
+Should activate:
+
+- “Critique this Compose screen screenshot.”
+- “Polish the hierarchy and spacing without changing behavior.”
+- “Build a new character inventory screen that fits the current theme.”
+- “Make the race artwork the focus.”
+- “Match this reference PNG and verify it at large font.”
+
+Should not activate:
+
+- “Fix this `LaunchedEffect` cancellation bug.”
+- “Change the navigation route argument type.”
+- “Optimize LazyColumn recomposition.”
+- “Add unit tests for the progression engine.”
+
+The negative boundary is included in frontmatter, where activation decisions are made, rather than only in the loaded body.
+
+## Deterministic validation
+
+Completed on 2026-08-11:
+
+- skill-creator `quick_validate.py .codex/skills/design-compose-ui`: **passed** (`Skill is valid!`);
+- initializer TODO scan: **passed**, no placeholders found;
+- `git diff --check`: **passed**;
+- `./gradlew :app:validateDebugScreenshotTest --tests '*SpellsTab_Screenshot*'`: **passed** in 18 seconds, exercising
+  the configured preview renderer and existing reference PNGs.
+
+The Gradle run emitted existing Kotlin/compiler warnings but no screenshot failure. The implementation makes
+documentation and skill-only changes, so no product behavior or screenshot baseline changes are expected.
+
+## Remaining human review
+
+This validation demonstrates routing, specificity, critique, preservation, implementation guidance, accessibility/adaptive
+coverage, and rendered-output workflow. It does not demonstrate that an agent can independently make every subjective
+choice well. High-impact visual direction, cultural tone, readability, accessibility with assistive technology, and final
+baseline approval still require human review.


### PR DESCRIPTION
## Summary

- add a narrowly activated repository-local `$design-compose-ui` skill for Compose UI critique, focused refinement, new-screen design, image-led composition, accessibility/adaptive review, and rendered verification
- separate Spellbindr visual language, Compose design guidance, screenshot workflow, and provenance into progressive references
- document the public-skill research, candidate matrix, licensing and supply-chain considerations, final decision, and maintenance expectations
- validate the harness against all six representative issue scenarios without committing experimental product UI

## Why

Existing public skills split between strong web-oriented design judgment and broad Android/Compose implementation guidance. None combines product-specific visual critique, Spellbindr's established design language, MVI preservation, accessibility/adaptive constraints, and the repository's AGP preview-to-PNG loop with sufficiently narrow activation and context cost.

The local layered harness keeps those concerns together without vendoring executable hooks, cross-platform templates, or large third-party instruction sets.

## User and developer impact

Codex can now critique and implement Spellbindr UI changes from repository context, preserve existing behavior and identity, and verify visual work from rendered evidence instead of claiming polish from source inspection alone. Non-visual Compose state, navigation, performance, and test tasks stay outside the skill's activation boundary.

## Validation

- `quick_validate.py .codex/skills/design-compose-ui` — passed (`Skill is valid!`)
- initializer TODO scan — passed
- `git diff --check` — passed
- `./gradlew :app:validateDebugScreenshotTest --tests '*SpellsTab_Screenshot*'` — passed (`BUILD SUCCESSFUL`)
- six scenario dry runs documented in `docs/compose-ui-design-skill-validation.md`

Closes #150